### PR TITLE
release 2.5.1 — bugs que rompen en producción, en silencio (P0/P1 silenciosos)

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,9 +2,17 @@ name: Python tests
 
 on:
   push:
-    branches: ["master"]
+    branches:
+      - master
+      - "release/**"
+      - "feat/**"
   pull_request:
-    branches: ["master"]
+    # Filtra por rama **base**, así que sin `release/**` y `feat/**` los PRs de una
+    # cadena apilada no disparan ningún check y el PR aparece sin CI.
+    branches:
+      - master
+      - "release/**"
+      - "feat/**"
 
 permissions:
   contents: read
@@ -17,17 +25,32 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.12"
+          enable-cache: true
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pytest anyio
-          pip install -e .
+        # `--extra all` es lo que hace que el suite se ejecute de verdad. Con sólo
+        # `pip install -e .` faltan SQLAlchemy, FastAPI, Redis, aiosqlite y httpx, así que
+        # los tests que dependen de ellos hacen `importorskip` y se saltan: CI reportaba
+        # verde habiendo ejecutado menos de la mitad.
+        # `--group dev` trae pytest, anyio y httpx desde el lockfile, para que el entorno
+        # de CI y el de desarrollo no se puedan desincronizar.
+        run: uv sync --extra all --group dev
 
       - name: Run tests
+        # `-rs` lista los tests saltados. Con todos los extras instalados no debe haber
+        # ninguno, así que un SKIPPED aquí significa que un extra no llegó al entorno y que
+        # estaríamos reportando verde habiendo saltado tests. Se falla a propósito.
+        # `python -m pytest` y no `pytest`: este proyecto no declara `build-system`, así que
+        # `uv sync` no lo instala en el venv y el script `pytest` no vería el paquete
+        # `hexcore`. Con `-m`, el directorio de trabajo entra en `sys.path`.
         run: |
-          pytest -q
+          set -o pipefail
+          uv run python -m pytest -q -rs | tee pytest-output.txt
+          if grep -q '^SKIPPED' pytest-output.txt; then
+            echo "::error::Hay tests saltados: falta alguna dependencia opcional en el entorno de CI."
+            grep '^SKIPPED' pytest-output.txt
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@
   (100 por defecto), crea un índice sobre `expires_at`, y expone `purge_expired()`
   (P0-4)
 
+### Behavior change
+
+- **cqrs**: `TransactionMiddleware` deja de ser el middleware por defecto de
+  `CQRSConfig.command_bus`, y `TransactionMiddleware()` sin `uow_factory` ahora lanza
+  `ValueError` en vez de adivinar. El default armaba la sesión con el session factory
+  *interno* de HexCore en vez del engine de la aplicación, y comiteaba después del
+  handler — así que un handler que ya comitea (el patrón que enseña la doc para los
+  use cases) comiteaba dos veces (P0-6)
+- **task_queues**: `enqueue_event` de los adaptadores de Procrastinate y Celery lanza
+  `NotImplementedError` con instrucciones en vez de ser un `pass` que perdía el
+  evento sin traza (P1-3)
+
 ### Test
 
 - **cqrs**: los tests del consumer parcheaban `_resolve_callable` sin restaurarlo y

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### Fix
 
+- **cqrs**: el worker ya **ejecuta** los `@background_command` que saca de la cola en
+  vez de reencolarlos. Antes, pasarle al `CQRSConsumer` el mismo bus que usa el
+  proceso web —lo natural, y lo que sugería la documentación— producía un bucle
+  infinito silencioso: la cola crecía sin límite y el handler no corría jamás.
+  Nuevo contextvar `hexcore.domain.cqrs.context.IN_WORKER` (P0-1)
+- **cqrs**: mismo arreglo para los suscriptores marcados con `@background_handler`
+  cuando el evento llega por `CQRSConsumer.process_event` (P0-2)
 - **cqrs**: los FQN con `__qualname__` anidado (clases dentro de clases, tasks como
   `@staticmethod`) ya se resuelven bien. Antes `rsplit(".", 1)` producía un module
   path inválido y el mensaje se encolaba correctamente para **fallar en el worker**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Unreleased
 
+### Fix
+
+- **cqrs**: los FQN con `__qualname__` anidado (clases dentro de clases, tasks como
+  `@staticmethod`) ya se resuelven bien. Antes `rsplit(".", 1)` producía un module
+  path inválido y el mensaje se encolaba correctamente para **fallar en el worker**.
+  Nuevo helper `hexcore.domain.cqrs.resolution.resolve_dotted`, usado por
+  `PydanticSerializer.deserialize` y por `_resolve_callable` del consumer (P0-3)
+- **cqrs**: `@background_command` / `@background_handler` / `@background_task` ahora
+  rechazan en tiempo de decoración los objetos con `<locals>` en su `__qualname__`:
+  una función definida dentro de otra función nunca será importable desde el worker
+  (P0-3)
+
 ### Test
 
 - **cqrs**: los tests del consumer parcheaban `_resolve_callable` sin restaurarlo y

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
   rechazan en tiempo de decoración los objetos con `<locals>` en su `__qualname__`:
   una función definida dentro de otra función nunca será importable desde el worker
   (P0-3)
+- **cqrs**: `PostgresLockProvider` ya no filtra filas indefinidamente. Con una clave
+  por `(job_id, minuto)` y 7 jobs eran ~10.000 filas/día **para siempre** en la BD
+  principal. Ahora purga lo expirado en `setup()` y cada `purge_every` adquisiciones
+  (100 por defecto), crea un índice sobre `expires_at`, y expone `purge_expired()`
+  (P0-4)
 
 ### Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Test
+
+- **cqrs**: los tests del consumer parcheaban `_resolve_callable` sin restaurarlo y
+  contaminaban cualquier test posterior del mismo proceso; ahora usan `monkeypatch`
+  (P3-2)
+
 ## 2.0.6 (2026-06-25)
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ HexCore v2 integra de forma nativa soporte para el patrón **CQRS (Command Query
 
 El sistema se basa en 3 buses principales, configurables e independientes:
 
-1. **`AbstractCommandBus`**: Despacha inteniones de mutación (`Command`) a un único `AbstractCommandHandler`. Los commands modifican el estado del sistema y se ejecutan (por defecto) dentro de una transacción de base de datos (Unit of Work).
+1. **`AbstractCommandBus`**: Despacha inteniones de mutación (`Command`) a un único `AbstractCommandHandler`. Los commands modifican el estado del sistema. La transacción la gestiona el handler (el patrón que enseñan los ejemplos de use case); si preferís que la gestione el bus, añadí `TransactionMiddleware` explícitamente con su `uow_factory`.
 2. **`AbstractQueryBus`**: Despacha intenciones de lectura (`Query`) a un único `AbstractQueryHandler`. Retornan un resultado sin mutar el estado.
 3. **`EventBus`**: Distribuye eventos de dominio (`DomainEvent`) a múltiples suscriptores asíncronamente (vía `subscribe`/`publish`).
 
@@ -265,14 +265,24 @@ from hexcore.application.cqrs.config import CQRSConfig, BusConfig
 config = ServerConfig(
     cqrs=CQRSConfig(
         command_bus=BusConfig(
-            # Por defecto incluye TransactionMiddleware
-            middlewares=["hexcore.infrastructure.cqrs.middlewares.TransactionMiddleware"]
+            # Sin middlewares por defecto. Los que no necesitan configuración se
+            # pueden declarar por dotted path:
+            middlewares=["hexcore.infrastructure.cqrs.middlewares.LoggingMiddleware"]
         ),
         # Puedes sustituir el backend en memoria por uno distribuido (Ej: Celery, Procrastinate)
         # backend="mi_app.infrastructure.ProcrastinateCommandBus" 
     )
 )
 ```
+
+> **`TransactionMiddleware` no es el default.** Comitea después del handler, así que
+> con un handler que ya gestiona su propia transacción comitearías dos veces. Y
+> necesita un `uow_factory` construido con *tu* engine, cosa que no se puede expresar
+> como dotted path: instancialo a mano y pasá el pipeline al bus.
+>
+> ```python
+> TransactionMiddleware(uow_factory=lambda: SqlAlchemyUnitOfWork(session=session_factory()))
+> ```
 
 ---
 

--- a/hexcore/application/cqrs/config.py
+++ b/hexcore/application/cqrs/config.py
@@ -55,13 +55,12 @@ class CQRSConfig(BaseModel):
     """
 
     enabled: bool = True
-    command_bus: BusConfig = Field(
-        default_factory=lambda: BusConfig(
-            middlewares=[
-                "hexcore.infrastructure.cqrs.middlewares.TransactionMiddleware"
-            ]
-        )
-    )
+    # Sin middlewares por defecto (P0-6). `TransactionMiddleware` *era* el default,
+    # pero adivinaba la sesión con el session factory interno de HexCore en vez del
+    # engine de la aplicación, y comiteaba por segunda vez sobre los handlers que ya
+    # gestionan su transacción. Si lo querés, declaralo explícitamente con su
+    # `uow_factory`.
+    command_bus: BusConfig = Field(default_factory=BusConfig)
     query_bus: BusConfig = Field(default_factory=BusConfig)
     event_bus: BusConfig = Field(default_factory=BusConfig)
     serializer: t.Optional[str] = None  # None = PydanticSerializer por defecto

--- a/hexcore/application/cqrs/in_memory_buses.py
+++ b/hexcore/application/cqrs/in_memory_buses.py
@@ -8,6 +8,7 @@ import logging
 
 from hexcore.domain.cqrs.buses import ICommandBus, IQueryBus, IEventBus
 from hexcore.domain.cqrs.commands import Command
+from hexcore.domain.cqrs.context import is_worker_execution, local_execution
 from hexcore.domain.cqrs.queries import Query
 from hexcore.domain.events import DomainEvent
 from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
@@ -28,6 +29,10 @@ class InMemoryCommandBus(ICommandBus):
     Si el comando está decorado con `@background_command` y se provee un `enqueuer`,
     el comando es automáticamente encolado para su ejecución en segundo plano
     sin bloquear el proceso actual (retornando None).
+
+    Cuando el mensaje viene de un worker (``IN_WORKER`` activo, lo pone el
+    ``CQRSConsumer``), el bus lo ejecuta **localmente** en vez de reencolarlo.
+    Esto permite usar el mismo bus en el proceso web y en el worker.
     """
 
     def __init__(
@@ -44,17 +49,19 @@ class InMemoryCommandBus(ICommandBus):
 
     async def dispatch(self, command: Command) -> t.Any:
         cmd_type = type(command)
-        
+
         # 1. Smart Routing: ¿Debe irse a background?
+        # Si ya estamos dentro de un worker, el mensaje viene de la cola: hay que
+        # ejecutarlo, no volver a encolarlo.
         is_background = getattr(cmd_type, "__cqrs_background__", False)
-        
-        if is_background:
+
+        if is_background and not is_worker_execution():
             if not self._enqueuer or not self._serializer:
                 raise RuntimeError(
                     f"El comando '{cmd_type.__name__}' requiere ejecución en background, "
                     "pero el InMemoryCommandBus no tiene configurado un 'enqueuer' o 'serializer'."
                 )
-            
+
             async def background_dispatcher(cmd: Command) -> None:
                 queue_name = getattr(cmd_type, "__cqrs_queue__", "default")
                 payload = self._serializer.serialize(cmd) # type: ignore
@@ -70,7 +77,10 @@ class InMemoryCommandBus(ICommandBus):
         async def final_handler(cmd: t.Any) -> t.Any:
             return await handler.handle(cmd)
 
-        return await self._pipeline.execute(command, final_handler)
+        # `local_execution` consume el flag de worker: si el handler despacha otro
+        # `@background_command`, ese sí debe encolarse.
+        with local_execution():
+            return await self._pipeline.execute(command, final_handler)
 
 
 class InMemoryQueryBus(IQueryBus):
@@ -129,9 +139,15 @@ class InMemoryEventBus(IEventBus):
 
     async def publish(self, event: DomainEvent) -> None:
         handlers = self._handlers.get(type(event), [])
+        # Si el evento viene de un worker, sus handlers de background se ejecutan
+        # aquí; reencolarlos sería un bucle infinito.
+        in_worker = is_worker_execution()
 
         for event_handler in handlers:
-            is_background = getattr(event_handler, "__cqrs_background_handler__", False)
+            is_background = (
+                getattr(event_handler, "__cqrs_background_handler__", False)
+                and not in_worker
+            )
 
             if is_background:
                 # Enrutamiento hacia background
@@ -161,4 +177,5 @@ class InMemoryEventBus(IEventBus):
                 ) -> None:
                     await _h(evt)
 
-                await self._pipeline.execute(event, final_handler)
+                with local_execution():
+                    await self._pipeline.execute(event, final_handler)

--- a/hexcore/domain/cqrs/__init__.py
+++ b/hexcore/domain/cqrs/__init__.py
@@ -22,6 +22,8 @@ from .buses import ICommandBus, IQueryBus, IEventBus
 from .middleware import IMiddleware
 from .serializer import ISerializer
 from .cron import CronJobDefinition, ICronJobRepository, ILockProvider
+from .context import IN_WORKER, is_worker_execution, local_execution, worker_execution
+from .resolution import build_fqn, resolve_dotted
 
 __all__ = [
     # Nombres canónicos (Abstract*)
@@ -39,6 +41,13 @@ __all__ = [
     "CronJobDefinition",
     "ICronJobRepository",
     "ILockProvider",
+    # Contexto de ejecución y resolución de FQN
+    "IN_WORKER",
+    "is_worker_execution",
+    "local_execution",
+    "worker_execution",
+    "build_fqn",
+    "resolve_dotted",
     # Aliases (I*)
     "ICommandHandler",
     "IQueryHandler",

--- a/hexcore/domain/cqrs/context.py
+++ b/hexcore/domain/cqrs/context.py
@@ -1,0 +1,61 @@
+"""
+Contexto de ejecución de mensajes CQRS.
+
+Los buses con Smart Routing necesitan saber si el mensaje que están despachando
+*viene* de una cola de tareas o si lo está originando el proceso actual. Sin esa
+distinción, un worker que recibe un ``@background_command`` lo vuelve a encolar
+en lugar de ejecutarlo, y el comando nunca corre (bucle infinito silencioso).
+
+Semántica del flag:
+
+- ``IN_WORKER`` sólo está activo alrededor de la **resolución** del mensaje entrante.
+- El primer bus que lo lee lo **consume**: lo pone en ``False`` antes de invocar
+  middlewares y handler. Así, un handler que despacha a propósito otro
+  ``@background_command`` sigue encolándolo, que es la semántica esperada.
+"""
+from __future__ import annotations
+
+import typing as t
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+__all__ = ["IN_WORKER", "worker_execution", "local_execution", "is_worker_execution"]
+
+
+IN_WORKER: ContextVar[bool] = ContextVar("hexcore_in_worker", default=False)
+
+
+def is_worker_execution() -> bool:
+    """Indica si el mensaje en curso proviene de un worker de background."""
+    return IN_WORKER.get()
+
+
+@contextmanager
+def worker_execution() -> t.Iterator[None]:
+    """
+    Marca el bloque como "ejecución dentro de un worker".
+
+    Lo usan los consumidores (``CQRSConsumer``) alrededor del despacho del mensaje
+    que acaban de sacar de la cola.
+    """
+    token = IN_WORKER.set(True)
+    try:
+        yield
+    finally:
+        IN_WORKER.reset(token)
+
+
+@contextmanager
+def local_execution() -> t.Iterator[None]:
+    """
+    Consume el flag de worker: dentro de este bloque ``IN_WORKER`` es ``False``.
+
+    Lo usan los buses antes de entrar al pipeline/handler, para que el despacho
+    explícito de otro mensaje de background desde dentro del handler se encole
+    en vez de ejecutarse inline.
+    """
+    token = IN_WORKER.set(False)
+    try:
+        yield
+    finally:
+        IN_WORKER.reset(token)

--- a/hexcore/domain/cqrs/decorators.py
+++ b/hexcore/domain/cqrs/decorators.py
@@ -6,6 +6,13 @@ from __future__ import annotations
 
 import typing as t
 
+from .resolution import build_fqn, ensure_resolvable_qualname
+
+
+def _unwrap(func: t.Any) -> t.Any:
+    """Descarta envoltorios (`staticmethod`/`classmethod`) para leer el objeto real."""
+    return getattr(func, "__func__", func)
+
 
 def background_command(queue: str = "default") -> t.Callable[[t.Type[t.Any]], t.Type[t.Any]]:
     """
@@ -21,6 +28,8 @@ def background_command(queue: str = "default") -> t.Callable[[t.Type[t.Any]], t.
             ...
     """
     def wrapper(cls: t.Type[t.Any]) -> t.Type[t.Any]:
+        # El worker tiene que poder importar la clase para deserializar el payload.
+        ensure_resolvable_qualname(cls, decorator="background_command")
         cls.__cqrs_background__ = True
         cls.__cqrs_queue__ = queue
         return cls
@@ -42,15 +51,17 @@ def background_handler(queue: str = "default") -> t.Callable[[t.Callable[..., t.
             ...
     """
     def wrapper(func: t.Callable[..., t.Any]) -> t.Callable[..., t.Any]:
-        func.__cqrs_background_handler__ = True
-        func.__cqrs_queue__ = queue
-        
-        # Guardamos el nombre calificado del handler para poder resolverlo luego en el Worker
-        if not hasattr(func, "__qualname__"):
-            func.__cqrs_handler_name__ = func.__name__
-        else:
-            func.__cqrs_handler_name__ = f"{func.__module__}.{func.__qualname__}"
-            
+        target = _unwrap(func)
+        ensure_resolvable_qualname(target, decorator="background_handler")
+
+        target.__cqrs_background_handler__ = True
+        target.__cqrs_queue__ = queue
+
+        # Guardamos el nombre calificado del handler para poder resolverlo luego en
+        # el Worker. `build_fqn` conserva el __qualname__ completo (métodos incluidos)
+        # y `resolve_dotted` sabe resolverlo del otro lado.
+        target.__cqrs_handler_name__ = build_fqn(target)
+
         return func
 
     return wrapper
@@ -65,14 +76,13 @@ def background_task(queue: str = "default") -> t.Callable[[t.Callable[..., t.Any
     `TaskManager` de HexCore o ejecutada directamente usando el `ITaskEnqueuer`.
     """
     def wrapper(func: t.Callable[..., t.Any]) -> t.Callable[..., t.Any]:
-        func.__cqrs_background_task__ = True
-        func.__cqrs_queue__ = queue
-        
-        if not hasattr(func, "__qualname__"):
-            func.__cqrs_task_name__ = func.__name__
-        else:
-            func.__cqrs_task_name__ = f"{func.__module__}.{func.__qualname__}"
-            
+        target = _unwrap(func)
+        ensure_resolvable_qualname(target, decorator="background_task")
+
+        target.__cqrs_background_task__ = True
+        target.__cqrs_queue__ = queue
+        target.__cqrs_task_name__ = build_fqn(target)
+
         return func
 
     return wrapper

--- a/hexcore/domain/cqrs/resolution.py
+++ b/hexcore/domain/cqrs/resolution.py
@@ -1,0 +1,87 @@
+"""
+Resolución de referencias por nombre calificado (FQN).
+
+Un ``__qualname__`` puede contener puntos (clases y funciones anidadas), así que
+``fqn.rsplit(".", 1)`` produce un module path inválido: ``"app.Outer.Inner"`` se
+parte en ``("app.Outer", "Inner")`` y el import falla con
+``No module named 'app.Outer'``.
+
+Este módulo centraliza la resolución correcta: probar prefijos de módulo de más
+largo a más corto y luego caminar los atributos restantes.
+"""
+from __future__ import annotations
+
+import importlib
+import typing as t
+
+__all__ = ["resolve_dotted", "build_fqn", "ensure_resolvable_qualname"]
+
+
+def resolve_dotted(fqn: str) -> t.Any:
+    """
+    Resuelve un FQN (``"paquete.modulo.Clase.Anidada"``) al objeto que referencia.
+
+    Soporta clases y funciones anidadas: prueba el prefijo de módulo más largo
+    que sea importable y después recorre los atributos restantes.
+
+    Raises:
+        LookupError: Si no se puede resolver ningún prefijo válido.
+    """
+    if not fqn or not isinstance(fqn, str):
+        raise LookupError(f"FQN inválido: {fqn!r}")
+
+    parts = fqn.split(".")
+    if len(parts) == 1:
+        # Sin módulo no hay nada que importar; sólo puede ser un builtin.
+        import builtins
+
+        try:
+            return getattr(builtins, parts[0])
+        except AttributeError as exc:
+            raise LookupError(f"No se pudo resolver '{fqn}': {exc}") from exc
+
+    last_error: Exception | None = None
+    # De más específico a más genérico: "a.b.c" → módulos "a.b.c", "a.b", "a".
+    for split_at in range(len(parts) - 1, 0, -1):
+        module_path = ".".join(parts[:split_at])
+        try:
+            obj: t.Any = importlib.import_module(module_path)
+        except ImportError as exc:
+            last_error = exc
+            continue
+
+        try:
+            for attr in parts[split_at:]:
+                obj = getattr(obj, attr)
+        except AttributeError as exc:
+            last_error = exc
+            continue
+        return obj
+
+    raise LookupError(f"No se pudo resolver '{fqn}': {last_error}")
+
+
+def build_fqn(obj: t.Any) -> str:
+    """Construye el FQN de una clase o función (``modulo.QualName``)."""
+    qualname = getattr(obj, "__qualname__", None) or obj.__name__
+    return f"{obj.__module__}.{qualname}"
+
+
+def ensure_resolvable_qualname(obj: t.Any, *, decorator: str) -> None:
+    """
+    Valida que ``obj`` pueda resolverse desde otro proceso.
+
+    Una función definida dentro de otra función lleva ``<locals>`` en su
+    ``__qualname__`` y **nunca** será importable desde el worker. Es mucho mejor
+    fallar al decorar que fallar en el primer job de producción.
+
+    Raises:
+        ValueError: Si el ``__qualname__`` contiene ``<locals>``.
+    """
+    qualname = getattr(obj, "__qualname__", "") or ""
+    if "<locals>" in qualname:
+        raise ValueError(
+            f"@{decorator} no se puede aplicar a '{qualname}': está definida dentro "
+            "de otra función, así que el worker no podrá importarla. Muévela al nivel "
+            "de módulo (o a un método de una clase de módulo)."
+        )

--- a/hexcore/infrastructure/cqrs/middlewares.py
+++ b/hexcore/infrastructure/cqrs/middlewares.py
@@ -100,33 +100,42 @@ class ValidationMiddleware(IMiddleware):
 class TransactionMiddleware(IMiddleware):
     """
     Middleware que envuelve la ejecución del handler en un contexto transaccional
-    usando el Unit of Work de Hexcore.
+    usando el Unit of Work de Hexcore, y comitea al terminar.
 
-    Requiere que el handler tenga acceso al UoW (inyectado vía constructor).
-    Este middleware se encarga del commit/rollback.
+    **Es para handlers que NO gestionan su propia transacción.** Si tu handler ya
+    hace ``async with self.uow:`` y ``await self.uow.commit()`` —el patrón que
+    enseña `DOCS.md` para los use cases— no uses este middleware: comitearías dos
+    veces.
+
+    ``uow_factory`` es obligatorio. Antes existía un default que armaba la sesión
+    con el session factory *interno* de HexCore en vez del engine de la aplicación,
+    lo que producía transacciones contra un engine distinto al del resto del
+    request. Adivinar aquí es peor que no funcionar.
+
+    Uso::
+
+        TransactionMiddleware(uow_factory=lambda: SqlAlchemyUnitOfWork(session=my_factory()))
     """
 
     def __init__(self, uow_factory: t.Callable[[], t.Any] | None = None) -> None:
         """
         Args:
-            uow_factory: Callable que retorna un IUnitOfWork context manager.
-                         Si es None, usa un factory por defecto (intenta SQL, luego NoSQL).
-        """
-        self._uow_factory = uow_factory or self._default_uow_factory
+            uow_factory: Callable que retorna un IUnitOfWork usable como context
+                manager. Obligatorio.
 
-    @staticmethod
-    def _default_uow_factory() -> t.Any:
-        from hexcore.config import LazyConfig
-        from hexcore.infrastructure.uow import SqlAlchemyUnitOfWork, NoSqlUnitOfWork
-        
-        config = LazyConfig.get_config()
-        # Heurística simple: Si hay una URL de SQL (por defecto siempre la hay), asume SQL.
-        # En una app real de Hexcore se puede inyectar esto mejor, pero provee un default funcional.
-        if config.sql_database_url:
-            from hexcore.infrastructure.repositories.orms.sqlalchemy.session import get_session_factory
-            factory = get_session_factory()
-            return SqlAlchemyUnitOfWork(session=factory())
-        return NoSqlUnitOfWork()
+        Raises:
+            ValueError: Si no se provee `uow_factory`.
+        """
+        if uow_factory is None:
+            raise ValueError(
+                "TransactionMiddleware requiere un 'uow_factory' explícito. "
+                "Pasá un callable que construya el UoW con el engine de tu "
+                "aplicación, p. ej. "
+                "TransactionMiddleware(uow_factory=lambda: SqlAlchemyUnitOfWork(session=session_factory())). "
+                "Recordá que este middleware comitea: no lo uses con handlers que "
+                "ya gestionan su propia transacción."
+            )
+        self._uow_factory = uow_factory
 
     async def handle(self, message: t.Any, next_handler: NextHandler) -> t.Any:
         uow = self._uow_factory()

--- a/hexcore/infrastructure/cqrs/postgres_bus.py
+++ b/hexcore/infrastructure/cqrs/postgres_bus.py
@@ -10,6 +10,7 @@ import logging
 import typing as t
 
 from hexcore.domain.cqrs.buses import IEventBus
+from hexcore.domain.cqrs.context import is_worker_execution, local_execution
 from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
 from hexcore.domain.events import DomainEvent
 
@@ -107,17 +108,24 @@ class PostgresEventBus(IEventBus):
             event = self._serializer.deserialize(payload_dict)
             handlers = self._handlers.get(event_type, [])
             
+            # Si ya estamos dentro de un worker, el mensaje viene de la cola:
+            # ejecutar en vez de reencolar (ver hexcore.domain.cqrs.context).
+            in_worker = is_worker_execution()
             for handler in handlers:
-                is_background = getattr(handler, "__cqrs_background_handler__", False)
+                is_background = (
+                    getattr(handler, "__cqrs_background_handler__", False)
+                    and not in_worker
+                )
                 if is_background:
                     queue_name = getattr(handler, "__cqrs_queue__", "default")
                     if not self.enqueuer:
                         raise RuntimeError(f"El handler asíncrono {handler.__name__} requiere un enqueuer.")
-                    
+
                     handler_ref = getattr(handler, "__cqrs_handler_name__", f"{handler.__module__}.{handler.__name__}")
                     await self.enqueuer.enqueue_handler(handler_ref, payload_dict, queue_name)
                 else:
-                    await handler(event)
+                    with local_execution():
+                        await handler(event)
                     
         except Exception as e:
             logger.error(f"Error parseando o ejecutando evento de PostgreSQL NOTIFY: {e}")

--- a/hexcore/infrastructure/cqrs/postgres_lock.py
+++ b/hexcore/infrastructure/cqrs/postgres_lock.py
@@ -22,34 +22,86 @@ class PostgresLockProvider(ILockProvider):
     Implementación de ILockProvider basada en PostgreSQL (vía asyncpg).
     Utiliza una tabla `hexcore_cron_locks` para gestionar la exclusión mutua
     con soporte para TTL atómico.
+
+    **Crecimiento de la tabla.** El `DynamicScheduler` usa una clave por
+    `(job_id, minuto)`, así que cada minuto genera filas nuevas: con 7 jobs son del
+    orden de 10.000 filas/día. Las filas expiradas ya no sirven para nada, así que
+    este provider las purga solo:
+
+    - en `setup()`,
+    - y cada `purge_every` adquisiciones (por defecto 100, ~1 query extra por 100).
+
+    `purge_expired()` es pública si preferís purgar desde un job propio; poné
+    `purge_every=0` para desactivar la purga automática.
     """
 
-    def __init__(self, pool: asyncpg.Pool | asyncpg.Connection, table_name: str = "hexcore_cron_locks") -> None:
+    def __init__(
+        self,
+        pool: asyncpg.Pool | asyncpg.Connection,
+        table_name: str = "hexcore_cron_locks",
+        *,
+        purge_every: int = 100,
+        purge_grace_seconds: int = 3600,
+    ) -> None:
         """
         Args:
             pool: Pool de conexiones o conexión simple de `asyncpg`.
             table_name: Nombre de la tabla a utilizar para los locks.
+            purge_every: Cada cuántas adquisiciones purgar lo expirado. 0 desactiva.
+            purge_grace_seconds: Margen antes de borrar una fila expirada. Evita
+                borrar locks que acaban de vencer y que otra réplica podría estar
+                evaluando en este mismo instante.
         """
         self.pool = pool
         self.table_name = table_name
+        self.purge_every = purge_every
+        self.purge_grace_seconds = purge_grace_seconds
+        self._acquisitions_since_purge = 0
 
     async def setup(self) -> None:
         """
-        Crea la tabla necesaria para los locks si no existe.
+        Crea la tabla y el índice necesarios para los locks si no existen,
+        y purga lo que haya quedado de ejecuciones anteriores.
         Debe llamarse al inicio de la aplicación.
         """
-        query = f"""
+        if not hasattr(self.pool, "execute"):
+            return
+
+        create_table = f"""
         CREATE TABLE IF NOT EXISTS {self.table_name} (
             lock_key TEXT PRIMARY KEY,
             expires_at TIMESTAMP WITH TIME ZONE NOT NULL
         )
         """
+        # El índice es lo que hace que la purga no degrade con el tamaño de la tabla.
+        create_index = f"""
+        CREATE INDEX IF NOT EXISTS {self.table_name}_expires_at_idx
+        ON {self.table_name} (expires_at)
+        """
         try:
-            if hasattr(self.pool, "execute"):
-                await self.pool.execute(query) # type: ignore
+            await self.pool.execute(create_table) # type: ignore
+            await self.pool.execute(create_index) # type: ignore
         except Exception as e:
             logger.error(f"Error creando tabla de locks en Postgres: {e}")
             raise
+
+        await self.purge_expired()
+
+    async def purge_expired(self) -> None:
+        """
+        Borra las filas cuyo `expires_at` venció hace más de `purge_grace_seconds`.
+
+        No propaga errores: una purga fallida no debe tumbar el scheduler.
+        """
+        query = f"""
+        DELETE FROM {self.table_name}
+        WHERE expires_at < NOW() - ($1 || ' seconds')::interval
+        """
+        try:
+            await self.pool.execute(query, str(self.purge_grace_seconds)) # type: ignore
+            self._acquisitions_since_purge = 0
+        except Exception as e:
+            logger.warning(f"Error purgando locks expirados de Postgres: {e}")
 
     async def acquire_lock(self, lock_key: str, ttl_seconds: int) -> bool:
         """
@@ -79,10 +131,21 @@ class PostgresLockProvider(ILockProvider):
         try:
             # fetchrow returns a record if RETURNING gave something, else None
             result = await self.pool.fetchrow(query, lock_key, str(ttl_seconds)) # type: ignore
-            return result is not None
+            acquired = result is not None
         except Exception as e:
             logger.error(f"Error intentando adquirir lock de Postgres para {lock_key}: {e}")
             return False
+
+        await self._maybe_purge()
+        return acquired
+
+    async def _maybe_purge(self) -> None:
+        """Purga amortizada: una query extra cada `purge_every` adquisiciones."""
+        if self.purge_every <= 0:
+            return
+        self._acquisitions_since_purge += 1
+        if self._acquisitions_since_purge >= self.purge_every:
+            await self.purge_expired()
 
     async def release_lock(self, lock_key: str) -> None:
         """

--- a/hexcore/infrastructure/cqrs/pydantic_serializer.py
+++ b/hexcore/infrastructure/cqrs/pydantic_serializer.py
@@ -4,11 +4,11 @@ a través de backends asíncronos (Procrastinate, Celery, etc.).
 """
 from __future__ import annotations
 
-import importlib
 import typing as t
 
 from hexcore.domain.cqrs.serializer import ISerializer
 from hexcore.domain.cqrs.exceptions import DeserializationError
+from hexcore.domain.cqrs.resolution import build_fqn, resolve_dotted
 
 
 class PydanticSerializer(ISerializer):
@@ -25,7 +25,7 @@ class PydanticSerializer(ISerializer):
     """
 
     def serialize(self, message: t.Any) -> dict[str, t.Any]:
-        fqn = f"{type(message).__module__}.{type(message).__qualname__}"
+        fqn = build_fqn(type(message))
         return {
             "__type__": fqn,
             "__data__": message.model_dump(mode="json"),
@@ -40,10 +40,10 @@ class PydanticSerializer(ISerializer):
             )
 
         try:
-            module_path, class_name = fqn.rsplit(".", 1)
-            module = importlib.import_module(module_path)
-            cls = getattr(module, class_name)
-        except (ValueError, ModuleNotFoundError, AttributeError) as exc:
+            # `resolve_dotted` soporta clases anidadas ("app.Outer.InnerCommand"),
+            # donde un rsplit(".", 1) produciría un module path inválido.
+            cls = resolve_dotted(fqn)
+        except LookupError as exc:
             raise DeserializationError(
                 f"Cannot resolve type '{fqn}': {exc}"
             ) from exc

--- a/hexcore/infrastructure/cqrs/redis_bus.py
+++ b/hexcore/infrastructure/cqrs/redis_bus.py
@@ -11,6 +11,7 @@ import typing as t
 import uuid
 
 from hexcore.domain.cqrs.buses import IEventBus
+from hexcore.domain.cqrs.context import is_worker_execution, local_execution
 from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
 from hexcore.domain.events import DomainEvent
 
@@ -120,18 +121,25 @@ class RedisEventBus(IEventBus):
             event = self._serializer.deserialize(payload_dict)
             handlers = self._handlers.get(event_type, [])
             
-            # Ejecutar handlers (respetando Smart Routing)
+            # Ejecutar handlers (respetando Smart Routing).
+            # Si ya estamos dentro de un worker, el mensaje viene de la cola:
+            # ejecutar en vez de reencolar (ver hexcore.domain.cqrs.context).
+            in_worker = is_worker_execution()
             for handler in handlers:
-                is_background = getattr(handler, "__cqrs_background_handler__", False)
+                is_background = (
+                    getattr(handler, "__cqrs_background_handler__", False)
+                    and not in_worker
+                )
                 if is_background:
                     queue_name = getattr(handler, "__cqrs_queue__", "default")
                     if not self.enqueuer:
                         raise RuntimeError(f"El handler asíncrono {handler.__name__} requiere un enqueuer.")
-                    
+
                     handler_ref = getattr(handler, "__cqrs_handler_name__", f"{handler.__module__}.{handler.__name__}")
                     await self.enqueuer.enqueue_handler(handler_ref, payload_dict, queue_name)
                 else:
-                    await handler(event)
+                    with local_execution():
+                        await handler(event)
 
             # Confirmar mensaje
             await self.redis.xack(self.stream_name, self.group_name, message_id)

--- a/hexcore/infrastructure/task_queues/celery_adapter.py
+++ b/hexcore/infrastructure/task_queues/celery_adapter.py
@@ -39,9 +39,13 @@ class CeleryEnqueuer(ITaskEnqueuer):
         )
 
     async def enqueue_event(self, event_name: str, payload: dict[str, t.Any], queue: str) -> None:
-        # Los eventos genéricos (publish a todos los workers) rara vez se envían a Celery
-        # de esta forma. Normalmente se usa enqueue_handler. Se provee para completitud.
-        pass
+        raise NotImplementedError(
+            "CeleryEnqueuer no encola eventos completos: Celery es una cola de tareas, "
+            "no un bus de fan-out, así que un evento encolado aquí no llegaría a los "
+            "suscriptores. Para ejecutar un suscriptor concreto en background, "
+            "decoralo con @background_handler (el EventBus llamará a enqueue_handler). "
+            "Para fan-out real, usá RedisEventBus o PostgresEventBus."
+        )
 
     async def enqueue_handler(self, handler_name: str, payload: dict[str, t.Any], queue: str) -> None:
         await asyncio.to_thread(

--- a/hexcore/infrastructure/task_queues/procrastinate_adapter.py
+++ b/hexcore/infrastructure/task_queues/procrastinate_adapter.py
@@ -32,7 +32,13 @@ class ProcrastinateEnqueuer(ITaskEnqueuer):
         await task.defer_async(payload=payload)
 
     async def enqueue_event(self, event_name: str, payload: dict[str, t.Any], queue: str) -> None:
-        pass
+        raise NotImplementedError(
+            "ProcrastinateEnqueuer no encola eventos completos: Procrastinate es una "
+            "cola de tareas, no un bus de fan-out, así que un evento encolado aquí no "
+            "llegaría a los suscriptores. Para ejecutar un suscriptor concreto en "
+            "background, decoralo con @background_handler (el EventBus llamará a "
+            "enqueue_handler). Para fan-out real, usá RedisEventBus o PostgresEventBus."
+        )
 
     async def enqueue_handler(self, handler_name: str, payload: dict[str, t.Any], queue: str) -> None:
         task = self.app.configure_task(name="hexcore.process_handler", queue=queue)

--- a/hexcore/infrastructure/workers/consumer.py
+++ b/hexcore/infrastructure/workers/consumer.py
@@ -3,11 +3,12 @@ Consumidor Universal para colas de tareas (Celery, Procrastinate).
 """
 from __future__ import annotations
 
-import importlib
 import logging
 import typing as t
 
 from hexcore.domain.cqrs.buses import AbstractCommandBus, AbstractEventBus
+from hexcore.domain.cqrs.context import worker_execution
+from hexcore.domain.cqrs.resolution import resolve_dotted
 from hexcore.domain.cqrs.serializer import ISerializer
 from hexcore.domain.events import DomainEvent
 
@@ -18,12 +19,15 @@ logger = logging.getLogger("hexcore.workers.consumer")
 
 
 def _resolve_callable(qualname: str) -> t.Callable[..., t.Any]:
-    """Resuelve un import por su nombre calificado (ej. 'myapp.events.on_user_created')."""
+    """
+    Resuelve un import por su nombre calificado (ej. 'myapp.events.on_user_created').
+
+    Soporta nombres anidados (``myapp.jobs.Jobs.cleanup``) delegando en
+    ``resolve_dotted``.
+    """
     try:
-        module_path, func_name = qualname.rsplit(".", 1)
-        module = importlib.import_module(module_path)
-        return getattr(module, func_name) # type: ignore
-    except (ValueError, ModuleNotFoundError, AttributeError) as exc:
+        return t.cast(t.Callable[..., t.Any], resolve_dotted(qualname))
+    except LookupError as exc:
         raise RuntimeError(f"No se pudo resolver el handler/tarea '{qualname}': {exc}") from exc
 
 
@@ -61,14 +65,19 @@ class CQRSConsumer:
     async def process_command(self, payload: dict[str, t.Any]) -> None:
         """
         Deserializa un payload de comando y lo despacha al bus local.
+
+        El despacho ocurre dentro de ``worker_execution()``, así que un bus con
+        Smart Routing **ejecuta** el comando en vez de reencolarlo. Esto permite
+        compartir el mismo bus entre el proceso web y el worker.
         """
         try:
             command = self._serializer.deserialize(payload)
             cmd = t.cast("Command", command)
-            
+
             logger.info("[CQRSConsumer] Procesando comando en background: %s", type(cmd).__qualname__)
-            await self._command_bus.dispatch(cmd)
-            
+            with worker_execution():
+                await self._command_bus.dispatch(cmd)
+
         except Exception as exc:
             logger.exception("[CQRSConsumer] Error procesando comando: %s", exc)
             raise
@@ -77,14 +86,19 @@ class CQRSConsumer:
         """
         Deserializa un payload de evento y lo publica en el bus local
         para que todos los handlers (suscriptores) locales lo consuman.
+
+        Igual que ``process_command``: se publica dentro de ``worker_execution()``,
+        así que los handlers marcados con ``@background_handler`` se ejecutan aquí
+        en vez de reencolarse.
         """
         try:
             event = self._serializer.deserialize(payload)
             evt = t.cast(DomainEvent, event)
-            
+
             logger.info("[CQRSConsumer] Procesando evento en background: %s", evt.event_name)
-            await self._event_bus.publish(evt)
-            
+            with worker_execution():
+                await self._event_bus.publish(evt)
+
         except Exception as exc:
             logger.exception("[CQRSConsumer] Error procesando evento: %s", exc)
             raise
@@ -93,6 +107,10 @@ class CQRSConsumer:
         """
         Deserializa el evento y ejecuta *específicamente* un handler decorado con `@background_handler`.
         Esto es inyectado por el Smart Routing del EventBus.
+
+        Nota: aquí **no** se activa ``worker_execution()``. El handler se invoca
+        directamente (no hay bus que consuma el flag), así que dejarlo activo haría
+        que los comandos que el handler despache a propósito se ejecutaran inline.
         """
         try:
             event = self._serializer.deserialize(payload)
@@ -110,6 +128,9 @@ class CQRSConsumer:
     async def process_task(self, task_name: str, payload: dict[str, t.Any]) -> None:
         """
         Ejecuta una tarea genérica de background decorada con `@background_task`.
+
+        Igual que ``process_handler``: la tarea se invoca directamente, sin activar
+        ``worker_execution()``.
         """
         try:
             logger.info("[CQRSConsumer] Ejecutando Task genérica en background: %s", task_name)

--- a/tests/test_cqrs_middlewares.py
+++ b/tests/test_cqrs_middlewares.py
@@ -1,0 +1,61 @@
+"""
+P0-6: `TransactionMiddleware` ya no es el default de `CQRSConfig` y exige
+`uow_factory` explícito en vez de adivinar la sesión.
+"""
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from hexcore.application.cqrs.config import CQRSConfig
+from hexcore.infrastructure.cqrs.middlewares import TransactionMiddleware
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_cqrs_config_has_no_default_middlewares():
+    config = CQRSConfig()
+
+    assert config.command_bus.middlewares == []
+    assert config.query_bus.middlewares == []
+    assert config.event_bus.middlewares == []
+
+
+def test_transaction_middleware_requires_explicit_uow_factory():
+    with pytest.raises(ValueError, match="uow_factory"):
+        TransactionMiddleware()
+
+
+class FakeUoW:
+    def __init__(self) -> None:
+        self.entered = False
+        self.commits = 0
+
+    async def __aenter__(self) -> "FakeUoW":
+        self.entered = True
+        return self
+
+    async def __aexit__(self, *exc: t.Any) -> None:
+        return None
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+
+@pytest.mark.anyio
+async def test_transaction_middleware_uses_the_injected_factory():
+    uow = FakeUoW()
+    middleware = TransactionMiddleware(uow_factory=lambda: uow)
+
+    async def next_handler(message: t.Any) -> str:
+        return f"handled:{message}"
+
+    result = await middleware.handle("msg", next_handler)
+
+    assert result == "handled:msg"
+    assert uow.entered is True
+    assert uow.commits == 1

--- a/tests/test_dotted_resolution.py
+++ b/tests/test_dotted_resolution.py
@@ -1,0 +1,138 @@
+"""
+P0-3: resolución de `__qualname__` para clases y funciones anidadas.
+
+Antes, `PydanticSerializer.deserialize` y `_resolve_callable` partían el FQN con
+`rsplit(".", 1)`. Para una clase anidada el `__qualname__` ya contiene puntos, así
+que el module path resultante era inválido y el mensaje fallaba **en el worker**,
+donde ya no se puede recuperar.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hexcore.domain.cqrs.commands import Command
+from hexcore.domain.cqrs.decorators import (
+    background_command,
+    background_handler,
+    background_task,
+)
+from hexcore.domain.cqrs.resolution import build_fqn, resolve_dotted
+from hexcore.infrastructure.cqrs.pydantic_serializer import PydanticSerializer
+from hexcore.infrastructure.workers.consumer import _resolve_callable
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class Outer:
+    class InnerCommand(Command):
+        value: str
+
+    @staticmethod
+    def a_function() -> str:
+        return "inner-function"
+
+
+def module_level_function() -> str:
+    return "module-level"
+
+
+# ── resolve_dotted ─────────────────────────────────────────────────────────────
+
+
+def test_resolve_dotted_resolves_module_level_object():
+    resolved = resolve_dotted(f"{__name__}.module_level_function")
+    assert resolved is module_level_function
+
+
+def test_resolve_dotted_resolves_nested_class():
+    resolved = resolve_dotted(f"{__name__}.Outer.InnerCommand")
+    assert resolved is Outer.InnerCommand
+
+
+def test_resolve_dotted_resolves_nested_function():
+    resolved = resolve_dotted(f"{__name__}.Outer.a_function")
+    assert resolved() == "inner-function"
+
+
+def test_resolve_dotted_raises_lookup_error_for_unknown():
+    with pytest.raises(LookupError):
+        resolve_dotted(f"{__name__}.DoesNotExist")
+
+
+def test_resolve_dotted_raises_lookup_error_for_unknown_module():
+    with pytest.raises(LookupError):
+        resolve_dotted("no_such_module_at_all.Thing")
+
+
+def test_build_fqn_keeps_full_qualname():
+    assert (
+        build_fqn(Outer.InnerCommand)
+        == f"{__name__}.Outer.InnerCommand"
+    )
+
+
+# ── Round-trip del serializer ──────────────────────────────────────────────────
+
+
+def test_serializer_round_trip_of_nested_command():
+    serializer = PydanticSerializer()
+    payload = serializer.serialize(Outer.InnerCommand(value="nested"))
+
+    assert payload["__type__"] == f"{__name__}.Outer.InnerCommand"
+
+    restored = serializer.deserialize(payload)
+    assert isinstance(restored, Outer.InnerCommand)
+    assert restored.value == "nested"
+
+
+# ── _resolve_callable del consumer ─────────────────────────────────────────────
+
+
+class TaskHolder:
+    ran: list[str] = []
+
+    @staticmethod
+    @background_task(queue="q")
+    async def cleanup() -> None:
+        TaskHolder.ran.append("cleanup")
+
+
+def test_consumer_resolves_nested_static_task():
+    task_name = getattr(TaskHolder.cleanup, "__cqrs_task_name__")
+    assert task_name == f"{__name__}.TaskHolder.cleanup"
+    assert _resolve_callable(task_name) is not None
+
+
+def test_consumer_resolve_callable_raises_runtime_error_on_unknown():
+    with pytest.raises(RuntimeError):
+        _resolve_callable(f"{__name__}.nope")
+
+
+# ── Rechazo en tiempo de decoración de objetos no resolubles ───────────────────
+
+
+def test_background_task_rejects_local_function():
+    with pytest.raises(ValueError, match="<locals>"):
+
+        @background_task(queue="q")
+        async def local_task() -> None:  # pragma: no cover - nunca se decora
+            ...
+
+
+def test_background_handler_rejects_local_function():
+    with pytest.raises(ValueError, match="<locals>"):
+
+        @background_handler(queue="q")
+        async def local_handler(event: object) -> None:  # pragma: no cover
+            ...
+
+
+def test_background_command_rejects_local_class():
+    with pytest.raises(ValueError, match="<locals>"):
+
+        @background_command(queue="q")
+        class LocalCommand(Command):  # pragma: no cover
+            value: str

--- a/tests/test_postgres_lock.py
+++ b/tests/test_postgres_lock.py
@@ -23,10 +23,16 @@ def mock_pool():
 async def test_postgres_lock_setup(mock_pool):
     provider = PostgresLockProvider(mock_pool)
     await provider.setup()
-    
-    mock_pool.execute.assert_awaited_once()
-    query = mock_pool.execute.call_args[0][0]
-    assert "CREATE TABLE IF NOT EXISTS hexcore_cron_locks" in query
+
+    queries = [call.args[0] for call in mock_pool.execute.await_args_list]
+    assert any("CREATE TABLE IF NOT EXISTS hexcore_cron_locks" in q for q in queries)
+    # P0-4: el índice sobre expires_at es lo que hace la purga barata.
+    assert any(
+        "CREATE INDEX IF NOT EXISTS hexcore_cron_locks_expires_at_idx" in q
+        for q in queries
+    )
+    # P0-4: setup() arrastra la basura de ejecuciones anteriores.
+    assert any("DELETE FROM hexcore_cron_locks" in q for q in queries)
 
 
 @pytest.mark.anyio
@@ -70,8 +76,77 @@ async def test_postgres_lock_acquire_exception(mock_pool):
 async def test_postgres_lock_release(mock_pool):
     provider = PostgresLockProvider(mock_pool)
     await provider.release_lock("my_lock")
-    
+
     mock_pool.execute.assert_awaited_once()
     args = mock_pool.execute.call_args[0]
     assert "DELETE FROM" in args[0]
     assert args[1] == "my_lock"
+
+
+# ── P0-4: la tabla de locks no puede crecer sin límite ─────────────────────────
+
+
+@pytest.mark.anyio
+async def test_acquire_lock_purges_expired_rows_periodically(mock_pool):
+    mock_pool.fetchrow.return_value = {"lock_key": "k"}
+    provider = PostgresLockProvider(mock_pool, purge_every=5)
+
+    for i in range(5):
+        await provider.acquire_lock(f"job:{i}", ttl_seconds=60)
+
+    deletes = [
+        call.args[0]
+        for call in mock_pool.execute.await_args_list
+        if "DELETE FROM hexcore_cron_locks" in call.args[0]
+    ]
+    assert len(deletes) == 1, "la purga no se disparó al alcanzar purge_every"
+    assert "expires_at <" in deletes[0]
+
+
+@pytest.mark.anyio
+async def test_acquire_lock_does_not_purge_before_threshold(mock_pool):
+    mock_pool.fetchrow.return_value = {"lock_key": "k"}
+    provider = PostgresLockProvider(mock_pool, purge_every=100)
+
+    for i in range(10):
+        await provider.acquire_lock(f"job:{i}", ttl_seconds=60)
+
+    assert mock_pool.execute.await_count == 0
+
+
+@pytest.mark.anyio
+async def test_purge_every_zero_disables_automatic_purge(mock_pool):
+    mock_pool.fetchrow.return_value = {"lock_key": "k"}
+    provider = PostgresLockProvider(mock_pool, purge_every=0)
+
+    for i in range(200):
+        await provider.acquire_lock(f"job:{i}", ttl_seconds=60)
+
+    assert mock_pool.execute.await_count == 0
+
+
+@pytest.mark.anyio
+async def test_purge_expired_respects_grace_period(mock_pool):
+    provider = PostgresLockProvider(mock_pool, purge_grace_seconds=7200)
+    await provider.purge_expired()
+
+    args = mock_pool.execute.call_args[0]
+    assert "DELETE FROM hexcore_cron_locks" in args[0]
+    assert args[1] == "7200"
+
+
+@pytest.mark.anyio
+async def test_purge_expired_does_not_propagate_errors(mock_pool):
+    mock_pool.execute.side_effect = Exception("DB down")
+    provider = PostgresLockProvider(mock_pool)
+
+    await provider.purge_expired()  # no debe lanzar
+
+
+@pytest.mark.anyio
+async def test_purge_failure_does_not_break_acquisition(mock_pool):
+    mock_pool.fetchrow.return_value = {"lock_key": "k"}
+    mock_pool.execute.side_effect = Exception("DB down")
+    provider = PostgresLockProvider(mock_pool, purge_every=1)
+
+    assert await provider.acquire_lock("job", ttl_seconds=60) is True

--- a/tests/test_smart_routing.py
+++ b/tests/test_smart_routing.py
@@ -91,37 +91,36 @@ async def test_smart_routing_event_bus_enqueues_background_handlers():
 
 
 @pytest.mark.anyio
-async def test_cqrs_consumer_processes_handler_resolution():
+async def test_cqrs_consumer_processes_handler_resolution(monkeypatch):
     # En este test simulamos la recepción de un mensaje de "handler individual"
     local_cmd_bus = AsyncMock()
     local_evt_bus = AsyncMock()
     serializer = PydanticSerializer()
-    
+
     consumer = CQRSConsumer(
         command_bus=local_cmd_bus,
         event_bus=local_evt_bus,
         serializer=serializer
     )
-    
+
     evt = DummyTaskEvent(info="consumed_event")
     payload = serializer.serialize(evt)
-    
+
     # Modificamos dummy_event_handler temporalmente para comprobar si fue llamado
     dummy_event_handler_was_called = False
-    
-    # Necesitamos mockear la funcion porque el import module va a buscar `dummy_event_handler` real
-    # Pero el resolve import funciona sobre modulos. Como esto es un script de tests,
-    # probaremos usando un modulo global conocido o un mock a _resolve_callable.
+
+    # Parcheamos la resolución con monkeypatch para que se restaure al terminar:
+    # asignar directamente sobre el módulo contamina los tests posteriores (P3-2).
     import hexcore.infrastructure.workers.consumer as consumer_module
-    
+
     async def mock_handler(e):
         nonlocal dummy_event_handler_was_called
         dummy_event_handler_was_called = True
-    
-    consumer_module._resolve_callable = lambda x: mock_handler
-    
-    await consumer.process_handler("tests.test_smart_routing.dummy_event_handler", payload)
-    
+
+    monkeypatch.setattr(consumer_module, "_resolve_callable", lambda x: mock_handler)
+
+    await consumer.process_handler(f"{__name__}.dummy_event_handler", payload)
+
     assert dummy_event_handler_was_called is True
 
 
@@ -190,29 +189,40 @@ async def test_background_handler_raises_if_no_enqueuer():
 
 
 @pytest.mark.anyio
-async def test_cqrs_consumer_processes_generic_task():
+async def test_cqrs_consumer_processes_generic_task(monkeypatch):
     local_cmd_bus = AsyncMock()
     local_evt_bus = AsyncMock()
     serializer = PydanticSerializer()
-    
+
     consumer = CQRSConsumer(
         command_bus=local_cmd_bus,
         event_bus=local_evt_bus,
         serializer=serializer
     )
-    
+
     generic_task_was_called = False
-    
+
     import hexcore.infrastructure.workers.consumer as consumer_module
-    
+
     async def mock_task(**kwargs):
         nonlocal generic_task_was_called
         assert kwargs["days"] == 30
         generic_task_was_called = True
-    
-    consumer_module._resolve_callable = lambda x: mock_task
-    
+
+    monkeypatch.setattr(consumer_module, "_resolve_callable", lambda x: mock_task)
+
     await consumer.process_task("my_maintenance_task", {"days": 30})
-    
+
     assert generic_task_was_called is True
+
+
+def test_resolve_callable_is_not_left_patched():
+    """
+    P3-2: los tests anteriores parcheaban `_resolve_callable` sin restaurarlo, así
+    que cualquier test posterior en el mismo proceso veía el parche.
+    """
+    from hexcore.infrastructure.workers.consumer import _resolve_callable
+
+    with pytest.raises(RuntimeError):
+        _resolve_callable("modulo.que.no.existe.jamas")
 

--- a/tests/test_task_queues_adapters.py
+++ b/tests/test_task_queues_adapters.py
@@ -72,11 +72,30 @@ async def test_procrastinate_enqueuer():
 def test_register_procrastinate_tasks():
     mock_app = MagicMock()
     mock_consumer = MagicMock()
-    
+
     register_hexcore_procrastinate_tasks(mock_app, mock_consumer)
-    
+
     assert mock_app.task.call_count == 3
     args = [call.kwargs.get("name") for call in mock_app.task.call_args_list]
     assert "hexcore.process_command" in args
     assert "hexcore.process_handler" in args
     assert "hexcore.process_task" in args
+
+
+# ── P1-3: enqueue_event no puede tragarse el evento en silencio ───────────────
+
+
+@pytest.mark.anyio
+async def test_procrastinate_enqueue_event_raises_instead_of_losing_the_event():
+    enqueuer = ProcrastinateEnqueuer(MagicMock())
+
+    with pytest.raises(NotImplementedError, match="background_handler"):
+        await enqueuer.enqueue_event("SomeEvent", {"data": 1}, "default")
+
+
+@pytest.mark.anyio
+async def test_celery_enqueue_event_raises_instead_of_losing_the_event():
+    enqueuer = CeleryEnqueuer(MagicMock())
+
+    with pytest.raises(NotImplementedError, match="background_handler"):
+        await enqueuer.enqueue_event("SomeEvent", {"data": 1}, "default")

--- a/tests/test_worker_bus_integration.py
+++ b/tests/test_worker_bus_integration.py
@@ -1,0 +1,271 @@
+"""
+Tests de integración bus + consumer con buses **reales** (no AsyncMock).
+
+Cubre P0-1 y P0-2 del plan de mejora: el worker debe *ejecutar* los mensajes de
+background que saca de la cola, no reencolarlos. Con un `AsyncMock` como bus estos
+bugs son invisibles, que es exactamente por qué pasaron el CI.
+"""
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from hexcore.application.cqrs.in_memory_buses import InMemoryCommandBus, InMemoryEventBus
+from hexcore.application.cqrs.registry import HandlerRegistry
+from hexcore.domain.cqrs.commands import Command
+from hexcore.domain.cqrs.decorators import (
+    background_command,
+    background_handler,
+    background_task,
+)
+from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
+from hexcore.domain.events import DomainEvent
+from hexcore.infrastructure.cqrs.pydantic_serializer import PydanticSerializer
+from hexcore.infrastructure.workers.consumer import CQRSConsumer
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class SpyEnqueuer(ITaskEnqueuer):
+    """Enqueuer que sólo anota lo que se le pide encolar."""
+
+    def __init__(self) -> None:
+        self.commands: list[tuple[str, dict[str, t.Any], str]] = []
+        self.events: list[tuple[str, dict[str, t.Any], str]] = []
+        self.handlers: list[tuple[str, dict[str, t.Any], str]] = []
+        self.tasks: list[tuple[str, dict[str, t.Any], str]] = []
+
+    async def enqueue_command(self, command_name: str, payload: dict[str, t.Any], queue: str) -> None:
+        self.commands.append((command_name, payload, queue))
+
+    async def enqueue_event(self, event_name: str, payload: dict[str, t.Any], queue: str) -> None:
+        self.events.append((event_name, payload, queue))
+
+    async def enqueue_handler(self, handler_name: str, payload: dict[str, t.Any], queue: str) -> None:
+        self.handlers.append((handler_name, payload, queue))
+
+    async def enqueue_task(self, task_name: str, payload: dict[str, t.Any], queue: str) -> None:
+        self.tasks.append((task_name, payload, queue))
+
+
+# ── Mensajes y handlers a nivel de módulo (resolubles desde un worker) ──────────
+
+HANDLED: list[str] = []
+NESTED_HANDLED: list[str] = []
+EVENT_HANDLED: list[str] = []
+
+
+@background_command(queue="reactive")
+class ReactiveCommand(Command):
+    value: str
+
+
+class ReactiveCommandHandler:
+    async def handle(self, cmd: ReactiveCommand) -> str:
+        HANDLED.append(cmd.value)
+        return f"ok:{cmd.value}"
+
+
+@background_command(queue="nested")
+class NestedCommand(Command):
+    value: str
+
+
+class NestedCommandHandler:
+    async def handle(self, cmd: NestedCommand) -> None:
+        NESTED_HANDLED.append(cmd.value)
+
+
+class SyncCommand(Command):
+    value: str
+
+
+class DispatchingCommandHandler:
+    """Handler síncrono que despacha *a propósito* un comando de background."""
+
+    def __init__(self, bus: InMemoryCommandBus) -> None:
+        self._bus = bus
+
+    async def handle(self, cmd: SyncCommand) -> None:
+        HANDLED.append(cmd.value)
+        await self._bus.dispatch(NestedCommand(value=f"nested:{cmd.value}"))
+
+
+class IntegrationEvent(DomainEvent):
+    info: str
+
+
+@background_handler(queue="analytics")
+async def on_integration_event(event: IntegrationEvent) -> None:
+    EVENT_HANDLED.append(event.info)
+
+
+@pytest.fixture(autouse=True)
+def _reset_spies():
+    HANDLED.clear()
+    NESTED_HANDLED.clear()
+    EVENT_HANDLED.clear()
+    yield
+    HANDLED.clear()
+    NESTED_HANDLED.clear()
+    EVENT_HANDLED.clear()
+
+
+def _build(registry: HandlerRegistry | None = None):
+    registry = registry or HandlerRegistry()
+    enqueuer = SpyEnqueuer()
+    serializer = PydanticSerializer()
+    command_bus = InMemoryCommandBus(
+        registry=registry, enqueuer=enqueuer, serializer=serializer
+    )
+    event_bus = InMemoryEventBus(enqueuer=enqueuer, serializer=serializer)
+    consumer = CQRSConsumer(
+        command_bus=command_bus, event_bus=event_bus, serializer=serializer
+    )
+    return registry, enqueuer, serializer, command_bus, event_bus, consumer
+
+
+# ── P0-1 ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_worker_executes_background_command_instead_of_reenqueueing():
+    """El bug original: el worker reencolaba el comando en bucle infinito."""
+    registry, enqueuer, serializer, _bus, _evt, consumer = _build()
+    registry.register_command_handler(ReactiveCommand, ReactiveCommandHandler())
+
+    await consumer.process_command(serializer.serialize(ReactiveCommand(value="x")))
+
+    assert HANDLED == ["x"], "el handler del comando de background no se ejecutó"
+    assert enqueuer.commands == [], "el worker reencoló el comando en vez de ejecutarlo"
+
+
+@pytest.mark.anyio
+async def test_same_bus_outside_worker_still_enqueues():
+    """Fuera del worker, el mismo bus debe seguir encolando."""
+    registry, enqueuer, _ser, bus, _evt, _consumer = _build()
+    registry.register_command_handler(ReactiveCommand, ReactiveCommandHandler())
+
+    result = await bus.dispatch(ReactiveCommand(value="y"))
+
+    assert result is None
+    assert HANDLED == []
+    assert [name for name, _p, _q in enqueuer.commands] == ["ReactiveCommand"]
+    assert enqueuer.commands[0][2] == "reactive"
+
+
+@pytest.mark.anyio
+async def test_nested_dispatch_from_handler_still_enqueues():
+    """
+    El contextvar no debe convertir el worker en "todo local para siempre":
+    un comando que el handler despacha a propósito sigue yendo a la cola.
+    """
+    registry, enqueuer, serializer, bus, _evt, consumer = _build()
+    registry.register_command_handler(SyncCommand, DispatchingCommandHandler(bus))
+    registry.register_command_handler(NestedCommand, NestedCommandHandler())
+
+    await consumer.process_command(serializer.serialize(SyncCommand(value="outer")))
+
+    assert HANDLED == ["outer"]
+    assert NESTED_HANDLED == [], "el comando anidado se ejecutó inline en vez de encolarse"
+    assert [name for name, _p, _q in enqueuer.commands] == ["NestedCommand"]
+
+
+@pytest.mark.anyio
+async def test_worker_context_is_reset_after_processing():
+    """Tras procesar, el proceso vuelve a encolar los comandos de background."""
+    registry, enqueuer, serializer, bus, _evt, consumer = _build()
+    registry.register_command_handler(ReactiveCommand, ReactiveCommandHandler())
+
+    await consumer.process_command(serializer.serialize(ReactiveCommand(value="a")))
+    await bus.dispatch(ReactiveCommand(value="b"))
+
+    assert HANDLED == ["a"]
+    assert len(enqueuer.commands) == 1
+
+
+# ── P0-2 ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_worker_executes_background_event_handler():
+    """Mismo bucle que P0-1, por la vía del EventBus."""
+    _registry, enqueuer, serializer, _bus, event_bus, consumer = _build()
+    event_bus.subscribe(IntegrationEvent, on_integration_event)
+
+    await consumer.process_event(serializer.serialize(IntegrationEvent(info="evt")))
+
+    assert EVENT_HANDLED == ["evt"]
+    assert enqueuer.handlers == [], "el worker reencoló el event handler de background"
+
+
+@pytest.mark.anyio
+async def test_event_bus_outside_worker_still_enqueues_background_handler():
+    _registry, enqueuer, _ser, _bus, event_bus, _consumer = _build()
+    event_bus.subscribe(IntegrationEvent, on_integration_event)
+
+    await event_bus.publish(IntegrationEvent(info="evt"))
+
+    assert EVENT_HANDLED == []
+    assert len(enqueuer.handlers) == 1
+    assert enqueuer.handlers[0][2] == "analytics"
+
+
+@pytest.mark.anyio
+async def test_sync_event_handler_runs_in_worker_and_outside():
+    _registry, enqueuer, serializer, _bus, event_bus, consumer = _build()
+    seen: list[str] = []
+
+    async def sync_handler(event: IntegrationEvent) -> None:
+        seen.append(event.info)
+
+    event_bus.subscribe(IntegrationEvent, sync_handler)
+
+    await event_bus.publish(IntegrationEvent(info="local"))
+    await consumer.process_event(serializer.serialize(IntegrationEvent(info="worker")))
+
+    assert seen == ["local", "worker"]
+    assert enqueuer.handlers == []
+
+
+# ── Camino de handler individual y tarea genérica (con resolución real) ────────
+
+
+@pytest.mark.anyio
+async def test_consumer_resolves_module_level_handler():
+    _registry, _enq, serializer, _bus, _evt, consumer = _build()
+
+    await consumer.process_handler(
+        f"{__name__}.on_integration_event",
+        serializer.serialize(IntegrationEvent(info="direct")),
+    )
+
+    assert EVENT_HANDLED == ["direct"]
+
+
+class Jobs:
+    """Contenedor de tareas: ejercita la resolución de __qualname__ anidado (P0-3)."""
+
+    ran: list[int] = []
+
+    @staticmethod
+    @background_task(queue="maintenance")
+    async def cleanup(days: int) -> None:
+        Jobs.ran.append(days)
+
+
+@pytest.mark.anyio
+async def test_consumer_resolves_nested_static_method_task():
+    _registry, _enq, _ser, _bus, _evt, consumer = _build()
+    Jobs.ran.clear()
+
+    task_name = getattr(Jobs.cleanup, "__cqrs_task_name__")
+    assert task_name == f"{__name__}.Jobs.cleanup"
+
+    await consumer.process_task(task_name, {"days": 30})
+
+    assert Jobs.ran == [30]

--- a/uv.lock
+++ b/uv.lock
@@ -453,6 +453,7 @@ sql = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "anyio" },
     { name = "commitizen" },
     { name = "pyright" },
     { name = "pytest" },
@@ -491,6 +492,7 @@ provides-extras = ["api", "redis", "mongo", "sql", "rabbitmq", "procrastinate", 
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "anyio", specifier = ">=4.0.0" },
     { name = "commitizen", specifier = ">=4.9.1" },
     { name = "pyright", specifier = ">=1.1.405" },
     { name = "pytest", specifier = ">=8.4.2" },


### PR DESCRIPTION
**1º de 4.** Reemplaza a #29, que se mergeó contra `feat/dynamic-cronjobs` en vez de `master`
y por tanto no llegó a `master`. La descripción detallada por ítem está en **#29**.

**Ítems del plan:** P3-2, P0-3, P0-1, P0-2, P0-4, P0-6, P1-3 (Fase 1) + arreglo de CI.

## Contenido (7 commits)

| Ítem | Qué arregla |
| :-- | :-- |
| **P0-1/P0-2** | El worker **reencolaba** los `@background_command` en bucle infinito en vez de ejecutarlos. Sin excepción y sin log de error: la cola crecía sin límite y el handler no corría jamás. Contextvar `IN_WORKER`. |
| **P0-3** | `__qualname__` anidados (clases dentro de clases, tasks como `@staticmethod`) producían un module path inválido: el mensaje se encolaba bien y **fallaba en el worker**. Helper `resolve_dotted` + rechazo de `<locals>` al decorar. |
| **P0-4** | `PostgresLockProvider` nunca borraba las filas expiradas: ~10.000 filas/día **para siempre**. Purga amortizada + índice. |
| **P0-6** | `TransactionMiddleware` era el default y armaba la sesión con el engine equivocado, comiteando por segunda vez. |
| **P1-3** | `enqueue_event` era `pass`: el evento se perdía sin traza. |
| **P3-2** | Los tests del consumer contaminaban el proceso al no restaurar el parche. |
| **ci** | Ver abajo. |

## El arreglo de CI, que es importante por sí solo

El workflow tenía dos defectos, el segundo peor:

1. `pull_request.branches` sólo llevaba `master`, así que los PRs de una cadena apilada no
   disparaban ningún check.
2. La instalación era `pip install -e .` **sin extras**. Sin SQLAlchemy, FastAPI, Redis,
   aiosqlite ni httpx, los tests que dependen de ellos hacen `importorskip` y se saltan: de
   530 tests, **278 quedaban fuera** y el workflow reportaba verde habiendo ejecutado menos
   de la mitad.

Se pasa a `uv sync --extra all --group dev` (el lockfile como única fuente de verdad) y se
añade un guarda: el suite corre con `-rs` y un `SKIPPED` hace **fallar** el job. Con todos
los extras no hay ninguno, así que un skip sólo puede significar que un extra no llegó al
entorno.

De paso, `uv.lock` estaba desincronizado: `anyio` está en `pyproject.toml` desde `248eec8`
pero el lock nunca se regeneró.

## Riesgo / compatibilidad

⚠️ **BEHAVIOR CHANGE** — detalle en el CHANGELOG y en #29:
- Quien dependía del `TransactionMiddleware` por defecto pierde el commit automático (que era
  el segundo, o iba contra otro engine).
- `enqueue_event` ahora lanza donde antes callaba.
- `ValueError` nuevo al decorar una función local.

Ninguna firma cambia.

## Verificación

`171 passed, 0 skipped` con los comandos exactos del workflow (`uv sync --extra all --group
dev` + `uv run python -m pytest -q -rs`). Con el fix de producción revertido, **9 de los
tests nuevos fallan**.
