### PR TITLE
feat(cqrs,sql): 2.6.0 — operabilidad y cimientos de las factories

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@
   acotar el catch-up, aviso `RuntimeWarning` si el tick es sub-minuto y no hay
   `lock_provider`, primer tick sin esperar el intervalo, `stop()` interrumpible al
   instante, y `except` que loguean traceback en vez de tragarse el error (P1-1)
+- **cqrs**: `HandlerRegistry` es realmente thread-safe: el docstring lo afirmaba pero
+  no había ningún lock, y `resolve_*` hace lazy-init con escritura en el dict, así que
+  dos hilos podían instanciar el mismo handler dos veces (relevante con el
+  free-threading de Python 3.14). Nuevo `HandlerRegistry.factory(...)` como marcador
+  explícito de factory, para quitar la ambigüedad con los handlers que implementan
+  `__call__` (P1-5)
 - **cqrs**: `RedisLockProvider` y `PostgresLockProvider` aceptan
   `on_error: "skip" | "raise"`. Antes capturaban `Exception` y devolvían `False`
   siempre, así que una caída de Redis apagaba el cron **entero** con un `logger.error`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@
 
 ### Feat
 
+- **cqrs**: `DynamicScheduler` implementa el catch-up que la versión anterior sólo
+  insinuaba: decide por "¿hubo alguna ocurrencia entre la última ejecución y ahora?"
+  en vez de `croniter.match(expr, minuto_actual)`. Con eso un minuto saltado por
+  drift del tick ya no pierde la ejecución, y `update_last_run` deduplica de verdad
+  cuando `tick_interval_seconds < 60`. Nuevo `catch_up_window_seconds` (1h) para
+  acotar el catch-up, aviso `RuntimeWarning` si el tick es sub-minuto y no hay
+  `lock_provider`, primer tick sin esperar el intervalo, `stop()` interrumpible al
+  instante, y `except` que loguean traceback en vez de tragarse el error (P1-1)
 - **cqrs**: `CQRSFactory` acepta un `enqueuer` y lo propaga junto al serializer a los
   buses in-memory, así que la vía oficial de construcción ya sirve para Smart Routing
   sin cablear los buses a mano. Si hay `@background_command` registrados y falta el

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@
   (100 por defecto), crea un índice sobre `expires_at`, y expone `purge_expired()`
   (P0-4)
 
+### Feat
+
+- **cqrs**: `CQRSFactory` acepta un `enqueuer` y lo propaga junto al serializer a los
+  buses in-memory, así que la vía oficial de construcción ya sirve para Smart Routing
+  sin cablear los buses a mano. Si hay `@background_command` registrados y falta el
+  enqueuer, falla **al construir** con el nombre de los comandos afectados, no en el
+  primer dispatch. El serializer se cachea para que buses y consumer compartan
+  instancia (P0-5)
+
 ### Behavior change
 
 - **cqrs**: `TransactionMiddleware` deja de ser el middleware por defecto de

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@
   acotar el catch-up, aviso `RuntimeWarning` si el tick es sub-minuto y no hay
   `lock_provider`, primer tick sin esperar el intervalo, `stop()` interrumpible al
   instante, y `except` que loguean traceback en vez de tragarse el error (P1-1)
+- **cqrs**: `RedisLockProvider` y `PostgresLockProvider` aceptan
+  `on_error: "skip" | "raise"`. Antes capturaban `Exception` y devolvían `False`
+  siempre, así que una caída de Redis apagaba el cron **entero** con un `logger.error`
+  por job y por tick indistinguible del caso normal. Ahora "no pude decidir" se loguea
+  como `critical` y "el lock estaba tomado" como `debug` (P1-2)
 - **cqrs**: `CQRSFactory` acepta un `enqueuer` y lo propaga junto al serializer a los
   buses in-memory, así que la vía oficial de construcción ya sirve para Smart Routing
   sin cablear los buses a mano. Si hay `@background_command` registrados y falta el

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@
   acotar el catch-up, aviso `RuntimeWarning` si el tick es sub-minuto y no hay
   `lock_provider`, primer tick sin esperar el intervalo, `stop()` interrumpible al
   instante, y `except` que loguean traceback en vez de tragarse el error (P1-1)
+- **task_queues**: `register_hexcore_procrastinate_tasks` y
+  `register_hexcore_celery_tasks` son idempotentes y devuelven `bool`; se añade
+  `is_registered(app)` y `force=True`. Antes llamarlas dos veces reventaba porque la
+  cola rechaza nombres duplicados, así que cada aplicación tenía que protegerlas con
+  un flag de módulo (P1-6)
 - **cqrs**: `HandlerRegistry` es realmente thread-safe: el docstring lo afirmaba pero
   no había ningún lock, y `resolve_*` hace lazy-init con escritura en el dict, así que
   dos hilos podían instanciar el mismo handler dos veces (relevante con el

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@
   acotar el catch-up, aviso `RuntimeWarning` si el tick es sub-minuto y no hay
   `lock_provider`, primer tick sin esperar el intervalo, `stop()` interrumpible al
   instante, y `except` que loguean traceback en vez de tragarse el error (P1-1)
+- **sql**: capa de sesión usable en producción. `init_engine(url=None, *, pool=PoolSettings(), **engine_kwargs)`
+  y `dispose_engine()`; `PoolSettings` (`size`, `max_overflow`, `pre_ping`, `recycle`)
+  con `pre_ping=True` por defecto; normalización del DSN (`postgresql://` →
+  `postgresql+asyncpg://`, expuesta como `normalize_async_dsn`); URL explícita para
+  workers, scripts y tests; y lock alrededor de los globals `_engine`/`_session_factory`
+  (F2)
+- **uow**: `session_scope`, `uow_scope`, `open_uow_scope` y `nosql_uow_scope` en
+  `hexcore.infrastructure.uow` — scopes para workers, cron, scripts y seeds, donde
+  antes sólo había dependencias de FastAPI. `session_scope` no construye el UoW, así
+  que no paga el auto-discovery de repositorios para leer una tabla de infraestructura
+  (F3)
+- **api**: nueva dependencia `get_sql_uow_open` para endpoints que quieren el UoW ya
+  abierto (F3)
 - **cqrs**: `CQRSConsumer(command_bus)` — `event_bus` y `serializer` pasan a ser
   opcionales. Un worker sólo-comandos ya no necesita `cast(Any, None)`, y si llega un
   evento sin event bus el error dice qué hacer. `serializer` cae en
@@ -63,6 +76,16 @@
 
 ### Behavior change
 
+- **sql**: el session factory de HexCore pasa a `expire_on_commit=False`. Con el
+  default de SQLAlchemy (`True`) los atributos de las entidades expiran al comitear y
+  el siguiente acceso dispara un lazy-load sobre una sesión cerrada
+  (`MissingGreenlet` / `DetachedInstanceError`) — y la documentación ya enseñaba
+  `async_sessionmaker(engine, expire_on_commit=False)`, o sea que doc e
+  implementación no coincidían. Quien necesite `True` debe construir su propio
+  `async_sessionmaker` (F2)
+- **api**: `get_sql_uow` ya **no entra** al UoW: cede el UoW sin abrir la transacción,
+  para que el use case controle su propio `async with uow:` sin anidar contextos. Si
+  dependías del comportamiento anterior, usá `get_sql_uow_open` (F3)
 - **cqrs**: `TransactionMiddleware` deja de ser el middleware por defecto de
   `CQRSConfig.command_bus`, y `TransactionMiddleware()` sin `uow_factory` ahora lanza
   `ValueError` en vez de adivinar. El default armaba la sesión con el session factory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
   acotar el catch-up, aviso `RuntimeWarning` si el tick es sub-minuto y no hay
   `lock_provider`, primer tick sin esperar el intervalo, `stop()` interrumpible al
   instante, y `except` que loguean traceback en vez de tragarse el error (P1-1)
+- **cqrs**: `CQRSConsumer(command_bus)` — `event_bus` y `serializer` pasan a ser
+  opcionales. Un worker sólo-comandos ya no necesita `cast(Any, None)`, y si llega un
+  evento sin event bus el error dice qué hacer. `serializer` cae en
+  `PydanticSerializer` (P2-2)
 - **task_queues**: `register_hexcore_procrastinate_tasks` y
   `register_hexcore_celery_tasks` son idempotentes y devuelven `bool`; se añade
   `is_registered(app)` y `force=True`. Antes llamarlas dos veces reventaba porque la

--- a/hexcore/application/cqrs/factory.py
+++ b/hexcore/application/cqrs/factory.py
@@ -10,6 +10,7 @@ import typing as t
 from hexcore.domain.cqrs.buses import ICommandBus, IQueryBus, IEventBus
 from hexcore.domain.cqrs.middleware import IMiddleware
 from hexcore.domain.cqrs.serializer import ISerializer
+from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
 
 from .config import CQRSConfig, BusConfig
 from .registry import HandlerRegistry
@@ -25,11 +26,31 @@ def _import_class(dotted_path: str) -> type:
 
 
 def _build_middlewares(dotted_paths: list[str]) -> list[IMiddleware]:
-    """Instancia middlewares a partir de sus dotted paths."""
+    """
+    Instancia middlewares a partir de sus dotted paths.
+
+    Sólo sirve para middlewares construibles sin argumentos. Los que necesitan
+    configuración (p. ej. `TransactionMiddleware`, que requiere un `uow_factory`
+    atado al engine de la aplicación) hay que instanciarlos a mano y pasar el
+    `MiddlewarePipeline` al bus.
+    """
     middlewares: list[IMiddleware] = []
     for path in dotted_paths:
         cls = _import_class(path)
-        middlewares.append(cls())
+        try:
+            middlewares.append(cls())
+        except TypeError as exc:
+            raise TypeError(
+                f"El middleware '{path}' no se puede construir sin argumentos: {exc}. "
+                "Declararlo por dotted path sólo funciona para middlewares sin "
+                "configuración; instancialo a mano y pasá el MiddlewarePipeline al bus."
+            ) from exc
+        except ValueError as exc:
+            raise ValueError(
+                f"El middleware '{path}' rechazó su construcción por defecto: {exc} "
+                "Declararlo por dotted path sólo funciona para middlewares sin "
+                "configuración; instancialo a mano y pasá el MiddlewarePipeline al bus."
+            ) from exc
     return middlewares
 
 
@@ -52,40 +73,63 @@ class CQRSFactory:
         registry = HandlerRegistry()
         # ...registrar handlers...
 
-        factory = CQRSFactory(config, registry)
+        factory = CQRSFactory(config, registry, enqueuer=ProcrastinateEnqueuer(app))
         command_bus = factory.create_command_bus()
         query_bus = factory.create_query_bus()
+        event_bus = factory.create_event_bus()
+
+    El `enqueuer` es lo que habilita el Smart Routing: sin él, los buses in-memory
+    no pueden enrutar un `@background_command` y la factory lo dice **al construir**,
+    no en el primer dispatch.
     """
 
     def __init__(
         self,
         config: CQRSConfig,
         registry: HandlerRegistry,
+        enqueuer: ITaskEnqueuer | None = None,
     ) -> None:
         self._config = config
         self._registry = registry
+        self._enqueuer = enqueuer
+        self._serializer: ISerializer | None = None
 
     def create_serializer(self) -> ISerializer:
-        """Crea el serializer configurado (PydanticSerializer por defecto)."""
+        """
+        Crea el serializer configurado (PydanticSerializer por defecto).
+
+        La instancia se cachea: los buses y el consumer tienen que compartir el
+        mismo serializer para que el round-trip por la cola sea coherente.
+        """
+        if self._serializer is not None:
+            return self._serializer
+
         if self._config.serializer:
             cls = _import_class(self._config.serializer)
-            return cls()
-        from hexcore.infrastructure.cqrs.pydantic_serializer import PydanticSerializer
+            self._serializer = t.cast(ISerializer, cls())
+        else:
+            from hexcore.infrastructure.cqrs.pydantic_serializer import PydanticSerializer
 
-        return PydanticSerializer()
+            self._serializer = PydanticSerializer()
+        return self._serializer
 
     def create_command_bus(self, **extra_kwargs: t.Any) -> ICommandBus:
         """
         Crea el CommandBus configurado.
-        Si no hay backend explícito, retorna InMemoryCommandBus.
+        Si no hay backend explícito, retorna InMemoryCommandBus con el enqueuer y el
+        serializer necesarios para el Smart Routing.
         """
         bus_config = self._config.command_bus
         pipeline = _build_pipeline(bus_config)
 
         if bus_config.backend is None:
+            self._assert_enqueuer_for_background_commands()
             return InMemoryCommandBus(
                 registry=self._registry,
                 pipeline=pipeline,
+                enqueuer=self._enqueuer,
+                serializer=self.create_serializer(),
+                **extra_kwargs,
             )
 
         # Backend personalizado (ej. ProcrastinateCommandBus)
@@ -119,13 +163,53 @@ class CQRSFactory:
             **bus_config.options,
         )
 
-    def create_event_bus(self) -> IEventBus:
-        """Crea el EventBus configurado."""
+    def create_event_bus(self, **extra_kwargs: t.Any) -> IEventBus:
+        """
+        Crea el EventBus configurado.
+
+        Al bus in-memory se le pasan enqueuer y serializer para que los suscriptores
+        marcados con `@background_handler` se puedan enrutar.
+        """
         bus_config = self._config.event_bus
         pipeline = _build_pipeline(bus_config)
 
         if bus_config.backend is None:
-            return InMemoryEventBus(pipeline=pipeline)
+            return InMemoryEventBus(
+                pipeline=pipeline,
+                enqueuer=self._enqueuer,
+                serializer=self.create_serializer(),
+                **extra_kwargs,
+            )
 
         cls = _import_class(bus_config.backend)
-        return cls(pipeline=pipeline, **bus_config.options)
+        return cls(
+            pipeline=pipeline,
+            **bus_config.options,
+            **extra_kwargs,
+        )
+
+    # ── Validación ────────────────────────────────────────────────────────────
+
+    def _assert_enqueuer_for_background_commands(self) -> None:
+        """
+        Falla al construir si hay commands de background registrados y no hay
+        enqueuer. El error en el primer dispatch llega demasiado tarde: para
+        entonces la petición del usuario ya está en vuelo.
+        """
+        if self._enqueuer is not None:
+            return
+
+        background = [
+            command_type.__name__
+            for command_type in self._registry.registered_commands
+            if getattr(command_type, "__cqrs_background__", False)
+        ]
+        if not background:
+            return
+
+        raise RuntimeError(
+            "CQRSFactory no tiene 'enqueuer', pero hay commands decorados con "
+            f"@background_command: {', '.join(sorted(background))}. "
+            "Pasá un ITaskEnqueuer al construir la factory, p. ej. "
+            "CQRSFactory(config, registry, enqueuer=ProcrastinateEnqueuer(app))."
+        )

--- a/hexcore/application/cqrs/registry.py
+++ b/hexcore/application/cqrs/registry.py
@@ -4,6 +4,7 @@ Mapea tipos de Command/Query a sus handlers correspondientes.
 """
 from __future__ import annotations
 
+import threading
 import typing as t
 
 from hexcore.domain.cqrs.commands import Command
@@ -16,15 +17,45 @@ from hexcore.domain.cqrs.exceptions import HandlerNotFoundError, DuplicateHandle
 CommandHandlerFactory = t.Callable[[], ICommandHandler[t.Any, t.Any]]
 QueryHandlerFactory = t.Callable[[], IQueryHandler[t.Any, t.Any]]
 
+TFactory = t.TypeVar("TFactory")
+
+
+class HandlerFactory(t.Generic[TFactory]):
+    """
+    Marcador explícito de "esto es un factory, no un handler".
+
+    `callable(entry) and not isinstance(entry, ICommandHandler)` es ambiguo: un handler
+    que implemente `__call__` se confundiría con un factory, y un factory que herede de
+    la interfaz se confundiría con un handler. Envolver el callable elimina la
+    heurística.
+
+    No es obligatorio: registrar un `lambda` sigue funcionando (se detecta por
+    heurística, igual que antes) y `HandlerRegistry.factory()` construye el marcador
+    por ti.
+    """
+
+    __slots__ = ("build",)
+
+    def __init__(self, build: t.Callable[[], TFactory]) -> None:
+        self.build = build
+
+    def __call__(self) -> TFactory:
+        return self.build()
+
 
 class HandlerRegistry:
     """
-    Registro thread-safe de handlers para Commands y Queries.
+    Registro de handlers para Commands y Queries.
 
     Soporta dos modos de registro:
 
     1. Registro directo de instancias (eager)
     2. Registro de factories (lazy, para DI containers)
+
+    **Thread-safety.** El registro y la resolución están protegidos por un
+    `threading.RLock`. Hace falta porque `resolve_*` hace lazy-init con escritura en el
+    dict: sin lock, dos hilos (o dos hilos reales bajo el free-threading de Python
+    3.14) pueden instanciar el mismo handler dos veces y quedarse cada uno con la suya.
 
     Uso::
 
@@ -33,8 +64,10 @@ class HandlerRegistry:
         # Registro directo
         registry.register_command_handler(CreateUserCommand, CreateUserHandler())
 
-        # Registro con factory (lazy)
-        registry.register_command_handler(CreateUserCommand, lambda: container.get(CreateUserHandler))
+        # Registro con factory (lazy) — marcador explícito
+        registry.register_command_handler(
+            CreateUserCommand, HandlerRegistry.factory(lambda: container.get(CreateUserHandler))
+        )
 
         # Resolución
         handler = registry.resolve_command_handler(CreateUserCommand)
@@ -48,6 +81,20 @@ class HandlerRegistry:
             type[Query[t.Any]], IQueryHandler[t.Any, t.Any] | QueryHandlerFactory
         ] = {}
         self._allow_override = allow_override
+        # Reentrante: un factory puede resolver otro handler del mismo registry.
+        self._lock = threading.RLock()
+
+    # ── Factories ─────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def factory(build: t.Callable[[], t.Any]) -> HandlerFactory[t.Any]:
+        """
+        Envuelve un callable para registrarlo como factory sin ambigüedad.
+
+        Preferí esto a pasar el callable pelado cuando tu handler implementa
+        `__call__`, porque entonces la heurística no puede distinguirlos.
+        """
+        return HandlerFactory(build)
 
     # ── Command Handlers ──────────────────────────────────────────
 
@@ -57,24 +104,26 @@ class HandlerRegistry:
         handler: ICommandHandler[t.Any, t.Any] | CommandHandlerFactory,
     ) -> "HandlerRegistry":
         """Registra un handler (o factory) para un tipo de command. Retorna self para fluent API."""
-        if not self._allow_override and command_type in self._command_handlers:
-            raise DuplicateHandlerError(command_type)
-        self._command_handlers[command_type] = handler
+        with self._lock:
+            if not self._allow_override and command_type in self._command_handlers:
+                raise DuplicateHandlerError(command_type)
+            self._command_handlers[command_type] = handler
         return self
 
     def resolve_command_handler(
         self, command_type: type[Command]
     ) -> ICommandHandler[t.Any, t.Any]:
         """Resuelve el handler para el tipo de command dado."""
-        entry = self._command_handlers.get(command_type)
-        if entry is None:
-            raise HandlerNotFoundError(command_type)
-        if callable(entry) and not isinstance(entry, ICommandHandler):
-            # Es un factory, invocar y cachear la instancia
-            handler = entry()
-            self._command_handlers[command_type] = handler
-            return handler
-        return t.cast(ICommandHandler[t.Any, t.Any], entry)
+        with self._lock:
+            entry = self._command_handlers.get(command_type)
+            if entry is None:
+                raise HandlerNotFoundError(command_type)
+            if _is_factory(entry, ICommandHandler):
+                # Es un factory, invocar y cachear la instancia
+                handler = t.cast(CommandHandlerFactory, entry)()
+                self._command_handlers[command_type] = handler
+                return handler
+            return t.cast(ICommandHandler[t.Any, t.Any], entry)
 
     # ── Query Handlers ────────────────────────────────────────────
 
@@ -84,32 +133,53 @@ class HandlerRegistry:
         handler: IQueryHandler[t.Any, t.Any] | QueryHandlerFactory,
     ) -> "HandlerRegistry":
         """Registra un handler (o factory) para un tipo de query. Retorna self para fluent API."""
-        if not self._allow_override and query_type in self._query_handlers:
-            raise DuplicateHandlerError(query_type)
-        self._query_handlers[query_type] = handler
+        with self._lock:
+            if not self._allow_override and query_type in self._query_handlers:
+                raise DuplicateHandlerError(query_type)
+            self._query_handlers[query_type] = handler
         return self
 
     def resolve_query_handler(
         self, query_type: type[Query[t.Any]]
     ) -> IQueryHandler[t.Any, t.Any]:
         """Resuelve el handler para el tipo de query dado."""
-        entry = self._query_handlers.get(query_type)
-        if entry is None:
-            raise HandlerNotFoundError(query_type)
-        if callable(entry) and not isinstance(entry, IQueryHandler):
-            handler = entry()
-            self._query_handlers[query_type] = handler
-            return handler
-        return t.cast(IQueryHandler[t.Any, t.Any], entry)
+        with self._lock:
+            entry = self._query_handlers.get(query_type)
+            if entry is None:
+                raise HandlerNotFoundError(query_type)
+            if _is_factory(entry, IQueryHandler):
+                handler = t.cast(QueryHandlerFactory, entry)()
+                self._query_handlers[query_type] = handler
+                return handler
+            return t.cast(IQueryHandler[t.Any, t.Any], entry)
 
     # ── Introspección ─────────────────────────────────────────────
 
     @property
     def registered_commands(self) -> frozenset[type[Command]]:
         """Retorna los tipos de command registrados."""
-        return frozenset(self._command_handlers.keys())
+        with self._lock:
+            return frozenset(self._command_handlers.keys())
 
     @property
     def registered_queries(self) -> frozenset[type[Query[t.Any]]]:
         """Retorna los tipos de query registrados."""
-        return frozenset(self._query_handlers.keys())
+        with self._lock:
+            return frozenset(self._query_handlers.keys())
+
+
+def _is_factory(entry: t.Any, handler_interface: type) -> bool:
+    """
+    Decide si `entry` es un factory de handlers o el handler mismo.
+
+    El marcador `HandlerFactory` es inequívoco. Para los callables pelados se mantiene
+    la heurística anterior por retrocompatibilidad, con una comprobación extra: un
+    objeto con método `handle` es un handler aunque además sea callable.
+    """
+    if isinstance(entry, HandlerFactory):
+        return True
+    if isinstance(entry, handler_interface):
+        return False
+    if hasattr(entry, "handle"):
+        return False
+    return callable(entry)

--- a/hexcore/application/cqrs/scheduler.py
+++ b/hexcore/application/cqrs/scheduler.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timezone
+import warnings
+from datetime import datetime, timedelta, timezone
 
-from hexcore.domain.cqrs.cron import ICronJobRepository, ILockProvider
+from hexcore.domain.cqrs.cron import CronJobDefinition, ICronJobRepository, ILockProvider
 from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
 
 logger = logging.getLogger(__name__)
@@ -17,6 +18,18 @@ class DynamicScheduler:
     """
     Evalúa constantemente un repositorio de tareas periódicas y delega la ejecución
     al TaskEnqueuer (Celery/Procrastinate). Permite cambiar configuraciones cron en "caliente".
+
+    **Catch-up.** La decisión no es "¿la expresión cron coincide con el minuto
+    actual?" —que se salta el job cuando el tick deriva un segundo— sino "¿hubo
+    alguna ocurrencia entre la última ejecución y ahora?". Eso hace que:
+
+    - un minuto saltado por drift del tick no pierda la ejecución;
+    - el mismo minuto muestreado varias veces (``tick_interval_seconds < 60``) no
+      duplique el encolado, porque ``last_run_at`` deduplica de verdad.
+
+    El catch-up se acota con ``catch_up_window_seconds`` para que un scheduler que
+    estuvo caído mucho tiempo no dispare ocurrencias antiguas ni itere millones de
+    minutos.
     """
 
     def __init__(
@@ -24,76 +37,206 @@ class DynamicScheduler:
         repository: ICronJobRepository,
         enqueuer: ITaskEnqueuer,
         lock_provider: ILockProvider | None = None,
-        tick_interval_seconds: int = 30
+        tick_interval_seconds: int = 30,
+        *,
+        catch_up_window_seconds: int = 3600,
     ) -> None:
         self.repository = repository
         self.enqueuer = enqueuer
         self.lock_provider = lock_provider
         self.tick_interval_seconds = tick_interval_seconds
-        
+        self.catch_up_window_seconds = catch_up_window_seconds
+
         self._stop_event = asyncio.Event()
+        # Memoria local de la última ocurrencia encolada por job. Complementa a
+        # `last_run_at` del repositorio: si el repo tarda en reflejar la escritura,
+        # esto evita que el mismo minuto se encole dos veces en este proceso.
+        self._last_enqueued: dict[str, datetime] = {}
+
+        if tick_interval_seconds < 60 and lock_provider is None:
+            warnings.warn(
+                f"DynamicScheduler con tick_interval_seconds={tick_interval_seconds} "
+                "(<60) y sin lock_provider: el mismo minuto se muestrea varias veces. "
+                "En este proceso la deduplicación por last_run_at lo cubre, pero con "
+                "varias réplicas del scheduler el job se duplicará. Pasá un "
+                "lock_provider (RedisLockProvider / PostgresLockProvider) o subí el "
+                "tick a 60s.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
     async def start(self) -> None:
         """Inicia el bucle infinito del scheduler."""
-        import croniter
-        
-        logger.info(f"[*] DynamicScheduler started (Tick interval: {self.tick_interval_seconds}s)")
+        logger.info(
+            "[*] DynamicScheduler started (Tick interval: %ss, catch-up window: %ss)",
+            self.tick_interval_seconds,
+            self.catch_up_window_seconds,
+        )
         self._stop_event.clear()
 
-        # El estado base es el momento en que se levantó el scheduler.
-        last_check_time = datetime.now(timezone.utc)
+        # Ancla inicial: el comienzo del minuto en curso, exclusivo. Así una
+        # ocurrencia de *este* minuto cuenta como pendiente (arrancar a las 03:00:30
+        # sí dispara el job de las 03:00), pero no se disparan ocurrencias
+        # anteriores al arranque. Si el job tiene `last_run_at`, manda ése.
+        last_check_time = _start_of_minute(datetime.now(timezone.utc)) - _EPSILON
 
         while not self._stop_event.is_set():
+            # El tick corre *antes* del sleep: con el sleep primero se perdía el
+            # primer tick entero.
             try:
-                # 1. Esperamos el tiempo del tick
-                await asyncio.sleep(self.tick_interval_seconds)
-                
-                current_time = datetime.now(timezone.utc)
-                
-                # 2. Obtenemos la configuración fresca de BD
-                active_jobs = await self.repository.get_active_jobs()
-                
-                for job in active_jobs:
-                    # Determinamos desde cuándo chequear. Si el job tiene `last_run_at`, lo usamos.
-                    # Sino, usamos el `last_check_time` global del bucle.
-                    base_time = job.last_run_at or last_check_time
-                    
-                    try:
-                        # 3. Comprobamos si la expresión cron cayó entre base_time y current_time
-                        if croniter.croniter.match(job.cron_expression, current_time):
-                            # Evitar múltiples encolados en el mismo tick (minuto)
-                            # Intentar adquirir lock si hay proveedor (Distributed Locks)
-                            if self.lock_provider:
-                                # Usamos el minuto actual (truncado) para evitar colisiones distribuidas
-                                minute_key = current_time.replace(second=0, microsecond=0).isoformat()
-                                lock_key = f"hexcore:cron_lock:{job.job_id}:{minute_key}"
-                                
-                                lock_acquired = await self.lock_provider.acquire_lock(lock_key, ttl_seconds=60)
-                                if not lock_acquired:
-                                    logger.debug(f"CronJob '{job.job_id}' ignorado (lock adquirido por otra réplica).")
-                                    continue
-                                    
-                            logger.info(f"Encolando CronJob '{job.job_id}' -> Task: {job.task_name}")
-                            
-                            await self.enqueuer.enqueue_task(
-                                task_name=job.task_name,
-                                payload=job.payload,
-                                queue=job.queue
-                            )
-                            
-                            # Actualizamos el timestamp en el repositorio
-                            await self.repository.update_last_run(job.job_id, current_time)
-                            
-                    except Exception as e:
-                        logger.error(f"Error procesando el cron job {job.job_id}: {e}")
-
-                last_check_time = current_time
-
+                # `current_time` del tick se reutiliza como ancla del siguiente, para
+                # que no quede un hueco sin cubrir entre dos ticks.
+                last_check_time = await self._tick(last_check_time)
             except asyncio.CancelledError:
                 break
-            except Exception as e:
-                logger.error(f"Error crítico en el bucle del scheduler: {e}")
+            except Exception:
+                logger.exception("Error en el tick del scheduler; el bucle continúa")
+                last_check_time = datetime.now(timezone.utc)
+
+            try:
+                await asyncio.wait_for(
+                    self._stop_event.wait(), timeout=self.tick_interval_seconds
+                )
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+
+    async def _tick(self, last_check_time: datetime) -> datetime:
+        """
+        Evalúa todos los jobs activos una vez.
+
+        Returns:
+            El `current_time` usado, para que el siguiente tick lo tome como ancla.
+        """
+        current_time = datetime.now(timezone.utc)
+        active_jobs = await self.repository.get_active_jobs()
+
+        for job in active_jobs:
+            try:
+                await self._process_job(job, last_check_time, current_time)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Error procesando el cron job %s", job.job_id)
+
+        return current_time
+
+    async def _process_job(
+        self,
+        job: CronJobDefinition,
+        last_check_time: datetime,
+        current_time: datetime,
+    ) -> None:
+        """Encola el job si le tocaba correr en algún momento desde su última ejecución."""
+        base_time = self._resolve_base_time(job, last_check_time, current_time)
+        occurrence = self._latest_due_occurrence(
+            job.cron_expression, base_time, current_time
+        )
+        if occurrence is None:
+            return
+
+        # El lock se toma sobre la *ocurrencia*, no sobre el minuto actual: dos
+        # réplicas con ticks desfasados compiten por la misma clave.
+        if self.lock_provider:
+            lock_key = f"hexcore:cron_lock:{job.job_id}:{occurrence.isoformat()}"
+            acquired = await self.lock_provider.acquire_lock(lock_key, ttl_seconds=60)
+            if not acquired:
+                logger.debug(
+                    "CronJob '%s' ignorado (lock adquirido por otra réplica).",
+                    job.job_id,
+                )
+                return
+
+        logger.info(
+            "Encolando CronJob '%s' -> Task: %s (ocurrencia %s)",
+            job.job_id,
+            job.task_name,
+            occurrence.isoformat(),
+        )
+
+        await self.enqueuer.enqueue_task(
+            task_name=job.task_name,
+            payload=job.payload,
+            queue=job.queue,
+        )
+
+        # Marcar *la ocurrencia*, no `current_time`: es lo que hace que el siguiente
+        # tick sepa que este minuto ya se sirvió.
+        self._last_enqueued[job.job_id] = occurrence
+        await self.repository.update_last_run(job.job_id, occurrence)
+
+    def _resolve_base_time(
+        self,
+        job: CronJobDefinition,
+        last_check_time: datetime,
+        current_time: datetime,
+    ) -> datetime:
+        """
+        Desde cuándo buscar ocurrencias pendientes.
+
+        Se toma la más reciente entre `last_run_at`, la memoria local de este proceso
+        y el arranque del bucle, y se acota con la ventana de catch-up.
+        """
+        candidates = [last_check_time]
+        if job.last_run_at is not None:
+            candidates.append(_as_utc(job.last_run_at))
+        local = self._last_enqueued.get(job.job_id)
+        if local is not None:
+            candidates.append(local)
+
+        base_time = max(candidates)
+        window_start = current_time - timedelta(seconds=self.catch_up_window_seconds)
+        return max(base_time, window_start)
+
+    def _latest_due_occurrence(
+        self,
+        cron_expression: str,
+        base_time: datetime,
+        current_time: datetime,
+    ) -> datetime | None:
+        """
+        Última ocurrencia de `cron_expression` en el intervalo `(base_time, current_time]`.
+
+        Devuelve `None` si no hubo ninguna. Se encola una sola vez aunque se hayan
+        saltado varias ocurrencias: para una tarea periódica, correr N veces seguidas
+        para "recuperar" es casi siempre peor que correr una.
+        """
+        import croniter
+
+        try:
+            iterator = croniter.croniter(cron_expression, base_time)
+        except (croniter.CroniterBadCronError, croniter.CroniterBadDateError) as exc:
+            logger.error("Expresión cron inválida '%s': %s", cron_expression, exc)
+            return None
+
+        latest: datetime | None = None
+        while True:
+            try:
+                candidate = iterator.get_next(datetime)
+            except croniter.CroniterBadDateError:
+                # Expresión que no vuelve a ocurrir (p. ej. "0 0 31 2 *").
+                break
+            if candidate > current_time:
+                break
+            latest = candidate
+
+        return latest
 
     def stop(self) -> None:
         """Detiene el bucle del scheduler de forma segura."""
         self._stop_event.set()
+
+
+_EPSILON = timedelta(microseconds=1)
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Normaliza a UTC: un `last_run_at` naive de la BD rompería las comparaciones."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _start_of_minute(value: datetime) -> datetime:
+    return value.replace(second=0, microsecond=0)

--- a/hexcore/infrastructure/api/utils.py
+++ b/hexcore/infrastructure/api/utils.py
@@ -30,6 +30,27 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
 async def get_sql_uow(
     session: AsyncSession = Depends(get_session),
 ) -> AsyncGenerator[IUnitOfWork, None]:
+    """
+    Cede un `SqlAlchemyUnitOfWork` **sin entrar** en él.
+
+    Es la convención de los ejemplos de use case: el use case hace su propio
+    ``async with self.uow:`` y controla el commit. Si esta dependencia entrara al UoW,
+    ese ``async with`` del use case anidaría contextos.
+
+    Si necesitás el UoW ya abierto en el endpoint, usá `get_sql_uow_open`.
+    """
+    yield SqlAlchemyUnitOfWork(session=session)
+
+
+async def get_sql_uow_open(
+    session: AsyncSession = Depends(get_session),
+) -> AsyncGenerator[IUnitOfWork, None]:
+    """
+    Cede un `SqlAlchemyUnitOfWork` ya **abierto** (dentro de ``async with``).
+
+    Para endpoints que operan sobre el UoW directamente, sin pasar por un use case.
+    No comitea: el commit sigue siendo explícito.
+    """
     async with SqlAlchemyUnitOfWork(session=session) as uow:
         yield uow
 

--- a/hexcore/infrastructure/cqrs/postgres_lock.py
+++ b/hexcore/infrastructure/cqrs/postgres_lock.py
@@ -6,7 +6,7 @@ sin necesidad de añadir Redis a tu stack.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone, timedelta
+import typing as t
 from typing import TYPE_CHECKING
 
 from hexcore.domain.cqrs.cron import ILockProvider
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
     import asyncpg
 
 logger = logging.getLogger(__name__)
+
+LockErrorPolicy = t.Literal["skip", "raise"]
 
 
 class PostgresLockProvider(ILockProvider):
@@ -33,6 +35,12 @@ class PostgresLockProvider(ILockProvider):
 
     `purge_expired()` es pública si preferís purgar desde un job propio; poné
     `purge_every=0` para desactivar la purga automática.
+
+    **Qué pasa si Postgres no responde.** Igual que en `RedisLockProvider`:
+    `on_error="skip"` (default) loguea `critical` y devuelve `False`, o sea que el
+    cron se detiene mientras la BD esté caída; `on_error="raise"` propaga para que el
+    supervisor del scheduler lo vea. El log distingue "no pude decidir" (`critical`)
+    de "el lock estaba tomado" (`debug`).
     """
 
     def __init__(
@@ -40,6 +48,7 @@ class PostgresLockProvider(ILockProvider):
         pool: asyncpg.Pool | asyncpg.Connection,
         table_name: str = "hexcore_cron_locks",
         *,
+        on_error: LockErrorPolicy = "skip",
         purge_every: int = 100,
         purge_grace_seconds: int = 3600,
     ) -> None:
@@ -47,6 +56,7 @@ class PostgresLockProvider(ILockProvider):
         Args:
             pool: Pool de conexiones o conexión simple de `asyncpg`.
             table_name: Nombre de la tabla a utilizar para los locks.
+            on_error: Qué hacer si Postgres no responde. Ver el docstring de la clase.
             purge_every: Cada cuántas adquisiciones purgar lo expirado. 0 desactiva.
             purge_grace_seconds: Margen antes de borrar una fila expirada. Evita
                 borrar locks que acaban de vencer y que otra réplica podría estar
@@ -54,6 +64,7 @@ class PostgresLockProvider(ILockProvider):
         """
         self.pool = pool
         self.table_name = table_name
+        self.on_error = on_error
         self.purge_every = purge_every
         self.purge_grace_seconds = purge_grace_seconds
         self._acquisitions_since_purge = 0
@@ -113,7 +124,11 @@ class PostgresLockProvider(ILockProvider):
             
         Returns:
             True si el lock fue adquirido con éxito.
-            False si el lock ya estaba tomado y aún no ha expirado.
+            False si el lock ya estaba tomado y aún no ha expirado, o si Postgres
+            falló y `on_error="skip"`.
+
+        Raises:
+            Exception: El error original de asyncpg, si `on_error="raise"`.
         """
         # Usamos UPSERT (ON CONFLICT) condicional
         # Si no existe, lo inserta.
@@ -133,8 +148,25 @@ class PostgresLockProvider(ILockProvider):
             result = await self.pool.fetchrow(query, lock_key, str(ttl_seconds)) # type: ignore
             acquired = result is not None
         except Exception as e:
-            logger.error(f"Error intentando adquirir lock de Postgres para {lock_key}: {e}")
+            if self.on_error == "raise":
+                logger.critical(
+                    "No se pudo decidir el lock de Postgres para %s: %s. "
+                    "on_error='raise': se propaga.",
+                    lock_key,
+                    e,
+                )
+                raise
+            # "No pude decidir" es un incidente de infraestructura, no un lock tomado.
+            logger.critical(
+                "No se pudo decidir el lock de Postgres para %s: %s. "
+                "on_error='skip': el job NO se ejecuta en este tick.",
+                lock_key,
+                e,
+            )
             return False
+
+        if not acquired:
+            logger.debug("Lock de Postgres %s ya estaba tomado por otro proceso.", lock_key)
 
         await self._maybe_purge()
         return acquired

--- a/hexcore/infrastructure/cqrs/redis_lock.py
+++ b/hexcore/infrastructure/cqrs/redis_lock.py
@@ -5,6 +5,7 @@ Ideal para garantizar ejecución única de CronJobs en múltiples réplicas.
 from __future__ import annotations
 
 import logging
+import typing as t
 from typing import TYPE_CHECKING
 
 from hexcore.domain.cqrs.cron import ILockProvider
@@ -14,47 +15,94 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+LockErrorPolicy = t.Literal["skip", "raise"]
+
 
 class RedisLockProvider(ILockProvider):
     """
     Implementación de ILockProvider basada en Redis.
     Utiliza el comando SET NX EX para asegurar exclusión mutua de manera atómica
     y evitar "deadlocks" mediante la expiración (TTL).
+
+    **Qué pasa si Redis se cae.** `acquire_lock` no puede decidir, y las dos
+    respuestas posibles son malas de formas distintas: devolver `False` apaga el cron
+    completo (ningún job corre), devolver `True` deja que corran todas las réplicas
+    (jobs duplicados). El default es `on_error="skip"` (no correr), pero la decisión
+    es tuya y explícita:
+
+    - ``on_error="skip"``: log `critical` y `False`. El cron se detiene mientras Redis
+      esté caído. Correcto si duplicar es peor que no correr (cobros, envío de mail).
+    - ``on_error="raise"``: propaga la excepción para que el supervisor del scheduler
+      la vea y reinicie o alerte. Correcto si prefieres caerte ruidosamente.
+
+    El log distingue "no pude decidir" (`critical`) de "el lock estaba tomado"
+    (`debug`), que antes eran indistinguibles.
     """
 
-    def __init__(self, redis_client: Redis) -> None:
+    def __init__(
+        self,
+        redis_client: Redis,
+        *,
+        on_error: LockErrorPolicy = "skip",
+    ) -> None:
         """
         Args:
             redis_client: Instancia activa de `redis.asyncio.Redis`.
+            on_error: Qué hacer si Redis no responde. Ver el docstring de la clase.
         """
         self.redis = redis_client
+        self.on_error = on_error
 
     async def acquire_lock(self, lock_key: str, ttl_seconds: int) -> bool:
         """
         Intenta adquirir un lock en Redis.
-        
+
         Args:
             lock_key: La clave única del lock (ej. "hexcore:cron_lock:job_1:2026-07-28T01:02:00").
             ttl_seconds: Tiempo de vida del lock en segundos (evita deadlocks).
-            
+
         Returns:
             True si el lock fue adquirido con éxito (nadie lo tenía).
-            False si el lock ya estaba tomado por otro proceso.
+            False si el lock ya estaba tomado por otro proceso, o si Redis falló y
+            `on_error="skip"`.
+
+        Raises:
+            Exception: El error original de Redis, si `on_error="raise"`.
         """
         try:
             # SET key "1" NX (solo si no existe) EX ttl_seconds (expira automáticamente)
             # Retorna True (si lo seteó) o None/False (si ya existía)
             result = await self.redis.set(lock_key, "locked", nx=True, ex=ttl_seconds)
-            return bool(result)
         except Exception as e:
-            logger.error(f"Error intentando adquirir lock de Redis para {lock_key}: {e}")
-            # En caso de error de Redis, asumimos False para evitar ejecución duplicada por dudas,
-            # o podríamos dejar que explote. En un scheduler, es más seguro no correr.
+            if self.on_error == "raise":
+                logger.critical(
+                    "No se pudo decidir el lock de Redis para %s: %s. "
+                    "on_error='raise': se propaga.",
+                    lock_key,
+                    e,
+                )
+                raise
+            # "No pude decidir" es un incidente de infraestructura, no un lock tomado:
+            # va a critical para que se distinga en los logs y en las alertas.
+            logger.critical(
+                "No se pudo decidir el lock de Redis para %s: %s. "
+                "on_error='skip': el job NO se ejecuta en este tick.",
+                lock_key,
+                e,
+            )
             return False
+
+        acquired = bool(result)
+        if not acquired:
+            logger.debug("Lock de Redis %s ya estaba tomado por otro proceso.", lock_key)
+        return acquired
 
     async def release_lock(self, lock_key: str) -> None:
         """
         Libera el lock explícitamente.
+
+        No propaga nunca: el TTL libera el lock igual, así que un fallo aquí es un
+        retraso, no una pérdida de corrección.
         """
         try:
             await self.redis.delete(lock_key)

--- a/hexcore/infrastructure/repositories/orms/sqlalchemy/session.py
+++ b/hexcore/infrastructure/repositories/orms/sqlalchemy/session.py
@@ -1,5 +1,26 @@
+"""
+Engine y session factory de SQLAlchemy para HexCore.
+
+Punto de entrada recomendado: `init_engine()` en el arranque y `dispose_engine()` en
+el apagado. `get_engine()` / `get_session_factory()` siguen existiendo y hacen
+lazy-init con los defaults correctos, así que nada obliga a llamar a `init_engine`.
+
+Decisiones que **no** son parámetros porque son el comportamiento correcto:
+
+- ``expire_on_commit=False``. Con el default de SQLAlchemy (``True``) los atributos de
+  las entidades expiran al comitear, y el siguiente acceso dispara un lazy-load sobre
+  una sesión ya cerrada → ``MissingGreenlet`` / ``DetachedInstanceError``. Quien
+  necesite ``True`` construye su propio ``async_sessionmaker``.
+- La normalización del driver en el DSN. Un ``DATABASE_URL`` de PaaS viene como
+  ``postgresql://…`` y ``create_async_engine`` no lo acepta.
+"""
+from __future__ import annotations
+
+import threading
+import typing as t
 from collections.abc import AsyncGenerator
 
+from pydantic import BaseModel as PydanticBaseModel
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -9,38 +30,164 @@ from sqlalchemy.ext.asyncio import (
 
 from hexcore.config import LazyConfig
 
+__all__ = [
+    "PoolSettings",
+    "init_engine",
+    "dispose_engine",
+    "get_engine",
+    "get_session_factory",
+    "get_async_db_session",
+    "normalize_async_dsn",
+    "reset_sqlalchemy_engine",
+]
+
+
+class PoolSettings(PydanticBaseModel):
+    """
+    Tuning del pool de conexiones.
+
+    ``pre_ping`` va en True por defecto a propósito: un pool sin pre-ping contra
+    Postgres detrás de un balanceador entrega conexiones muertas al primer failover.
+    """
+
+    size: int | None = None
+    max_overflow: int | None = None
+    pre_ping: bool = True
+    recycle: int | None = 1800
+
+
+# Mapeo de esquemas "síncronos" al driver async equivalente. Sólo se aplica cuando el
+# DSN no declara driver (`postgresql://`, no `postgresql+psycopg://`).
+_ASYNC_DRIVERS: dict[str, str] = {
+    "postgresql": "postgresql+asyncpg",
+    "postgres": "postgresql+asyncpg",
+    "sqlite": "sqlite+aiosqlite",
+    "mysql": "mysql+aiomysql",
+    "mariadb": "mariadb+aiomysql",
+}
+
 _engine: AsyncEngine | None = None
 _session_factory: async_sessionmaker[AsyncSession] | None = None
+# Los globals se tocan desde el lifespan, desde los workers y potencialmente desde
+# varios hilos (free-threading en 3.14): sin lock se pueden crear dos engines.
+_lock = threading.RLock()
+
+
+def normalize_async_dsn(url: str) -> str:
+    """
+    Devuelve un DSN utilizable por ``create_async_engine``.
+
+    ``postgresql://host/db`` → ``postgresql+asyncpg://host/db``. Si el DSN ya declara
+    un driver (``+asyncpg``, ``+psycopg``…) se deja intacto: puede que sea a propósito.
+    """
+    scheme, separator, rest = url.partition("://")
+    if not separator or "+" in scheme:
+        return url
+    replacement = _ASYNC_DRIVERS.get(scheme.lower())
+    if replacement is None:
+        return url
+    return f"{replacement}://{rest}"
+
+
+def init_engine(
+    url: str | None = None,
+    *,
+    pool: PoolSettings | None = None,
+    **engine_kwargs: t.Any,
+) -> AsyncEngine:
+    """
+    Crea (o devuelve) el engine asíncrono del proceso.
+
+    Args:
+        url: DSN explícito. Si es None, se usa ``config.async_sql_database_url``.
+            En ambos casos se normaliza el driver. Los workers, scripts y tests
+            necesitan poder pasarlo explícitamente.
+        pool: Tuning del pool. Ver `PoolSettings`.
+        **engine_kwargs: Se pasan tal cual a ``create_async_engine`` (``echo``,
+            ``connect_args``, ``json_serializer``…).
+
+    Returns:
+        El engine. Si ya había uno inicializado se devuelve ése **sin** aplicar los
+        parámetros nuevos: llamá a `dispose_engine()` antes si querés reconfigurar.
+    """
+    global _engine
+
+    with _lock:
+        if _engine is not None:
+            return _engine
+
+        dsn = normalize_async_dsn(url or LazyConfig.get_config().async_sql_database_url)
+        options = _pool_kwargs(dsn, pool or PoolSettings())
+        options.update(engine_kwargs)
+        _engine = create_async_engine(dsn, **options)
+        return _engine
+
+
+def _pool_kwargs(dsn: str, pool: PoolSettings) -> dict[str, t.Any]:
+    """
+    Traduce `PoolSettings` a kwargs de ``create_async_engine``.
+
+    SQLite no usa un pool con tamaño (``NullPool``/``StaticPool`` según el caso), y
+    pasarle ``pool_size`` es un ``TypeError``, así que esas dos opciones se omiten.
+    """
+    options: dict[str, t.Any] = {"pool_pre_ping": pool.pre_ping}
+    if pool.recycle is not None:
+        options["pool_recycle"] = pool.recycle
+
+    if dsn.startswith("sqlite"):
+        return options
+
+    if pool.size is not None:
+        options["pool_size"] = pool.size
+    if pool.max_overflow is not None:
+        options["max_overflow"] = pool.max_overflow
+    return options
+
+
+async def dispose_engine() -> None:
+    """
+    Cierra el pool de conexiones y deja el módulo re-inicializable.
+
+    Es lo que hay que llamar en el shutdown de un lifespan, y también antes de
+    reconfigurar el engine.
+    """
+    global _engine, _session_factory
+
+    with _lock:
+        engine, _engine = _engine, None
+        _session_factory = None
+
+    if engine is not None:
+        await engine.dispose()
 
 
 def get_engine() -> AsyncEngine:
     """
     Retorna el engine asíncrono de SQLAlchemy.
-    Se inicializa de forma lazy (solo cuando se solicita).
+    Se inicializa de forma lazy con los defaults de `init_engine()`.
     """
-    global _engine
-    if _engine is None:
-        _engine = create_async_engine(
-            LazyConfig.get_config().async_sql_database_url,
-            # echo=True,
-        )
-    return _engine
+    return init_engine()
 
 
 def get_session_factory() -> async_sessionmaker[AsyncSession]:
     """
     Retorna la factoría de sesiones de SQLAlchemy.
-    Se inicializa de forma lazy.
+    Se inicializa de forma lazy, con ``expire_on_commit=False``.
     """
     global _session_factory
-    if _session_factory is None:
-        _session_factory = async_sessionmaker(
-            autocommit=False,
-            autoflush=False,
-            bind=get_engine(),
-            class_=AsyncSession,
-        )
-    return _session_factory
+
+    with _lock:
+        if _session_factory is None:
+            _session_factory = async_sessionmaker(
+                autocommit=False,
+                autoflush=False,
+                bind=get_engine(),
+                class_=AsyncSession,
+                # Sin esto, acceder a un atributo después de `uow.commit()` dispara un
+                # lazy-load sobre una sesión cerrada.
+                expire_on_commit=False,
+            )
+        return _session_factory
 
 
 async def get_async_db_session() -> AsyncGenerator[AsyncSession, None]:
@@ -52,15 +199,10 @@ async def get_async_db_session() -> AsyncGenerator[AsyncSession, None]:
 
 async def reset_sqlalchemy_engine() -> None:
     """
-    Cierra el pool de conexiones actual y recrea el engine de forma lazy.
-    Crítico para inicializar asíncronamente workers (ej. RabbitMQ, Celery) 
-    y evitar el error de 'Task attached to a different loop'.
-    """
-    global _engine
-    global _session_factory
+    Alias legacy de `dispose_engine()`.
 
-    if _engine is not None:
-        await _engine.dispose()
-    
-    _engine = None
-    _session_factory = None
+    Se conserva porque los workers (RabbitMQ, Celery) lo llaman para re-atar el pool al
+    event loop nuevo. Para el shutdown de una app, `dispose_engine()` dice mejor lo que
+    hace.
+    """
+    await dispose_engine()

--- a/hexcore/infrastructure/task_queues/celery_adapter.py
+++ b/hexcore/infrastructure/task_queues/celery_adapter.py
@@ -6,9 +6,13 @@ utilidades para auto-registrar las tareas asíncronas en el Worker.
 from __future__ import annotations
 
 import asyncio
+import logging
 import typing as t
+import weakref
 
 from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
+
+logger = logging.getLogger("hexcore.task_queues.celery")
 
 if t.TYPE_CHECKING:
     try:
@@ -64,15 +68,46 @@ class CeleryEnqueuer(ITaskEnqueuer):
         )
 
 
-def register_hexcore_celery_tasks(app: "Celery", consumer: "CQRSConsumer") -> None:
+HEXCORE_TASK_NAMES = (
+    "hexcore.process_command",
+    "hexcore.process_handler",
+    "hexcore.process_task",
+)
+
+_registered_apps: "weakref.WeakValueDictionary[int, t.Any]" = weakref.WeakValueDictionary()
+
+
+def is_registered(app: "Celery") -> bool:
+    """Indica si `register_hexcore_celery_tasks` ya corrió sobre esta app."""
+    return id(app) in _registered_apps
+
+
+def register_hexcore_celery_tasks(
+    app: "Celery",
+    consumer: "CQRSConsumer",
+    *,
+    force: bool = False,
+) -> bool:
     """
     Auto-registra las tareas base de HexCore en una aplicación Celery.
     Esto permite que un worker de Celery esté listo para recibir mensajes
     generados por el Smart Routing de HexCore.
-    
-    Dado que las tareas de Celery son síncronas y el Consumer de HexCore es 
+
+    Es **idempotente**: llamarla dos veces sobre la misma app no vuelve a registrar.
+    Antes cada aplicación tenía que protegerla con un flag de módulo.
+
+    Dado que las tareas de Celery son síncronas y el Consumer de HexCore es
     asíncrono, se envuelven en `asyncio.run()`.
+
+    Returns:
+        True si se registraron las tareas, False si ya estaban registradas.
     """
+    if not force and is_registered(app):
+        logger.debug(
+            "Las tareas de HexCore ya estaban registradas en esta app de Celery; "
+            "no se vuelven a registrar."
+        )
+        return False
 
     @app.task(name="hexcore.process_command", bind=True)
     def process_command(self: t.Any, payload: dict[str, t.Any]) -> None:
@@ -85,3 +120,9 @@ def register_hexcore_celery_tasks(app: "Celery", consumer: "CQRSConsumer") -> No
     @app.task(name="hexcore.process_task", bind=True)
     def process_task(self: t.Any, task_name: str, payload: dict[str, t.Any]) -> None:
         asyncio.run(consumer.process_task(task_name, payload))
+
+    try:
+        _registered_apps[id(app)] = app
+    except TypeError:
+        logger.debug("No se pudo memorizar el registro para esta app de Celery.")
+    return True

--- a/hexcore/infrastructure/task_queues/procrastinate_adapter.py
+++ b/hexcore/infrastructure/task_queues/procrastinate_adapter.py
@@ -5,9 +5,13 @@ utilidades para auto-registrar las tareas asíncronas en el Worker.
 """
 from __future__ import annotations
 
+import logging
 import typing as t
+import weakref
 
 from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
+
+logger = logging.getLogger("hexcore.task_queues.procrastinate")
 
 if t.TYPE_CHECKING:
     try:
@@ -49,10 +53,51 @@ class ProcrastinateEnqueuer(ITaskEnqueuer):
         await task.defer_async(task_name=task_name, payload=payload)
 
 
-def register_hexcore_procrastinate_tasks(app: "procrastinate.App", consumer: "CQRSConsumer") -> None:
+HEXCORE_TASK_NAMES = (
+    "hexcore.process_command",
+    "hexcore.process_handler",
+    "hexcore.process_task",
+)
+
+# Apps en las que ya se registraron las tareas. Se guarda por `id()` en un
+# WeakValueDictionary para no mantener viva la app y para tolerar varias apps en el
+# mismo proceso (tests, scripts que construyen y descartan apps).
+_registered_apps: "weakref.WeakValueDictionary[int, t.Any]" = weakref.WeakValueDictionary()
+
+
+def is_registered(app: "procrastinate.App") -> bool:
+    """Indica si `register_hexcore_procrastinate_tasks` ya corrió sobre esta app."""
+    return id(app) in _registered_apps
+
+
+def register_hexcore_procrastinate_tasks(
+    app: "procrastinate.App",
+    consumer: "CQRSConsumer",
+    *,
+    force: bool = False,
+) -> bool:
     """
     Auto-registra las tareas base de HexCore en una aplicación Procrastinate.
+
+    Es **idempotente**: llamarla dos veces sobre la misma app no hace nada la segunda
+    vez, en vez de reventar porque Procrastinate rechaza nombres duplicados. Antes cada
+    aplicación tenía que protegerla con un flag de módulo.
+
+    Args:
+        app: La aplicación de Procrastinate.
+        consumer: El `CQRSConsumer` que ejecutará los mensajes.
+        force: Registrar aunque ya se hubiera registrado. Útil para rebindear el
+            consumer; puede fallar si Procrastinate rechaza el nombre duplicado.
+
+    Returns:
+        True si se registraron las tareas, False si ya estaban registradas.
     """
+    if not force and is_registered(app):
+        logger.debug(
+            "Las tareas de HexCore ya estaban registradas en esta app de Procrastinate; "
+            "no se vuelven a registrar."
+        )
+        return False
 
     @app.task(name="hexcore.process_command")
     async def process_command(payload: dict[str, t.Any]) -> None:
@@ -65,3 +110,11 @@ def register_hexcore_procrastinate_tasks(app: "procrastinate.App", consumer: "CQ
     @app.task(name="hexcore.process_task")
     async def process_task(task_name: str, payload: dict[str, t.Any]) -> None:
         await consumer.process_task(task_name, payload)
+
+    try:
+        _registered_apps[id(app)] = app
+    except TypeError:
+        # Un objeto no referenciable débilmente (p. ej. un mock exótico): la
+        # idempotencia no se puede memorizar, pero el registro ya ocurrió.
+        logger.debug("No se pudo memorizar el registro para esta app de Procrastinate.")
+    return True

--- a/hexcore/infrastructure/uow/__init__.py
+++ b/hexcore/infrastructure/uow/__init__.py
@@ -187,3 +187,23 @@ class BeanieUnitOfWork(IUnitOfWork):
 
 # Alias por retrocompatibilidad
 NoSqlUnitOfWork = BeanieUnitOfWork
+
+
+# Scopes para código fuera de FastAPI (workers, cron, scripts, seeds).
+# Se importan al final: `scopes` sólo importa de este módulo de forma perezosa.
+from .scopes import (  # noqa: E402
+    nosql_uow_scope,
+    open_uow_scope,
+    session_scope,
+    uow_scope,
+)
+
+__all__ = [
+    "SqlAlchemyUnitOfWork",
+    "BeanieUnitOfWork",
+    "NoSqlUnitOfWork",
+    "session_scope",
+    "uow_scope",
+    "open_uow_scope",
+    "nosql_uow_scope",
+]

--- a/hexcore/infrastructure/uow/scopes.py
+++ b/hexcore/infrastructure/uow/scopes.py
@@ -1,0 +1,93 @@
+"""
+Scopes de sesión y Unit of Work para código que **no** es un request de FastAPI.
+
+`hexcore.infrastructure.api.utils` sólo ofrece dependencias FastAPI (`get_session`,
+`get_sql_uow`). Todo lo demás —workers, tasks de background, cron, scripts, seeds,
+migraciones de datos— se queda sin nada y termina reescribiendo estos dos context
+managers.
+
+`session_scope` no es un lujo: construir un `SqlAlchemyUnitOfWork` corre el
+auto-discovery e **instancia todos los repositorios de dominio**, un coste absurdo para
+leer una tabla de infraestructura como `cron_jobs`.
+
+Convención de `uow_scope`: **no** entra al UoW. Cede el UoW sin abrir la transacción,
+para que el use case controle su propio ``async with uow:``, que es la convención de
+los ejemplos de use case. Si querés el UoW ya abierto, usá `open_uow_scope`.
+"""
+from __future__ import annotations
+
+import typing as t
+from contextlib import asynccontextmanager
+
+if t.TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from hexcore.domain.uow import IUnitOfWork
+
+__all__ = ["session_scope", "uow_scope", "open_uow_scope", "nosql_uow_scope"]
+
+
+@asynccontextmanager
+async def session_scope() -> t.AsyncIterator["AsyncSession"]:
+    """
+    Cede una `AsyncSession` con su ciclo de vida gestionado.
+
+    No abre transacción ni comitea: eso lo decide quien la usa. Sirve para leer o
+    escribir tablas de infraestructura sin pagar el auto-discovery de repositorios.
+
+    Uso::
+
+        async with session_scope() as session:
+            rows = (await session.execute(select(CronJobModel))).scalars().all()
+    """
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (
+        get_session_factory,
+    )
+
+    factory = get_session_factory()
+    async with factory() as session:
+        yield session
+
+
+@asynccontextmanager
+async def uow_scope() -> t.AsyncIterator["IUnitOfWork"]:
+    """
+    Cede un `SqlAlchemyUnitOfWork` **sin entrar** en él.
+
+    Es la convención de los ejemplos de use case: el use case hace su propio
+    ``async with self.uow:`` y controla el commit. Entrar aquí y además allí anida
+    contextos.
+
+    Uso::
+
+        async with uow_scope() as uow:
+            await CerrarTicketUseCase(uow).execute(request)
+    """
+    from hexcore.infrastructure.uow import SqlAlchemyUnitOfWork
+
+    async with session_scope() as session:
+        yield SqlAlchemyUnitOfWork(session=session)
+
+
+@asynccontextmanager
+async def open_uow_scope() -> t.AsyncIterator["IUnitOfWork"]:
+    """
+    Como `uow_scope`, pero **entra** al UoW (abre la transacción) y hace rollback si
+    el bloque lanza.
+
+    Para código que no delega en un use case y quiere el UoW listo para usar. No
+    comitea: el commit sigue siendo explícito.
+    """
+    async with uow_scope() as uow:
+        async with uow:
+            yield uow
+
+
+@asynccontextmanager
+async def nosql_uow_scope() -> t.AsyncIterator["IUnitOfWork"]:
+    """Equivalente de `open_uow_scope` para el UoW de Beanie/MongoDB."""
+    from hexcore.infrastructure.uow import NoSqlUnitOfWork
+
+    uow: "IUnitOfWork" = NoSqlUnitOfWork()
+    async with uow:
+        yield uow

--- a/hexcore/infrastructure/workers/consumer.py
+++ b/hexcore/infrastructure/workers/consumer.py
@@ -36,31 +36,55 @@ class CQRSConsumer:
     Ayudante universal para recibir mensajes serializados desde un Worker 
     y despacharlos a los handlers locales usando buses en memoria.
     
-    Uso (ej. Procrastinate):
-    
-        consumer = CQRSConsumer(local_cmd_bus, local_evt_bus, serializer)
-        
-        @app.task(name="process_cqrs_command")
-        async def process_cqrs_command(payload: dict):
-            await consumer.process_command(payload)
+    Uso (ej. Procrastinate)::
+
+        consumer = CQRSConsumer(command_bus, event_bus)
+        register_hexcore_procrastinate_tasks(app, consumer)
+
+    Un worker sólo-comandos puede omitir el event bus::
+
+        consumer = CQRSConsumer(command_bus)
     """
 
     def __init__(
         self,
         command_bus: AbstractCommandBus,
-        event_bus: AbstractEventBus,
-        serializer: ISerializer,
+        event_bus: AbstractEventBus | None = None,
+        serializer: ISerializer | None = None,
     ) -> None:
         """
         Args:
             command_bus: El bus de comandos *local* (usualmente InMemoryCommandBus)
                          que tiene registrados los handlers.
             event_bus: El bus de eventos *local* (usualmente InMemoryEventBus).
-            serializer: El serializador usado (ej. PydanticSerializer).
+                       Opcional: un worker sólo-comandos no lo necesita, y antes había
+                       que pasar `cast(Any, None)` para satisfacer el tipo.
+            serializer: El serializador usado. Por defecto `PydanticSerializer`.
         """
+        if serializer is None:
+            from hexcore.infrastructure.cqrs.pydantic_serializer import PydanticSerializer
+
+            serializer = PydanticSerializer()
+
         self._command_bus = command_bus
         self._event_bus = event_bus
         self._serializer = serializer
+
+    @property
+    def event_bus(self) -> AbstractEventBus:
+        """
+        El event bus configurado.
+
+        Raises:
+            RuntimeError: Si el consumer se construyó sin event bus y llega un evento.
+        """
+        if self._event_bus is None:
+            raise RuntimeError(
+                "Llegó un evento pero este CQRSConsumer se construyó sin 'event_bus'. "
+                "Pasá un AbstractEventBus al construirlo si el worker tiene que "
+                "procesar eventos, o enrutá los eventos a otra cola."
+            )
+        return self._event_bus
 
     async def process_command(self, payload: dict[str, t.Any]) -> None:
         """
@@ -97,7 +121,7 @@ class CQRSConsumer:
 
             logger.info("[CQRSConsumer] Procesando evento en background: %s", evt.event_name)
             with worker_execution():
-                await self._event_bus.publish(evt)
+                await self.event_bus.publish(evt)
 
         except Exception as exc:
             logger.exception("[CQRSConsumer] Error procesando evento: %s", exc)

--- a/hexcore/infrastructure/workers/rabbitmq_worker.py
+++ b/hexcore/infrastructure/workers/rabbitmq_worker.py
@@ -16,17 +16,21 @@ logger = logging.getLogger("hexcore.workers.rabbitmq")
 @asynccontextmanager
 async def setup_sqlalchemy():
     """Context manager para inicializar y limpiar conexiones SQL en el worker."""
-    from hexcore.infrastructure.repositories.orms.sqlalchemy.session import reset_sqlalchemy_engine, engine
-    
-    # 1. Resetear el pool para atarlo a ESTE event loop
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (
+        dispose_engine,
+        init_engine,
+    )
+
+    # 1. Descartar cualquier pool heredado y crear el engine dentro de ESTE event loop.
     logger.info("[Worker Lifecycle] Inicializando engine de SQLAlchemy...")
-    await reset_sqlalchemy_engine()
-    
+    await dispose_engine()
+    init_engine()
+
     try:
         yield
     finally:
         logger.info("[Worker Lifecycle] Cerrando conexiones de SQLAlchemy...")
-        await engine.dispose()
+        await dispose_engine()
 
 
 @asynccontextmanager

--- a/tests/test_consumer_optional_event_bus.py
+++ b/tests/test_consumer_optional_event_bus.py
@@ -1,0 +1,68 @@
+"""
+P2-2: `CQRSConsumer` exigía un `event_bus` no-opcional, así que un worker
+sólo-comandos tenía que pasar `cast(Any, None)` para satisfacer el tipo.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hexcore.application.cqrs.in_memory_buses import InMemoryCommandBus
+from hexcore.application.cqrs.registry import HandlerRegistry
+from hexcore.domain.cqrs.commands import Command
+from hexcore.domain.events import DomainEvent
+from hexcore.infrastructure.cqrs.pydantic_serializer import PydanticSerializer
+from hexcore.infrastructure.workers.consumer import CQRSConsumer
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class OnlyCommand(Command):
+    value: str
+
+
+class OnlyCommandHandler:
+    def __init__(self) -> None:
+        self.seen: list[str] = []
+
+    async def handle(self, cmd: OnlyCommand) -> None:
+        self.seen.append(cmd.value)
+
+
+class StrayEvent(DomainEvent):
+    info: str
+
+
+def _command_only_consumer() -> tuple[CQRSConsumer, OnlyCommandHandler, PydanticSerializer]:
+    registry = HandlerRegistry()
+    handler = OnlyCommandHandler()
+    registry.register_command_handler(OnlyCommand, handler)
+    serializer = PydanticSerializer()
+    consumer = CQRSConsumer(InMemoryCommandBus(registry=registry, serializer=serializer))
+    return consumer, handler, serializer
+
+
+@pytest.mark.anyio
+async def test_command_only_worker_needs_no_event_bus():
+    consumer, handler, serializer = _command_only_consumer()
+
+    await consumer.process_command(serializer.serialize(OnlyCommand(value="x")))
+
+    assert handler.seen == ["x"]
+
+
+@pytest.mark.anyio
+async def test_event_without_event_bus_raises_a_clear_error():
+    consumer, _handler, serializer = _command_only_consumer()
+
+    with pytest.raises(RuntimeError, match="sin 'event_bus'"):
+        await consumer.process_event(serializer.serialize(StrayEvent(info="i")))
+
+
+def test_serializer_defaults_to_pydantic():
+    registry = HandlerRegistry()
+    consumer = CQRSConsumer(InMemoryCommandBus(registry=registry))
+
+    assert isinstance(consumer._serializer, PydanticSerializer)

--- a/tests/test_cqrs_factory.py
+++ b/tests/test_cqrs_factory.py
@@ -1,0 +1,141 @@
+"""
+P0-5: la vía oficial de construcción (`CQRSFactory`) debe producir buses capaces de
+Smart Routing. Antes construía `InMemoryCommandBus(registry=..., pipeline=...)` y
+nada más, así que el primer `@background_command` reventaba con `RuntimeError`.
+"""
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from hexcore.application.cqrs.config import BusConfig, CQRSConfig
+from hexcore.application.cqrs.factory import CQRSFactory
+from hexcore.application.cqrs.registry import HandlerRegistry
+from hexcore.domain.cqrs.commands import Command
+from hexcore.domain.cqrs.decorators import background_command, background_handler
+from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
+from hexcore.domain.events import DomainEvent
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class SpyEnqueuer(ITaskEnqueuer):
+    def __init__(self) -> None:
+        self.commands: list[tuple[str, dict[str, t.Any], str]] = []
+        self.handlers: list[tuple[str, dict[str, t.Any], str]] = []
+
+    async def enqueue_command(self, command_name: str, payload: dict[str, t.Any], queue: str) -> None:
+        self.commands.append((command_name, payload, queue))
+
+    async def enqueue_event(self, event_name: str, payload: dict[str, t.Any], queue: str) -> None:
+        raise NotImplementedError
+
+    async def enqueue_handler(self, handler_name: str, payload: dict[str, t.Any], queue: str) -> None:
+        self.handlers.append((handler_name, payload, queue))
+
+    async def enqueue_task(self, task_name: str, payload: dict[str, t.Any], queue: str) -> None:
+        raise NotImplementedError
+
+
+@background_command(queue="factory_queue")
+class FactoryBackgroundCommand(Command):
+    value: str
+
+
+class PlainCommand(Command):
+    value: str
+
+
+class PlainCommandHandler:
+    async def handle(self, cmd: PlainCommand) -> str:
+        return f"ok:{cmd.value}"
+
+
+class FactoryEvent(DomainEvent):
+    info: str
+
+
+@background_handler(queue="factory_events")
+async def on_factory_event(event: FactoryEvent) -> None:  # pragma: no cover
+    ...
+
+
+@pytest.mark.anyio
+async def test_factory_command_bus_can_route_background_commands():
+    registry = HandlerRegistry()
+    registry.register_command_handler(FactoryBackgroundCommand, PlainCommandHandler())
+    enqueuer = SpyEnqueuer()
+
+    factory = CQRSFactory(CQRSConfig(), registry, enqueuer=enqueuer)
+    bus = factory.create_command_bus()
+
+    await bus.dispatch(FactoryBackgroundCommand(value="x"))
+
+    assert [name for name, _p, _q in enqueuer.commands] == ["FactoryBackgroundCommand"]
+    assert enqueuer.commands[0][2] == "factory_queue"
+
+
+@pytest.mark.anyio
+async def test_factory_event_bus_can_route_background_handlers():
+    registry = HandlerRegistry()
+    enqueuer = SpyEnqueuer()
+
+    factory = CQRSFactory(CQRSConfig(), registry, enqueuer=enqueuer)
+    event_bus = factory.create_event_bus()
+    event_bus.subscribe(FactoryEvent, on_factory_event)
+
+    await event_bus.publish(FactoryEvent(info="i"))
+
+    assert len(enqueuer.handlers) == 1
+    assert enqueuer.handlers[0][2] == "factory_events"
+
+
+def test_factory_fails_at_construction_when_background_commands_have_no_enqueuer():
+    registry = HandlerRegistry()
+    registry.register_command_handler(FactoryBackgroundCommand, PlainCommandHandler())
+
+    factory = CQRSFactory(CQRSConfig(), registry)
+
+    with pytest.raises(RuntimeError, match="FactoryBackgroundCommand"):
+        factory.create_command_bus()
+
+
+def test_factory_without_enqueuer_still_works_without_background_commands():
+    registry = HandlerRegistry()
+    registry.register_command_handler(PlainCommand, PlainCommandHandler())
+
+    factory = CQRSFactory(CQRSConfig(), registry)
+
+    assert factory.create_command_bus() is not None
+
+
+@pytest.mark.anyio
+async def test_factory_command_bus_executes_plain_commands():
+    registry = HandlerRegistry()
+    registry.register_command_handler(PlainCommand, PlainCommandHandler())
+
+    bus = CQRSFactory(CQRSConfig(), registry).create_command_bus()
+
+    assert await bus.dispatch(PlainCommand(value="v")) == "ok:v"
+
+
+def test_factory_caches_the_serializer():
+    factory = CQRSFactory(CQRSConfig(), HandlerRegistry())
+
+    assert factory.create_serializer() is factory.create_serializer()
+
+
+def test_factory_reports_middlewares_that_need_configuration():
+    config = CQRSConfig(
+        command_bus=BusConfig(
+            middlewares=["hexcore.infrastructure.cqrs.middlewares.TransactionMiddleware"]
+        )
+    )
+    factory = CQRSFactory(config, HandlerRegistry())
+
+    with pytest.raises(ValueError, match="instancialo a mano"):
+        factory.create_command_bus()

--- a/tests/test_handler_registry.py
+++ b/tests/test_handler_registry.py
@@ -1,0 +1,199 @@
+"""
+P1-5: el `HandlerRegistry` decía ser thread-safe y no lo era.
+
+`resolve_*` hace lazy-init con escritura en el dict, sin ningún lock. Con dos hilos
+(y con el free-threading de Python 3.14 son hilos reales) el handler se instanciaba
+dos veces y cada hilo se quedaba con la suya.
+
+También cubre la ambigüedad de `callable(entry) and not isinstance(entry, ICommandHandler)`
+cuando un handler implementa `__call__`.
+"""
+from __future__ import annotations
+
+import threading
+import typing as t
+
+import pytest
+
+from hexcore.application.cqrs.registry import HandlerRegistry
+from hexcore.domain.cqrs.commands import Command
+from hexcore.domain.cqrs.exceptions import DuplicateHandlerError, HandlerNotFoundError
+from hexcore.domain.cqrs.queries import Query
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class SomeCommand(Command):
+    value: str
+
+
+class SomeQuery(Query[str]):
+    value: str
+
+
+class SomeHandler:
+    instances = 0
+
+    def __init__(self) -> None:
+        type(self).instances += 1
+
+    async def handle(self, message: t.Any) -> str:
+        return "ok"
+
+
+class CallableHandler:
+    """Handler que además implementa `__call__`: el caso ambiguo del plan."""
+
+    async def handle(self, message: t.Any) -> str:
+        return "handled"
+
+    def __call__(self) -> "CallableHandler":  # pragma: no cover - no debe invocarse
+        raise AssertionError("se trató un handler callable como si fuera un factory")
+
+
+# ── Thread-safety ──────────────────────────────────────────────────────────────
+
+
+def test_concurrent_resolution_instantiates_the_handler_once():
+    SomeHandler.instances = 0
+    registry = HandlerRegistry()
+    ready = threading.Barrier(8)
+    resolved: list[object] = []
+    lock = threading.Lock()
+
+    def build() -> SomeHandler:
+        return SomeHandler()
+
+    registry.register_command_handler(SomeCommand, HandlerRegistry.factory(build))
+
+    def worker() -> None:
+        ready.wait()
+        handler = registry.resolve_command_handler(SomeCommand)
+        with lock:
+            resolved.append(handler)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert SomeHandler.instances == 1, "el handler se instanció más de una vez"
+    assert len({id(handler) for handler in resolved}) == 1, "los hilos vieron instancias distintas"
+
+
+def test_concurrent_registration_of_distinct_types_does_not_lose_entries():
+    registry = HandlerRegistry()
+    command_types = [
+        type(f"Cmd{i}", (Command,), {"__annotations__": {"value": str}})
+        for i in range(50)
+    ]
+    ready = threading.Barrier(5)
+
+    def worker(chunk: list[type[Command]]) -> None:
+        ready.wait()
+        for command_type in chunk:
+            registry.register_command_handler(command_type, SomeHandler())
+
+    chunks = [command_types[i::5] for i in range(5)]
+    threads = [threading.Thread(target=worker, args=(chunk,)) for chunk in chunks]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(registry.registered_commands) == 50
+
+
+def test_factory_can_resolve_another_handler_reentrantly():
+    """El lock es reentrante: un factory puede pedirle otro handler al registry."""
+    registry = HandlerRegistry()
+    registry.register_command_handler(SomeCommand, SomeHandler())
+
+    def build() -> SomeHandler:
+        registry.resolve_command_handler(SomeCommand)
+        return SomeHandler()
+
+    other = type("OtherCommand", (Command,), {"__annotations__": {"value": str}})
+    registry.register_command_handler(other, HandlerRegistry.factory(build))
+
+    assert registry.resolve_command_handler(other) is not None
+
+
+# ── Marcador explícito de factory ──────────────────────────────────────────────
+
+
+def test_callable_handler_is_not_mistaken_for_a_factory():
+    registry = HandlerRegistry()
+    handler = CallableHandler()
+    registry.register_command_handler(SomeCommand, handler)
+
+    assert registry.resolve_command_handler(SomeCommand) is handler
+
+
+def test_explicit_factory_marker_is_invoked_and_cached():
+    SomeHandler.instances = 0
+    registry = HandlerRegistry()
+    registry.register_command_handler(
+        SomeCommand, HandlerRegistry.factory(lambda: SomeHandler())
+    )
+
+    first = registry.resolve_command_handler(SomeCommand)
+    second = registry.resolve_command_handler(SomeCommand)
+
+    assert first is second
+    assert SomeHandler.instances == 1
+
+
+def test_bare_lambda_factory_still_works():
+    """Retrocompatibilidad: el callable pelado sigue detectándose por heurística."""
+    SomeHandler.instances = 0
+    registry = HandlerRegistry()
+    registry.register_command_handler(SomeCommand, lambda: SomeHandler())
+
+    assert registry.resolve_command_handler(SomeCommand) is not None
+    assert SomeHandler.instances == 1
+
+
+def test_query_factory_marker_works_too():
+    SomeHandler.instances = 0
+    registry = HandlerRegistry()
+    registry.register_query_handler(
+        SomeQuery, HandlerRegistry.factory(lambda: SomeHandler())
+    )
+
+    first = registry.resolve_query_handler(SomeQuery)
+
+    assert first is registry.resolve_query_handler(SomeQuery)
+    assert SomeHandler.instances == 1
+
+
+# ── Comportamiento existente que no debe cambiar ───────────────────────────────
+
+
+def test_duplicate_registration_still_raises():
+    registry = HandlerRegistry()
+    registry.register_command_handler(SomeCommand, SomeHandler())
+
+    with pytest.raises(DuplicateHandlerError):
+        registry.register_command_handler(SomeCommand, SomeHandler())
+
+
+def test_allow_override_still_works():
+    registry = HandlerRegistry(allow_override=True)
+    first = SomeHandler()
+    second = SomeHandler()
+    registry.register_command_handler(SomeCommand, first)
+    registry.register_command_handler(SomeCommand, second)
+
+    assert registry.resolve_command_handler(SomeCommand) is second
+
+
+def test_missing_handler_still_raises():
+    registry = HandlerRegistry()
+
+    with pytest.raises(HandlerNotFoundError):
+        registry.resolve_command_handler(SomeCommand)

--- a/tests/test_lock_error_policy.py
+++ b/tests/test_lock_error_policy.py
@@ -1,0 +1,132 @@
+"""
+P1-2: los lock providers ya no apagan el cron entero en silencio.
+
+Ambos capturaban `Exception` y devolvían `False`. Si Redis (o Postgres) se caía,
+`acquire_lock` devolvía `False` para **todos** los jobs → el cron completo dejaba de
+funcionar, con un `logger.error` por job y por tick indistinguible de "el lock estaba
+tomado por otra réplica", que es el caso normal y esperado.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+from unittest.mock import AsyncMock
+
+from hexcore.infrastructure.cqrs.postgres_lock import PostgresLockProvider
+from hexcore.infrastructure.cqrs.redis_lock import RedisLockProvider
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── Redis ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_redis_skip_is_the_default_and_returns_false():
+    client = AsyncMock()
+    client.set.side_effect = ConnectionError("redis down")
+    provider = RedisLockProvider(client)
+
+    assert provider.on_error == "skip"
+    assert await provider.acquire_lock("k", 60) is False
+
+
+@pytest.mark.anyio
+async def test_redis_raise_propagates_the_error():
+    client = AsyncMock()
+    client.set.side_effect = ConnectionError("redis down")
+    provider = RedisLockProvider(client, on_error="raise")
+
+    with pytest.raises(ConnectionError):
+        await provider.acquire_lock("k", 60)
+
+
+@pytest.mark.anyio
+async def test_redis_undecidable_logs_critical(caplog):
+    client = AsyncMock()
+    client.set.side_effect = ConnectionError("redis down")
+    provider = RedisLockProvider(client)
+
+    with caplog.at_level(logging.DEBUG):
+        await provider.acquire_lock("k", 60)
+
+    criticals = [r for r in caplog.records if r.levelno == logging.CRITICAL]
+    assert len(criticals) == 1
+    assert "No se pudo decidir" in criticals[0].getMessage()
+
+
+@pytest.mark.anyio
+async def test_redis_lock_already_taken_is_only_debug(caplog):
+    """El caso normal no debe generar ruido de nivel error/critical."""
+    client = AsyncMock()
+    client.set.return_value = None  # otro proceso lo tiene
+    provider = RedisLockProvider(client)
+
+    with caplog.at_level(logging.DEBUG):
+        assert await provider.acquire_lock("k", 60) is False
+
+    assert [r for r in caplog.records if r.levelno >= logging.ERROR] == []
+    assert any("ya estaba tomado" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.anyio
+async def test_redis_acquire_success():
+    client = AsyncMock()
+    client.set.return_value = True
+    provider = RedisLockProvider(client)
+
+    assert await provider.acquire_lock("k", 60) is True
+
+
+# ── Postgres ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_postgres_skip_is_the_default_and_returns_false():
+    pool = AsyncMock()
+    pool.fetchrow.side_effect = ConnectionError("pg down")
+    provider = PostgresLockProvider(pool)
+
+    assert provider.on_error == "skip"
+    assert await provider.acquire_lock("k", 60) is False
+
+
+@pytest.mark.anyio
+async def test_postgres_raise_propagates_the_error():
+    pool = AsyncMock()
+    pool.fetchrow.side_effect = ConnectionError("pg down")
+    provider = PostgresLockProvider(pool, on_error="raise")
+
+    with pytest.raises(ConnectionError):
+        await provider.acquire_lock("k", 60)
+
+
+@pytest.mark.anyio
+async def test_postgres_undecidable_logs_critical(caplog):
+    pool = AsyncMock()
+    pool.fetchrow.side_effect = ConnectionError("pg down")
+    provider = PostgresLockProvider(pool)
+
+    with caplog.at_level(logging.DEBUG):
+        await provider.acquire_lock("k", 60)
+
+    criticals = [r for r in caplog.records if r.levelno == logging.CRITICAL]
+    assert len(criticals) == 1
+    assert "No se pudo decidir" in criticals[0].getMessage()
+
+
+@pytest.mark.anyio
+async def test_postgres_lock_already_taken_is_only_debug(caplog):
+    pool = AsyncMock()
+    pool.fetchrow.return_value = None
+    provider = PostgresLockProvider(pool, purge_every=0)
+
+    with caplog.at_level(logging.DEBUG):
+        assert await provider.acquire_lock("k", 60) is False
+
+    assert [r for r in caplog.records if r.levelno >= logging.ERROR] == []
+    assert any("ya estaba tomado" in r.getMessage() for r in caplog.records)

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -38,6 +38,8 @@ def anyio_backend():
 
 
 @pytest.mark.anyio
+# tick=1s sin lock_provider avisa a propósito (P1-1); aquí es intencional.
+@pytest.mark.filterwarnings("ignore:DynamicScheduler con tick_interval_seconds:RuntimeWarning")
 async def test_dynamic_scheduler_enqueues_matched_jobs():
     enqueuer = AsyncMock()
     

--- a/tests/test_scheduler_catchup.py
+++ b/tests/test_scheduler_catchup.py
@@ -1,0 +1,361 @@
+"""
+P1-1: el `DynamicScheduler` decide por catch-up real, no por "¿coincide con el
+minuto actual?".
+
+Antes, `base_time` y `last_check_time` se calculaban y no se usaban: la decisión era
+`croniter.match(expr, current_time)`. Con `tick=60s` el drift acumulado terminaba
+saltándose un minuto entero (y el job no corría); con `tick<60s` el mismo minuto se
+muestreaba varias veces y el job se duplicaba si no había lock.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from hexcore.application.cqrs.scheduler import DynamicScheduler
+from hexcore.domain.cqrs.cron import CronJobDefinition, ICronJobRepository, ILockProvider
+from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class FakeRepo(ICronJobRepository):
+    def __init__(self, jobs: list[CronJobDefinition]) -> None:
+        self.jobs = jobs
+        self.last_runs: list[tuple[str, datetime]] = []
+
+    async def get_active_jobs(self) -> list[CronJobDefinition]:
+        return self.jobs
+
+    async def update_last_run(self, job_id: str, run_time: datetime) -> None:
+        self.last_runs.append((job_id, run_time))
+        for job in self.jobs:
+            if job.job_id == job_id:
+                job.last_run_at = run_time
+
+
+class FakeEnqueuer(ITaskEnqueuer):
+    def __init__(self) -> None:
+        self.tasks: list[tuple[str, dict, str]] = []
+
+    async def enqueue_command(self, command_name: str, payload: dict, queue: str) -> None:
+        raise NotImplementedError
+
+    async def enqueue_event(self, event_name: str, payload: dict, queue: str) -> None:
+        raise NotImplementedError
+
+    async def enqueue_handler(self, handler_name: str, payload: dict, queue: str) -> None:
+        raise NotImplementedError
+
+    async def enqueue_task(self, task_name: str, payload: dict, queue: str) -> None:
+        self.tasks.append((task_name, payload, queue))
+
+
+class SharedLockProvider(ILockProvider):
+    """Lock in-memory compartido: simula dos réplicas contra el mismo Redis."""
+
+    def __init__(self) -> None:
+        self.held: set[str] = set()
+        self.attempts: list[str] = []
+
+    async def acquire_lock(self, lock_key: str, ttl_seconds: int) -> bool:
+        self.attempts.append(lock_key)
+        if lock_key in self.held:
+            return False
+        self.held.add(lock_key)
+        return True
+
+    async def release_lock(self, lock_key: str) -> None:
+        self.held.discard(lock_key)
+
+
+def _job(cron: str = "* * * * *", **kwargs) -> CronJobDefinition:
+    defaults = dict(job_id="j1", task_name="my_task", cron_expression=cron)
+    defaults.update(kwargs)
+    return CronJobDefinition(**defaults)  # type: ignore[arg-type]
+
+
+def _make(repo: FakeRepo, **kwargs) -> tuple[DynamicScheduler, FakeEnqueuer]:
+    enqueuer = FakeEnqueuer()
+    kwargs.setdefault("tick_interval_seconds", 60)
+    scheduler = DynamicScheduler(repository=repo, enqueuer=enqueuer, **kwargs)
+    return scheduler, enqueuer
+
+
+# ── Catch-up: el minuto saltado no se pierde ───────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_job_runs_even_if_its_minute_was_skipped():
+    """
+    El caso que motivó el ítem: un cierre contable diario cuyo minuto exacto se
+    saltó por drift del tick. La ocurrencia sigue pendiente y debe encolarse.
+    """
+    now = datetime(2026, 7, 29, 3, 5, 0, tzinfo=timezone.utc)
+    # El job era a las 03:00. El tick anterior fue a las 02:59:50, el actual a las
+    # 03:05: 03:00 quedó entre ambos y `croniter.match(expr, 03:05)` no lo vería.
+    repo = FakeRepo([_job("0 3 * * *")])
+    scheduler, enqueuer = _make(repo)
+
+    await scheduler._process_job(
+        repo.jobs[0],
+        last_check_time=now - timedelta(minutes=5, seconds=10),
+        current_time=now,
+    )
+
+    assert len(enqueuer.tasks) == 1
+    assert repo.last_runs == [("j1", datetime(2026, 7, 29, 3, 0, tzinfo=timezone.utc))]
+
+
+@pytest.mark.anyio
+async def test_job_is_not_enqueued_when_no_occurrence_is_due():
+    now = datetime(2026, 7, 29, 3, 5, 0, tzinfo=timezone.utc)
+    repo = FakeRepo([_job("0 3 * * *")])
+    scheduler, enqueuer = _make(repo)
+
+    # El job ya corrió a las 03:00; entre 03:00 y 03:05 no hay otra ocurrencia.
+    repo.jobs[0].last_run_at = datetime(2026, 7, 29, 3, 0, tzinfo=timezone.utc)
+
+    await scheduler._process_job(
+        repo.jobs[0],
+        last_check_time=now - timedelta(minutes=1),
+        current_time=now,
+    )
+
+    assert enqueuer.tasks == []
+
+
+@pytest.mark.anyio
+async def test_catch_up_window_bounds_ancient_occurrences():
+    """Un scheduler caído mucho tiempo no debe disparar ocurrencias antiguas."""
+    now = datetime(2026, 7, 29, 12, 0, 0, tzinfo=timezone.utc)
+    repo = FakeRepo([_job("0 3 * * *")])
+    # Última ejecución hace un mes; la ventana de catch-up es de 1h por defecto.
+    repo.jobs[0].last_run_at = now - timedelta(days=30)
+    scheduler, enqueuer = _make(repo, catch_up_window_seconds=3600)
+
+    await scheduler._process_job(
+        repo.jobs[0], last_check_time=now - timedelta(days=30), current_time=now
+    )
+
+    assert enqueuer.tasks == []
+
+
+@pytest.mark.anyio
+async def test_multiple_missed_occurrences_enqueue_only_once():
+    """Recuperar N veces seguidas es peor que recuperar una."""
+    now = datetime(2026, 7, 29, 3, 30, 0, tzinfo=timezone.utc)
+    repo = FakeRepo([_job("* * * * *")])  # 30 ocurrencias perdidas
+    scheduler, enqueuer = _make(repo)
+
+    await scheduler._process_job(
+        repo.jobs[0], last_check_time=now - timedelta(minutes=30), current_time=now
+    )
+
+    assert len(enqueuer.tasks) == 1
+    # Se marca la ocurrencia más reciente, no la más antigua.
+    assert repo.last_runs[0][1] == now
+
+
+# ── Deduplicación con tick < 60s ───────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_sub_minute_ticks_do_not_duplicate_the_same_occurrence():
+    repo = FakeRepo([_job("* * * * *")])
+    scheduler, enqueuer = _make(
+        repo, tick_interval_seconds=15, lock_provider=SharedLockProvider()
+    )
+
+    anchor = datetime(2026, 7, 29, 3, 0, 0, tzinfo=timezone.utc) - timedelta(microseconds=1)
+    # Cuatro muestreos del mismo minuto, como haría un tick de 15s.
+    for offset in (1, 16, 31, 46):
+        await scheduler._process_job(
+            repo.jobs[0],
+            last_check_time=anchor,
+            current_time=datetime(2026, 7, 29, 3, 0, offset, tzinfo=timezone.utc),
+        )
+
+    assert len(enqueuer.tasks) == 1, "el mismo minuto se encoló más de una vez"
+
+
+@pytest.mark.anyio
+async def test_local_memory_dedupes_even_if_repository_does_not_persist():
+    """Si el repo ignora `update_last_run`, la memoria local sigue deduplicando."""
+
+    class ForgetfulRepo(FakeRepo):
+        async def update_last_run(self, job_id: str, run_time: datetime) -> None:
+            return None  # no persiste nada
+
+    repo = ForgetfulRepo([_job("* * * * *")])
+    scheduler, enqueuer = _make(repo, tick_interval_seconds=60)
+
+    anchor = datetime(2026, 7, 29, 3, 0, 0, tzinfo=timezone.utc) - timedelta(microseconds=1)
+    for offset in (1, 20, 40):
+        await scheduler._process_job(
+            repo.jobs[0],
+            last_check_time=anchor,
+            current_time=datetime(2026, 7, 29, 3, 0, offset, tzinfo=timezone.utc),
+        )
+
+    assert len(enqueuer.tasks) == 1
+
+
+# ── Locks: dos réplicas, un solo encolado ──────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_two_concurrent_schedulers_with_a_shared_lock_enqueue_once():
+    lock = SharedLockProvider()
+    now = datetime(2026, 7, 29, 3, 0, 30, tzinfo=timezone.utc)
+    anchor = datetime(2026, 7, 29, 3, 0, 0, tzinfo=timezone.utc) - timedelta(microseconds=1)
+
+    repo_a = FakeRepo([_job("* * * * *")])
+    repo_b = FakeRepo([_job("* * * * *")])
+    scheduler_a, enqueuer_a = _make(repo_a, lock_provider=lock)
+    scheduler_b, enqueuer_b = _make(repo_b, lock_provider=lock)
+
+    await asyncio.gather(
+        scheduler_a._process_job(repo_a.jobs[0], anchor, now),
+        scheduler_b._process_job(repo_b.jobs[0], anchor, now),
+    )
+
+    assert len(enqueuer_a.tasks) + len(enqueuer_b.tasks) == 1
+
+
+@pytest.mark.anyio
+async def test_lock_key_is_built_from_the_occurrence_not_the_current_minute():
+    """
+    Dos réplicas con ticks desfasados (una a las 03:00:59, otra a las 03:01:01)
+    deben competir por la misma clave, o el job se duplica.
+    """
+    lock = SharedLockProvider()
+    anchor = datetime(2026, 7, 29, 3, 0, 0, tzinfo=timezone.utc) - timedelta(microseconds=1)
+
+    repo = FakeRepo([_job("0 3 * * *")])
+    scheduler, enqueuer = _make(repo, lock_provider=lock)
+
+    await scheduler._process_job(
+        repo.jobs[0], anchor, datetime(2026, 7, 29, 3, 0, 59, tzinfo=timezone.utc)
+    )
+
+    assert lock.attempts == ["hexcore:cron_lock:j1:2026-07-29T03:00:00+00:00"]
+    assert len(enqueuer.tasks) == 1
+
+
+# ── Avisos y robustez ──────────────────────────────────────────────────────────
+
+
+def test_warns_when_sub_minute_tick_has_no_lock_provider():
+    repo = FakeRepo([])
+    with pytest.warns(RuntimeWarning, match="lock_provider"):
+        DynamicScheduler(
+            repository=repo, enqueuer=FakeEnqueuer(), tick_interval_seconds=30
+        )
+
+
+def test_does_not_warn_with_lock_provider():
+    repo = FakeRepo([])
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        DynamicScheduler(
+            repository=repo,
+            enqueuer=FakeEnqueuer(),
+            tick_interval_seconds=30,
+            lock_provider=SharedLockProvider(),
+        )
+
+
+def test_does_not_warn_with_minute_tick():
+    repo = FakeRepo([])
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        DynamicScheduler(
+            repository=repo, enqueuer=FakeEnqueuer(), tick_interval_seconds=60
+        )
+
+
+@pytest.mark.anyio
+async def test_invalid_cron_expression_is_logged_and_skipped(caplog):
+    repo = FakeRepo([_job("no soy un cron")])
+    scheduler, enqueuer = _make(repo)
+    now = datetime(2026, 7, 29, 3, 0, 0, tzinfo=timezone.utc)
+
+    await scheduler._process_job(repo.jobs[0], now - timedelta(minutes=5), now)
+
+    assert enqueuer.tasks == []
+    assert any("inválida" in record.getMessage() for record in caplog.records)
+
+
+@pytest.mark.anyio
+async def test_naive_last_run_at_is_treated_as_utc():
+    """Un `last_run_at` naive de la BD no debe romper las comparaciones."""
+    now = datetime(2026, 7, 29, 3, 5, 0, tzinfo=timezone.utc)
+    repo = FakeRepo([_job("0 3 * * *")])
+    repo.jobs[0].last_run_at = datetime(2026, 7, 29, 3, 0, 0)  # sin tzinfo
+    scheduler, enqueuer = _make(repo)
+
+    await scheduler._process_job(repo.jobs[0], now - timedelta(minutes=10), now)
+
+    assert enqueuer.tasks == []
+
+
+@pytest.mark.anyio
+async def test_one_failing_job_does_not_stop_the_others():
+    class BoomEnqueuer(FakeEnqueuer):
+        async def enqueue_task(self, task_name: str, payload: dict, queue: str) -> None:
+            if task_name == "boom":
+                raise RuntimeError("broker down")
+            await super().enqueue_task(task_name, payload, queue)
+
+    repo = FakeRepo(
+        [
+            _job("* * * * *", job_id="bad", task_name="boom"),
+            _job("* * * * *", job_id="good", task_name="fine"),
+        ]
+    )
+    scheduler = DynamicScheduler(
+        repository=repo, enqueuer=BoomEnqueuer(), tick_interval_seconds=60
+    )
+    enqueuer = scheduler.enqueuer
+
+    anchor = datetime(2026, 7, 29, 3, 0, 0, tzinfo=timezone.utc) - timedelta(microseconds=1)
+    await scheduler._tick(anchor)
+
+    assert [name for name, _p, _q in enqueuer.tasks] == ["fine"]  # type: ignore[attr-defined]
+
+
+@pytest.mark.anyio
+async def test_first_tick_runs_without_waiting_for_the_interval():
+    """El sleep era la primera sentencia del bucle: se perdía el primer tick."""
+    repo = FakeRepo([_job("* * * * *")])
+    scheduler, enqueuer = _make(repo, tick_interval_seconds=3600)
+
+    task = asyncio.create_task(scheduler.start())
+    await asyncio.sleep(0.05)
+    scheduler.stop()
+    await asyncio.wait_for(task, timeout=1)
+
+    assert len(enqueuer.tasks) == 1
+
+
+@pytest.mark.anyio
+async def test_stop_interrupts_the_wait_without_waiting_the_full_interval():
+    repo = FakeRepo([])
+    scheduler, _enqueuer = _make(repo, tick_interval_seconds=3600)
+
+    task = asyncio.create_task(scheduler.start())
+    await asyncio.sleep(0.05)
+    scheduler.stop()
+
+    # Si el sleep no fuera interrumpible, esto haría timeout.
+    await asyncio.wait_for(task, timeout=1)

--- a/tests/test_sql_session_layer.py
+++ b/tests/test_sql_session_layer.py
@@ -1,0 +1,338 @@
+"""
+F2 y F3: la capa de sesión SQL tiene que ser usable en producción, y los scopes
+tienen que existir fuera de FastAPI.
+
+Defectos que cubren estos tests:
+1. `expire_on_commit` no se pasaba → quedaba en True (default de SQLAlchemy), así que
+   tras `commit()` los atributos expiraban y el siguiente acceso disparaba un lazy-load
+   sobre una sesión cerrada (`MissingGreenlet` / `DetachedInstanceError`).
+2. Sin tuning del pool (`pre_ping`, `recycle`, `size`, `max_overflow`).
+3. Sin normalización del DSN: `postgresql://…` reventaba en `create_async_engine`.
+4. No se podía pasar la URL explícitamente.
+5. Sin cierre ordenado con un nombre que lo dijera.
+6. Globals sin lock.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+sqlalchemy = pytest.importorskip("sqlalchemy")
+pytest.importorskip("aiosqlite")
+
+from sqlalchemy import String, select  # noqa: E402
+from sqlalchemy.orm import Mapped, mapped_column  # noqa: E402
+
+from hexcore.infrastructure.repositories.orms.sqlalchemy import Base  # noqa: E402
+from hexcore.infrastructure.repositories.orms.sqlalchemy import session as session_module  # noqa: E402
+from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (  # noqa: E402
+    PoolSettings,
+    dispose_engine,
+    get_engine,
+    get_session_factory,
+    init_engine,
+    normalize_async_dsn,
+    reset_sqlalchemy_engine,
+)
+from hexcore.infrastructure.uow.scopes import session_scope  # noqa: E402
+
+SQLITE_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _clean_engine():
+    # Fixture síncrono a propósito: los tests de concurrencia no son async y una
+    # fixture async no se resolvería para ellos.
+    asyncio.run(dispose_engine())
+    yield
+    asyncio.run(dispose_engine())
+
+
+class Widget(Base):
+    __tablename__ = "f2_widgets"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(50))
+
+
+# ── Normalización del DSN (defecto 3) ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("postgresql://u:p@h/db", "postgresql+asyncpg://u:p@h/db"),
+        ("postgres://u:p@h/db", "postgresql+asyncpg://u:p@h/db"),
+        ("sqlite:///./db.sqlite3", "sqlite+aiosqlite:///./db.sqlite3"),
+        ("mysql://u:p@h/db", "mysql+aiomysql://u:p@h/db"),
+    ],
+)
+def test_normalize_async_dsn_adds_the_async_driver(raw, expected):
+    assert normalize_async_dsn(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "already_async",
+    [
+        "postgresql+asyncpg://u:p@h/db",
+        "sqlite+aiosqlite:///./db.sqlite3",
+        # Un driver explícito distinto se respeta: puede ser a propósito.
+        "postgresql+psycopg://u:p@h/db",
+    ],
+)
+def test_normalize_async_dsn_leaves_explicit_drivers_alone(already_async):
+    assert normalize_async_dsn(already_async) == already_async
+
+
+def test_normalize_async_dsn_leaves_unknown_schemes_alone():
+    assert normalize_async_dsn("oracle://u:p@h/db") == "oracle://u:p@h/db"
+    assert normalize_async_dsn("not-a-dsn") == "not-a-dsn"
+
+
+# ── URL explícita y pool (defectos 2 y 4) ──────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_init_engine_accepts_an_explicit_url():
+    engine = init_engine(SQLITE_URL)
+
+    assert engine.url.database == ":memory:"
+    assert engine.url.drivername == "sqlite+aiosqlite"
+
+
+@pytest.mark.anyio
+async def test_init_engine_normalizes_the_explicit_url():
+    engine = init_engine("sqlite:///:memory:")
+
+    assert engine.url.drivername == "sqlite+aiosqlite"
+
+
+@pytest.mark.anyio
+async def test_pool_pre_ping_is_on_by_default():
+    engine = init_engine(SQLITE_URL)
+
+    assert engine.pool._pre_ping is True  # type: ignore[attr-defined]
+
+
+@pytest.mark.anyio
+async def test_pool_settings_are_applied_for_non_sqlite():
+    engine = init_engine(
+        "postgresql+asyncpg://u:p@localhost/db",
+        pool=PoolSettings(size=7, max_overflow=3, recycle=60),
+    )
+
+    assert engine.pool.size() == 7  # type: ignore[attr-defined]
+    assert engine.pool._max_overflow == 3  # type: ignore[attr-defined]
+    assert engine.pool._recycle == 60  # type: ignore[attr-defined]
+
+
+@pytest.mark.anyio
+async def test_sqlite_ignores_pool_size_instead_of_crashing():
+    """SQLite no usa un pool con tamaño; pasarle pool_size es un TypeError."""
+    engine = init_engine(SQLITE_URL, pool=PoolSettings(size=10, max_overflow=5))
+
+    assert engine is not None
+
+
+@pytest.mark.anyio
+async def test_engine_kwargs_are_forwarded():
+    engine = init_engine(SQLITE_URL, echo=True)
+
+    assert engine.echo is True
+
+
+# ── expire_on_commit (defecto 1) ───────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_session_factory_sets_expire_on_commit_to_false():
+    init_engine(SQLITE_URL)
+    factory = get_session_factory()
+
+    assert factory.kw["expire_on_commit"] is False
+
+
+@pytest.mark.anyio
+async def test_attribute_access_after_commit_does_not_lazy_load():
+    """
+    El síntoma real: con expire_on_commit=True esto lanza MissingGreenlet, porque el
+    acceso al atributo dispara IO sobre una sesión ya comiteada.
+    """
+    engine = init_engine(SQLITE_URL)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+    factory = get_session_factory()
+    async with factory() as session:
+        widget = Widget(name="gizmo")
+        session.add(widget)
+        await session.commit()
+        # Sin expire_on_commit=False, este acceso revienta.
+        assert widget.name == "gizmo"
+
+
+@pytest.mark.anyio
+async def test_entity_survives_outside_the_session_block():
+    engine = init_engine(SQLITE_URL)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+    factory = get_session_factory()
+    async with factory() as session:
+        widget = Widget(name="detached")
+        session.add(widget)
+        await session.commit()
+
+    # Fuera del bloque la sesión está cerrada: sin el arreglo, DetachedInstanceError.
+    assert widget.name == "detached"
+
+
+# ── Ciclo de vida (defecto 5) ──────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_dispose_engine_leaves_the_module_reinitialisable():
+    first = init_engine(SQLITE_URL)
+    await dispose_engine()
+    second = init_engine(SQLITE_URL)
+
+    assert first is not second
+
+
+@pytest.mark.anyio
+async def test_dispose_engine_clears_the_session_factory_too():
+    init_engine(SQLITE_URL)
+    first_factory = get_session_factory()
+    await dispose_engine()
+    init_engine(SQLITE_URL)
+
+    assert get_session_factory() is not first_factory
+
+
+@pytest.mark.anyio
+async def test_dispose_engine_is_safe_without_an_engine():
+    await dispose_engine()
+    await dispose_engine()
+
+
+@pytest.mark.anyio
+async def test_reset_sqlalchemy_engine_is_still_available():
+    init_engine(SQLITE_URL)
+    await reset_sqlalchemy_engine()
+
+    assert session_module._engine is None
+
+
+@pytest.mark.anyio
+async def test_init_engine_is_idempotent():
+    first = init_engine(SQLITE_URL)
+    second = init_engine(SQLITE_URL)
+
+    assert first is second
+
+
+@pytest.mark.anyio
+async def test_get_engine_lazily_initialises():
+    assert session_module._engine is None
+    engine = get_engine()
+
+    assert engine is not None
+    assert session_module._engine is engine
+
+
+# ── Globals con lock (defecto 6) ───────────────────────────────────────────────
+
+
+def test_concurrent_init_engine_creates_a_single_engine():
+    asyncio.run(dispose_engine())
+    ready = threading.Barrier(8)
+    engines: list[object] = []
+    lock = threading.Lock()
+
+    def worker() -> None:
+        ready.wait()
+        engine = init_engine(SQLITE_URL)
+        with lock:
+            engines.append(engine)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len({id(engine) for engine in engines}) == 1
+    asyncio.run(dispose_engine())
+
+
+def test_concurrent_get_session_factory_creates_a_single_factory():
+    asyncio.run(dispose_engine())
+    init_engine(SQLITE_URL)
+    ready = threading.Barrier(8)
+    factories: list[object] = []
+    lock = threading.Lock()
+
+    def worker() -> None:
+        ready.wait()
+        factory = get_session_factory()
+        with lock:
+            factories.append(factory)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len({id(factory) for factory in factories}) == 1
+    asyncio.run(dispose_engine())
+
+
+# ── F3: session_scope fuera de FastAPI ─────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_session_scope_yields_a_usable_session():
+    engine = init_engine(SQLITE_URL)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+    async with session_scope() as session:
+        session.add(Widget(name="from-scope"))
+        await session.commit()
+
+    async with session_scope() as session:
+        names = (await session.execute(select(Widget.name))).scalars().all()
+
+    assert "from-scope" in names
+
+
+@pytest.mark.anyio
+async def test_session_scope_closes_the_session_on_exit():
+    init_engine(SQLITE_URL)
+
+    async with session_scope() as session:
+        pass
+
+    assert session.is_active is False or not session.in_transaction()
+
+
+@pytest.mark.anyio
+async def test_session_scope_does_not_instantiate_repositories():
+    """
+    El punto de F3: construir un UoW corre el auto-discovery e instancia todos los
+    repositorios de dominio. `session_scope` no debe hacer nada de eso — de hecho
+    funciona sin `repository_discovery_paths` configurado, que es lo que haría fallar
+    a un UoW.
+    """
+    init_engine(SQLITE_URL)
+
+    async with session_scope() as session:
+        assert not hasattr(session, "repositories")

--- a/tests/test_task_queues_adapters.py
+++ b/tests/test_task_queues_adapters.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, AsyncMock, ANY
 sys.modules["celery"] = MagicMock()
 sys.modules["procrastinate"] = MagicMock()
 
+from hexcore.infrastructure.task_queues import celery_adapter, procrastinate_adapter
 from hexcore.infrastructure.task_queues.celery_adapter import CeleryEnqueuer, register_hexcore_celery_tasks
 from hexcore.infrastructure.task_queues.procrastinate_adapter import ProcrastinateEnqueuer, register_hexcore_procrastinate_tasks
 
@@ -99,3 +100,63 @@ async def test_celery_enqueue_event_raises_instead_of_losing_the_event():
 
     with pytest.raises(NotImplementedError, match="background_handler"):
         await enqueuer.enqueue_event("SomeEvent", {"data": 1}, "default")
+
+
+# ── P1-6: registrar dos veces no debe reventar ─────────────────────────────────
+
+
+class FakeApp:
+    """App mínima referenciable débilmente que rechaza nombres duplicados."""
+
+    def __init__(self) -> None:
+        self.registered: list[str] = []
+
+    def task(self, *args, **kwargs):
+        name = kwargs.get("name")
+
+        def decorator(func):
+            if name in self.registered:
+                raise ValueError(f"Task name already registered: {name}")
+            self.registered.append(name)
+            return func
+
+        return decorator
+
+
+def test_register_procrastinate_tasks_is_idempotent():
+    app = FakeApp()
+    consumer = MagicMock()
+
+    assert register_hexcore_procrastinate_tasks(app, consumer) is True
+    assert procrastinate_adapter.is_registered(app) is True
+    # Sin idempotencia, esta segunda llamada revienta con "already registered".
+    assert register_hexcore_procrastinate_tasks(app, consumer) is False
+    assert app.registered == list(procrastinate_adapter.HEXCORE_TASK_NAMES)
+
+
+def test_register_celery_tasks_is_idempotent():
+    app = FakeApp()
+    consumer = MagicMock()
+
+    assert register_hexcore_celery_tasks(app, consumer) is True
+    assert celery_adapter.is_registered(app) is True
+    assert register_hexcore_celery_tasks(app, consumer) is False
+    assert app.registered == list(celery_adapter.HEXCORE_TASK_NAMES)
+
+
+def test_is_registered_is_per_app():
+    app_a, app_b = FakeApp(), FakeApp()
+    register_hexcore_procrastinate_tasks(app_a, MagicMock())
+
+    assert procrastinate_adapter.is_registered(app_a) is True
+    assert procrastinate_adapter.is_registered(app_b) is False
+
+
+def test_force_reregisters():
+    app = FakeApp()
+    register_hexcore_celery_tasks(app, MagicMock())
+
+    # `force` reintenta el registro; esta app lo rechaza, que es justo lo que
+    # documenta el parámetro.
+    with pytest.raises(ValueError, match="already registered"):
+        register_hexcore_celery_tasks(app, MagicMock(), force=True)


### PR DESCRIPTION
**Ítems del plan:** P0-5, P1-1, P1-2, P1-5, P1-6, P2-2, F2, F3 (Fase 2)

> ⚠️ **Apilado sobre #29.** Mergear #29 primero; después este PR queda con su diff limpio.

## Problema

- **P0-5.** `CQRSFactory.create_command_bus()` construía `InMemoryCommandBus(registry, pipeline)`
  y nada más: **la vía oficial de construcción producía un bus que lanzaba `RuntimeError` en
  el primer `@background_command`**, así que había que abandonar la factory y cablear los
  buses a mano.
- **P1-1.** En `DynamicScheduler`, `base_time` y `last_check_time` se calculaban y **no se
  usaban**: la decisión era `croniter.match(expr, minuto_actual)`. Con `tick=60s` el drift
  acumulado se saltaba un minuto entero y el job no corría (inaceptable para un cierre
  contable); con `tick<60s` el mismo minuto se muestreaba varias veces y el job se
  duplicaba. Y el `sleep` era la primera sentencia del bucle: se perdía el primer tick.
- **P1-2.** Los lock providers capturaban `Exception` y devolvían `False`, así que una caída
  de Redis **apagaba el cron entero** con un `logger.error` por job y por tick
  indistinguible del caso normal.
- **P1-5.** El docstring de `HandlerRegistry` decía "thread-safe" y no había ningún lock,
  con `resolve_*` haciendo lazy-init con escritura en el dict.
- **P1-6.** `register_hexcore_*_tasks` reventaba al llamarla dos veces.
- **P2-2.** `CQRSConsumer` exigía `event_bus`: un worker sólo-comandos escribía `cast(Any, None)`.
- **F2.** `get_engine()`/`get_session_factory()` eran inutilizables en producción — seis
  defectos, empezando por `expire_on_commit` sin pasar (queda en `True`, y tras `commit()`
  el siguiente acceso a un atributo lanza `MissingGreenlet`/`DetachedInstanceError`, mientras
  la doc ya enseñaba `expire_on_commit=False`).
- **F3.** Sólo había dependencias de FastAPI: workers, cron, scripts y seeds se quedaban sin
  nada.

## Solución

- **P0-5:** `CQRSFactory(config, registry, enqueuer=...)`. Enqueuer y serializer se propagan
  a los buses in-memory; el serializer se cachea para que buses y consumer compartan
  instancia. Si hay `@background_command` registrados y falta el enqueuer, **falla al
  construir** listando los comandos afectados, no en el primer dispatch — cuando la petición
  del usuario ya está en vuelo.
- **P1-1:** se implementa el catch-up que `base_time` insinuaba: `_latest_due_occurrence`
  busca ocurrencias en `(base_time, current_time]`, y `update_last_run` recibe **la
  ocurrencia**, no `current_time`, que es lo que hace que el siguiente tick sepa que ese
  minuto ya se sirvió. Se encola una vez aunque se hayan saltado varias: recuperar N veces
  es peor que recuperar una. La clave del lock se construye sobre la ocurrencia para que dos
  réplicas con ticks desfasados compitan por la misma. `catch_up_window_seconds` (1h) acota
  el catch-up; `RuntimeWarning` si el tick es sub-minuto sin lock.
- **P1-2:** `on_error: "skip" | "raise"`. Se mantiene `skip` como default, pero ahora es una
  decisión escrita con su trade-off. El log distingue "no pude decidir" (`critical`) de "el
  lock estaba tomado" (`debug`).
- **P1-5:** `threading.RLock` — reentrante porque un factory puede resolver otro handler del
  mismo registry. Y `HandlerRegistry.factory()` como marcador explícito, para quitar la
  ambigüedad con los handlers que implementan `__call__`.
- **P1-6:** idempotencia memorizada en un `WeakValueDictionary` por `id(app)` — por app y no
  global, y débil para no mantener viva la app. Se expone `is_registered()` y `force=True`.
- **F2:** `init_engine(url=None, *, pool=PoolSettings(), **engine_kwargs)` y
  `dispose_engine()`. Los nueve keywords del primer borrador colapsan en un settings object
  (S2). `expire_on_commit=False` y la normalización del DSN **no son parámetros**: son el
  comportamiento correcto (S1). `get_engine()` sigue haciendo lazy-init con defaults.
- **F3:** `session_scope`, `uow_scope`, `open_uow_scope`, `nosql_uow_scope`. `session_scope`
  no construye el UoW a propósito: construirlo corre el auto-discovery e instancia **todos**
  los repositorios de dominio, un coste absurdo para leer `cron_jobs`.

Sobre la incoherencia semántica que señala F3: `get_sql_uow` **entraba** al UoW, mientras la
doc enseña use cases que hacen su propio `async with self.uow:` — que con eso anida. Se elige
la convención de la documentación y el nombre lo dice: `get_sql_uow` no entra,
`get_sql_uow_open` sí.

## Riesgo / compatibilidad

⚠️ **BEHAVIOR CHANGE.**

- `expire_on_commit=False` (F2). Quien necesite `True` construye su propio
  `async_sessionmaker`; no merece un knob en la ruta principal.
- `get_sql_uow` ya no entra al UoW (F3). Impacto real pequeño —`__aenter__` sólo devuelve
  `self`— y hay `get_sql_uow_open` para revertirlo caso por caso.
- Cambia **cuándo** corre un cron job (P1-1). El ancla inicial es el comienzo del minuto en
  curso, así que arrancar a las 03:00:30 sigue disparando el job de las 03:00.
- Un proyecto con `@background_command` y sin enqueuer ahora falla al arrancar (P0-5): es el
  cambio buscado.
- `on_error` y `force` son keyword-only; el retorno de `register_hexcore_*_tasks` pasa de
  `None` a `bool` (aditivo).

De paso se arregla `rabbitmq_worker.setup_sqlalchemy`, que importaba un símbolo `engine` que
no existe en el módulo — su `await engine.dispose()` nunca podía ejecutarse.

## Tests

`248 passed` (+77).

- `tests/test_cqrs_factory.py` — 7: routing por la factory, fallo explícito sin enqueuer,
  factory sin enqueuer cuando no hay background, cacheo del serializer.
- `tests/test_scheduler_catchup.py` — 16: **minuto saltado**, ventana de catch-up, N
  ocurrencias → un encolado, dedup con tick sub-minuto, dedup con repo que no persiste, **dos
  schedulers con lock compartido → un solo encolado**, clave de lock por ocurrencia, los tres
  casos del aviso, cron inválido, `last_run_at` naive, primer tick inmediato, stop inmediato.
- `tests/test_lock_error_policy.py` — 10: default skip, raise que propaga, `critical`
  exactamente una vez, y que el lock ya tomado no genera ruido ≥ ERROR, para los dos providers.
- `tests/test_handler_registry.py` — 11: **8 hilos con barrera** instancian una sola vez y ven
  la misma instancia, registro concurrente de 50 tipos, factory reentrante, handler callable
  no confundido con factory.
- `tests/test_sql_session_layer.py` — 28: normalización del DSN, `PoolSettings`, SQLite sin
  reventar, **`expire_on_commit=False` verificado por sus síntomas** (acceso tras commit y
  fuera del bloque de sesión), ciclo de vida, y **dos tests de 8 hilos** que comprueban que
  sólo se crea un engine y una session factory.
- Verificado: con `expire_on_commit=True` los 3 tests de F2 fallan con `DetachedInstanceError`.

## Checklist

- [x] Los tests nuevos fallan si revierto el cambio de producción
- [x] Los cambios de default están en el CHANGELOG bajo `BEHAVIOR CHANGE`
- [x] El import sigue funcionando sin las dependencias opcionales
- [x] La API nueva pasa el filtro `S` (S1: `init_engine()` sin argumentos da un engine de
      producción correcto; S2: `PoolSettings` en vez de nueve keywords)
