### PR TITLE
release 2.6.0 — operabilidad y cimientos de las factories

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -2,9 +2,17 @@ name: Python tests
 
 on:
   push:
-    branches: ["master"]
+    branches:
+      - master
+      - "release/**"
+      - "feat/**"
   pull_request:
-    branches: ["master"]
+    # Filtra por rama **base**, así que sin `release/**` y `feat/**` los PRs de una
+    # cadena apilada no disparan ningún check y el PR aparece sin CI.
+    branches:
+      - master
+      - "release/**"
+      - "feat/**"
 
 permissions:
   contents: read
@@ -17,17 +25,32 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up Python 3.12
-        uses: actions/setup-python@v5
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
         with:
-          python-version: "3.12"
+          enable-cache: true
 
       - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          pip install pytest anyio
-          pip install -e .
+        # `--extra all` es lo que hace que el suite se ejecute de verdad. Con sólo
+        # `pip install -e .` faltan SQLAlchemy, FastAPI, Redis, aiosqlite y httpx, así que
+        # los tests que dependen de ellos hacen `importorskip` y se saltan: CI reportaba
+        # verde habiendo ejecutado menos de la mitad.
+        # `--group dev` trae pytest, anyio y httpx desde el lockfile, para que el entorno
+        # de CI y el de desarrollo no se puedan desincronizar.
+        run: uv sync --extra all --group dev
 
       - name: Run tests
+        # `-rs` lista los tests saltados. Con todos los extras instalados no debe haber
+        # ninguno, así que un SKIPPED aquí significa que un extra no llegó al entorno y que
+        # estaríamos reportando verde habiendo saltado tests. Se falla a propósito.
+        # `python -m pytest` y no `pytest`: este proyecto no declara `build-system`, así que
+        # `uv sync` no lo instala en el venv y el script `pytest` no vería el paquete
+        # `hexcore`. Con `-m`, el directorio de trabajo entra en `sys.path`.
         run: |
-          pytest -q
+          set -o pipefail
+          uv run python -m pytest -q -rs | tee pytest-output.txt
+          if grep -q '^SKIPPED' pytest-output.txt; then
+            echo "::error::Hay tests saltados: falta alguna dependencia opcional en el entorno de CI."
+            grep '^SKIPPED' pytest-output.txt
+            exit 1
+          fi

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@
   (100 por defecto), crea un índice sobre `expires_at`, y expone `purge_expired()`
   (P0-4)
 
+### Behavior change
+
+- **cqrs**: `TransactionMiddleware` deja de ser el middleware por defecto de
+  `CQRSConfig.command_bus`, y `TransactionMiddleware()` sin `uow_factory` ahora lanza
+  `ValueError` en vez de adivinar. El default armaba la sesión con el session factory
+  *interno* de HexCore en vez del engine de la aplicación, y comiteaba después del
+  handler — así que un handler que ya comitea (el patrón que enseña la doc para los
+  use cases) comiteaba dos veces (P0-6)
+- **task_queues**: `enqueue_event` de los adaptadores de Procrastinate y Celery lanza
+  `NotImplementedError` con instrucciones en vez de ser un `pass` que perdía el
+  evento sin traza (P1-3)
+
 ### Test
 
 - **cqrs**: los tests del consumer parcheaban `_resolve_callable` sin restaurarlo y

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@
   acotar el catch-up, aviso `RuntimeWarning` si el tick es sub-minuto y no hay
   `lock_provider`, primer tick sin esperar el intervalo, `stop()` interrumpible al
   instante, y `except` que loguean traceback en vez de tragarse el error (P1-1)
+- **cqrs**: `HandlerRegistry` es realmente thread-safe: el docstring lo afirmaba pero
+  no había ningún lock, y `resolve_*` hace lazy-init con escritura en el dict, así que
+  dos hilos podían instanciar el mismo handler dos veces (relevante con el
+  free-threading de Python 3.14). Nuevo `HandlerRegistry.factory(...)` como marcador
+  explícito de factory, para quitar la ambigüedad con los handlers que implementan
+  `__call__` (P1-5)
 - **cqrs**: `RedisLockProvider` y `PostgresLockProvider` aceptan
   `on_error: "skip" | "raise"`. Antes capturaban `Exception` y devolvían `False`
   siempre, así que una caída de Redis apagaba el cron **entero** con un `logger.error`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ### Fix
 
+- **cqrs**: el worker ya **ejecuta** los `@background_command` que saca de la cola en
+  vez de reencolarlos. Antes, pasarle al `CQRSConsumer` el mismo bus que usa el
+  proceso web —lo natural, y lo que sugería la documentación— producía un bucle
+  infinito silencioso: la cola crecía sin límite y el handler no corría jamás.
+  Nuevo contextvar `hexcore.domain.cqrs.context.IN_WORKER` (P0-1)
+- **cqrs**: mismo arreglo para los suscriptores marcados con `@background_handler`
+  cuando el evento llega por `CQRSConsumer.process_event` (P0-2)
 - **cqrs**: los FQN con `__qualname__` anidado (clases dentro de clases, tasks como
   `@staticmethod`) ya se resuelven bien. Antes `rsplit(".", 1)` producía un module
   path inválido y el mensaje se encolaba correctamente para **fallar en el worker**.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 ## Unreleased
 
+### Fix
+
+- **cqrs**: los FQN con `__qualname__` anidado (clases dentro de clases, tasks como
+  `@staticmethod`) ya se resuelven bien. Antes `rsplit(".", 1)` producía un module
+  path inválido y el mensaje se encolaba correctamente para **fallar en el worker**.
+  Nuevo helper `hexcore.domain.cqrs.resolution.resolve_dotted`, usado por
+  `PydanticSerializer.deserialize` y por `_resolve_callable` del consumer (P0-3)
+- **cqrs**: `@background_command` / `@background_handler` / `@background_task` ahora
+  rechazan en tiempo de decoración los objetos con `<locals>` en su `__qualname__`:
+  una función definida dentro de otra función nunca será importable desde el worker
+  (P0-3)
+
 ### Test
 
 - **cqrs**: los tests del consumer parcheaban `_resolve_callable` sin restaurarlo y

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,14 @@
 
 ### Feat
 
+- **cqrs**: `DynamicScheduler` implementa el catch-up que la versión anterior sólo
+  insinuaba: decide por "¿hubo alguna ocurrencia entre la última ejecución y ahora?"
+  en vez de `croniter.match(expr, minuto_actual)`. Con eso un minuto saltado por
+  drift del tick ya no pierde la ejecución, y `update_last_run` deduplica de verdad
+  cuando `tick_interval_seconds < 60`. Nuevo `catch_up_window_seconds` (1h) para
+  acotar el catch-up, aviso `RuntimeWarning` si el tick es sub-minuto y no hay
+  `lock_provider`, primer tick sin esperar el intervalo, `stop()` interrumpible al
+  instante, y `except` que loguean traceback en vez de tragarse el error (P1-1)
 - **cqrs**: `CQRSFactory` acepta un `enqueuer` y lo propaga junto al serializer a los
   buses in-memory, así que la vía oficial de construcción ya sirve para Smart Routing
   sin cablear los buses a mano. Si hay `@background_command` registrados y falta el

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,15 @@
   (100 por defecto), crea un índice sobre `expires_at`, y expone `purge_expired()`
   (P0-4)
 
+### Feat
+
+- **cqrs**: `CQRSFactory` acepta un `enqueuer` y lo propaga junto al serializer a los
+  buses in-memory, así que la vía oficial de construcción ya sirve para Smart Routing
+  sin cablear los buses a mano. Si hay `@background_command` registrados y falta el
+  enqueuer, falla **al construir** con el nombre de los comandos afectados, no en el
+  primer dispatch. El serializer se cachea para que buses y consumer compartan
+  instancia (P0-5)
+
 ### Behavior change
 
 - **cqrs**: `TransactionMiddleware` deja de ser el middleware por defecto de

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@
   acotar el catch-up, aviso `RuntimeWarning` si el tick es sub-minuto y no hay
   `lock_provider`, primer tick sin esperar el intervalo, `stop()` interrumpible al
   instante, y `except` que loguean traceback en vez de tragarse el error (P1-1)
+- **cqrs**: `RedisLockProvider` y `PostgresLockProvider` aceptan
+  `on_error: "skip" | "raise"`. Antes capturaban `Exception` y devolvían `False`
+  siempre, así que una caída de Redis apagaba el cron **entero** con un `logger.error`
+  por job y por tick indistinguible del caso normal. Ahora "no pude decidir" se loguea
+  como `critical` y "el lock estaba tomado" como `debug` (P1-2)
 - **cqrs**: `CQRSFactory` acepta un `enqueuer` y lo propaga junto al serializer a los
   buses in-memory, así que la vía oficial de construcción ya sirve para Smart Routing
   sin cablear los buses a mano. Si hay `@background_command` registrados y falta el

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,11 @@
   rechazan en tiempo de decoración los objetos con `<locals>` en su `__qualname__`:
   una función definida dentro de otra función nunca será importable desde el worker
   (P0-3)
+- **cqrs**: `PostgresLockProvider` ya no filtra filas indefinidamente. Con una clave
+  por `(job_id, minuto)` y 7 jobs eran ~10.000 filas/día **para siempre** en la BD
+  principal. Ahora purga lo expirado en `setup()` y cada `purge_every` adquisiciones
+  (100 por defecto), crea un índice sobre `expires_at`, y expone `purge_expired()`
+  (P0-4)
 
 ### Test
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,11 @@
   acotar el catch-up, aviso `RuntimeWarning` si el tick es sub-minuto y no hay
   `lock_provider`, primer tick sin esperar el intervalo, `stop()` interrumpible al
   instante, y `except` que loguean traceback en vez de tragarse el error (P1-1)
+- **task_queues**: `register_hexcore_procrastinate_tasks` y
+  `register_hexcore_celery_tasks` son idempotentes y devuelven `bool`; se añade
+  `is_registered(app)` y `force=True`. Antes llamarlas dos veces reventaba porque la
+  cola rechaza nombres duplicados, así que cada aplicación tenía que protegerlas con
+  un flag de módulo (P1-6)
 - **cqrs**: `HandlerRegistry` es realmente thread-safe: el docstring lo afirmaba pero
   no había ningún lock, y `resolve_*` hace lazy-init con escritura en el dict, así que
   dos hilos podían instanciar el mismo handler dos veces (relevante con el

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,19 @@
   acotar el catch-up, aviso `RuntimeWarning` si el tick es sub-minuto y no hay
   `lock_provider`, primer tick sin esperar el intervalo, `stop()` interrumpible al
   instante, y `except` que loguean traceback en vez de tragarse el error (P1-1)
+- **sql**: capa de sesión usable en producción. `init_engine(url=None, *, pool=PoolSettings(), **engine_kwargs)`
+  y `dispose_engine()`; `PoolSettings` (`size`, `max_overflow`, `pre_ping`, `recycle`)
+  con `pre_ping=True` por defecto; normalización del DSN (`postgresql://` →
+  `postgresql+asyncpg://`, expuesta como `normalize_async_dsn`); URL explícita para
+  workers, scripts y tests; y lock alrededor de los globals `_engine`/`_session_factory`
+  (F2)
+- **uow**: `session_scope`, `uow_scope`, `open_uow_scope` y `nosql_uow_scope` en
+  `hexcore.infrastructure.uow` — scopes para workers, cron, scripts y seeds, donde
+  antes sólo había dependencias de FastAPI. `session_scope` no construye el UoW, así
+  que no paga el auto-discovery de repositorios para leer una tabla de infraestructura
+  (F3)
+- **api**: nueva dependencia `get_sql_uow_open` para endpoints que quieren el UoW ya
+  abierto (F3)
 - **cqrs**: `CQRSConsumer(command_bus)` — `event_bus` y `serializer` pasan a ser
   opcionales. Un worker sólo-comandos ya no necesita `cast(Any, None)`, y si llega un
   evento sin event bus el error dice qué hacer. `serializer` cae en
@@ -63,6 +76,16 @@
 
 ### Behavior change
 
+- **sql**: el session factory de HexCore pasa a `expire_on_commit=False`. Con el
+  default de SQLAlchemy (`True`) los atributos de las entidades expiran al comitear y
+  el siguiente acceso dispara un lazy-load sobre una sesión cerrada
+  (`MissingGreenlet` / `DetachedInstanceError`) — y la documentación ya enseñaba
+  `async_sessionmaker(engine, expire_on_commit=False)`, o sea que doc e
+  implementación no coincidían. Quien necesite `True` debe construir su propio
+  `async_sessionmaker` (F2)
+- **api**: `get_sql_uow` ya **no entra** al UoW: cede el UoW sin abrir la transacción,
+  para que el use case controle su propio `async with uow:` sin anidar contextos. Si
+  dependías del comportamiento anterior, usá `get_sql_uow_open` (F3)
 - **cqrs**: `TransactionMiddleware` deja de ser el middleware por defecto de
   `CQRSConfig.command_bus`, y `TransactionMiddleware()` sin `uow_factory` ahora lanza
   `ValueError` en vez de adivinar. El default armaba la sesión con el session factory

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,10 @@
   acotar el catch-up, aviso `RuntimeWarning` si el tick es sub-minuto y no hay
   `lock_provider`, primer tick sin esperar el intervalo, `stop()` interrumpible al
   instante, y `except` que loguean traceback en vez de tragarse el error (P1-1)
+- **cqrs**: `CQRSConsumer(command_bus)` — `event_bus` y `serializer` pasan a ser
+  opcionales. Un worker sólo-comandos ya no necesita `cast(Any, None)`, y si llega un
+  evento sin event bus el error dice qué hacer. `serializer` cae en
+  `PydanticSerializer` (P2-2)
 - **task_queues**: `register_hexcore_procrastinate_tasks` y
   `register_hexcore_celery_tasks` son idempotentes y devuelven `bool`; se añade
   `is_registered(app)` y `force=True`. Antes llamarlas dos veces reventaba porque la

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## Unreleased
+
+### Test
+
+- **cqrs**: los tests del consumer parcheaban `_resolve_callable` sin restaurarlo y
+  contaminaban cualquier test posterior del mismo proceso; ahora usan `monkeypatch`
+  (P3-2)
+
 ## 2.0.6 (2026-06-25)
 
 ### Fix

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ HexCore v2 integra de forma nativa soporte para el patrón **CQRS (Command Query
 
 El sistema se basa en 3 buses principales, configurables e independientes:
 
-1. **`AbstractCommandBus`**: Despacha inteniones de mutación (`Command`) a un único `AbstractCommandHandler`. Los commands modifican el estado del sistema y se ejecutan (por defecto) dentro de una transacción de base de datos (Unit of Work).
+1. **`AbstractCommandBus`**: Despacha inteniones de mutación (`Command`) a un único `AbstractCommandHandler`. Los commands modifican el estado del sistema. La transacción la gestiona el handler (el patrón que enseñan los ejemplos de use case); si preferís que la gestione el bus, añadí `TransactionMiddleware` explícitamente con su `uow_factory`.
 2. **`AbstractQueryBus`**: Despacha intenciones de lectura (`Query`) a un único `AbstractQueryHandler`. Retornan un resultado sin mutar el estado.
 3. **`EventBus`**: Distribuye eventos de dominio (`DomainEvent`) a múltiples suscriptores asíncronamente (vía `subscribe`/`publish`).
 
@@ -265,14 +265,24 @@ from hexcore.application.cqrs.config import CQRSConfig, BusConfig
 config = ServerConfig(
     cqrs=CQRSConfig(
         command_bus=BusConfig(
-            # Por defecto incluye TransactionMiddleware
-            middlewares=["hexcore.infrastructure.cqrs.middlewares.TransactionMiddleware"]
+            # Sin middlewares por defecto. Los que no necesitan configuración se
+            # pueden declarar por dotted path:
+            middlewares=["hexcore.infrastructure.cqrs.middlewares.LoggingMiddleware"]
         ),
         # Puedes sustituir el backend en memoria por uno distribuido (Ej: Celery, Procrastinate)
         # backend="mi_app.infrastructure.ProcrastinateCommandBus" 
     )
 )
 ```
+
+> **`TransactionMiddleware` no es el default.** Comitea después del handler, así que
+> con un handler que ya gestiona su propia transacción comitearías dos veces. Y
+> necesita un `uow_factory` construido con *tu* engine, cosa que no se puede expresar
+> como dotted path: instancialo a mano y pasá el pipeline al bus.
+>
+> ```python
+> TransactionMiddleware(uow_factory=lambda: SqlAlchemyUnitOfWork(session=session_factory()))
+> ```
 
 ---
 

--- a/hexcore/application/cqrs/config.py
+++ b/hexcore/application/cqrs/config.py
@@ -55,13 +55,12 @@ class CQRSConfig(BaseModel):
     """
 
     enabled: bool = True
-    command_bus: BusConfig = Field(
-        default_factory=lambda: BusConfig(
-            middlewares=[
-                "hexcore.infrastructure.cqrs.middlewares.TransactionMiddleware"
-            ]
-        )
-    )
+    # Sin middlewares por defecto (P0-6). `TransactionMiddleware` *era* el default,
+    # pero adivinaba la sesión con el session factory interno de HexCore en vez del
+    # engine de la aplicación, y comiteaba por segunda vez sobre los handlers que ya
+    # gestionan su transacción. Si lo querés, declaralo explícitamente con su
+    # `uow_factory`.
+    command_bus: BusConfig = Field(default_factory=BusConfig)
     query_bus: BusConfig = Field(default_factory=BusConfig)
     event_bus: BusConfig = Field(default_factory=BusConfig)
     serializer: t.Optional[str] = None  # None = PydanticSerializer por defecto

--- a/hexcore/application/cqrs/factory.py
+++ b/hexcore/application/cqrs/factory.py
@@ -10,6 +10,7 @@ import typing as t
 from hexcore.domain.cqrs.buses import ICommandBus, IQueryBus, IEventBus
 from hexcore.domain.cqrs.middleware import IMiddleware
 from hexcore.domain.cqrs.serializer import ISerializer
+from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
 
 from .config import CQRSConfig, BusConfig
 from .registry import HandlerRegistry
@@ -25,11 +26,31 @@ def _import_class(dotted_path: str) -> type:
 
 
 def _build_middlewares(dotted_paths: list[str]) -> list[IMiddleware]:
-    """Instancia middlewares a partir de sus dotted paths."""
+    """
+    Instancia middlewares a partir de sus dotted paths.
+
+    Sólo sirve para middlewares construibles sin argumentos. Los que necesitan
+    configuración (p. ej. `TransactionMiddleware`, que requiere un `uow_factory`
+    atado al engine de la aplicación) hay que instanciarlos a mano y pasar el
+    `MiddlewarePipeline` al bus.
+    """
     middlewares: list[IMiddleware] = []
     for path in dotted_paths:
         cls = _import_class(path)
-        middlewares.append(cls())
+        try:
+            middlewares.append(cls())
+        except TypeError as exc:
+            raise TypeError(
+                f"El middleware '{path}' no se puede construir sin argumentos: {exc}. "
+                "Declararlo por dotted path sólo funciona para middlewares sin "
+                "configuración; instancialo a mano y pasá el MiddlewarePipeline al bus."
+            ) from exc
+        except ValueError as exc:
+            raise ValueError(
+                f"El middleware '{path}' rechazó su construcción por defecto: {exc} "
+                "Declararlo por dotted path sólo funciona para middlewares sin "
+                "configuración; instancialo a mano y pasá el MiddlewarePipeline al bus."
+            ) from exc
     return middlewares
 
 
@@ -52,40 +73,63 @@ class CQRSFactory:
         registry = HandlerRegistry()
         # ...registrar handlers...
 
-        factory = CQRSFactory(config, registry)
+        factory = CQRSFactory(config, registry, enqueuer=ProcrastinateEnqueuer(app))
         command_bus = factory.create_command_bus()
         query_bus = factory.create_query_bus()
+        event_bus = factory.create_event_bus()
+
+    El `enqueuer` es lo que habilita el Smart Routing: sin él, los buses in-memory
+    no pueden enrutar un `@background_command` y la factory lo dice **al construir**,
+    no en el primer dispatch.
     """
 
     def __init__(
         self,
         config: CQRSConfig,
         registry: HandlerRegistry,
+        enqueuer: ITaskEnqueuer | None = None,
     ) -> None:
         self._config = config
         self._registry = registry
+        self._enqueuer = enqueuer
+        self._serializer: ISerializer | None = None
 
     def create_serializer(self) -> ISerializer:
-        """Crea el serializer configurado (PydanticSerializer por defecto)."""
+        """
+        Crea el serializer configurado (PydanticSerializer por defecto).
+
+        La instancia se cachea: los buses y el consumer tienen que compartir el
+        mismo serializer para que el round-trip por la cola sea coherente.
+        """
+        if self._serializer is not None:
+            return self._serializer
+
         if self._config.serializer:
             cls = _import_class(self._config.serializer)
-            return cls()
-        from hexcore.infrastructure.cqrs.pydantic_serializer import PydanticSerializer
+            self._serializer = t.cast(ISerializer, cls())
+        else:
+            from hexcore.infrastructure.cqrs.pydantic_serializer import PydanticSerializer
 
-        return PydanticSerializer()
+            self._serializer = PydanticSerializer()
+        return self._serializer
 
     def create_command_bus(self, **extra_kwargs: t.Any) -> ICommandBus:
         """
         Crea el CommandBus configurado.
-        Si no hay backend explícito, retorna InMemoryCommandBus.
+        Si no hay backend explícito, retorna InMemoryCommandBus con el enqueuer y el
+        serializer necesarios para el Smart Routing.
         """
         bus_config = self._config.command_bus
         pipeline = _build_pipeline(bus_config)
 
         if bus_config.backend is None:
+            self._assert_enqueuer_for_background_commands()
             return InMemoryCommandBus(
                 registry=self._registry,
                 pipeline=pipeline,
+                enqueuer=self._enqueuer,
+                serializer=self.create_serializer(),
+                **extra_kwargs,
             )
 
         # Backend personalizado (ej. ProcrastinateCommandBus)
@@ -119,13 +163,53 @@ class CQRSFactory:
             **bus_config.options,
         )
 
-    def create_event_bus(self) -> IEventBus:
-        """Crea el EventBus configurado."""
+    def create_event_bus(self, **extra_kwargs: t.Any) -> IEventBus:
+        """
+        Crea el EventBus configurado.
+
+        Al bus in-memory se le pasan enqueuer y serializer para que los suscriptores
+        marcados con `@background_handler` se puedan enrutar.
+        """
         bus_config = self._config.event_bus
         pipeline = _build_pipeline(bus_config)
 
         if bus_config.backend is None:
-            return InMemoryEventBus(pipeline=pipeline)
+            return InMemoryEventBus(
+                pipeline=pipeline,
+                enqueuer=self._enqueuer,
+                serializer=self.create_serializer(),
+                **extra_kwargs,
+            )
 
         cls = _import_class(bus_config.backend)
-        return cls(pipeline=pipeline, **bus_config.options)
+        return cls(
+            pipeline=pipeline,
+            **bus_config.options,
+            **extra_kwargs,
+        )
+
+    # ── Validación ────────────────────────────────────────────────────────────
+
+    def _assert_enqueuer_for_background_commands(self) -> None:
+        """
+        Falla al construir si hay commands de background registrados y no hay
+        enqueuer. El error en el primer dispatch llega demasiado tarde: para
+        entonces la petición del usuario ya está en vuelo.
+        """
+        if self._enqueuer is not None:
+            return
+
+        background = [
+            command_type.__name__
+            for command_type in self._registry.registered_commands
+            if getattr(command_type, "__cqrs_background__", False)
+        ]
+        if not background:
+            return
+
+        raise RuntimeError(
+            "CQRSFactory no tiene 'enqueuer', pero hay commands decorados con "
+            f"@background_command: {', '.join(sorted(background))}. "
+            "Pasá un ITaskEnqueuer al construir la factory, p. ej. "
+            "CQRSFactory(config, registry, enqueuer=ProcrastinateEnqueuer(app))."
+        )

--- a/hexcore/application/cqrs/in_memory_buses.py
+++ b/hexcore/application/cqrs/in_memory_buses.py
@@ -8,6 +8,7 @@ import logging
 
 from hexcore.domain.cqrs.buses import ICommandBus, IQueryBus, IEventBus
 from hexcore.domain.cqrs.commands import Command
+from hexcore.domain.cqrs.context import is_worker_execution, local_execution
 from hexcore.domain.cqrs.queries import Query
 from hexcore.domain.events import DomainEvent
 from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
@@ -28,6 +29,10 @@ class InMemoryCommandBus(ICommandBus):
     Si el comando está decorado con `@background_command` y se provee un `enqueuer`,
     el comando es automáticamente encolado para su ejecución en segundo plano
     sin bloquear el proceso actual (retornando None).
+
+    Cuando el mensaje viene de un worker (``IN_WORKER`` activo, lo pone el
+    ``CQRSConsumer``), el bus lo ejecuta **localmente** en vez de reencolarlo.
+    Esto permite usar el mismo bus en el proceso web y en el worker.
     """
 
     def __init__(
@@ -44,17 +49,19 @@ class InMemoryCommandBus(ICommandBus):
 
     async def dispatch(self, command: Command) -> t.Any:
         cmd_type = type(command)
-        
+
         # 1. Smart Routing: ¿Debe irse a background?
+        # Si ya estamos dentro de un worker, el mensaje viene de la cola: hay que
+        # ejecutarlo, no volver a encolarlo.
         is_background = getattr(cmd_type, "__cqrs_background__", False)
-        
-        if is_background:
+
+        if is_background and not is_worker_execution():
             if not self._enqueuer or not self._serializer:
                 raise RuntimeError(
                     f"El comando '{cmd_type.__name__}' requiere ejecución en background, "
                     "pero el InMemoryCommandBus no tiene configurado un 'enqueuer' o 'serializer'."
                 )
-            
+
             async def background_dispatcher(cmd: Command) -> None:
                 queue_name = getattr(cmd_type, "__cqrs_queue__", "default")
                 payload = self._serializer.serialize(cmd) # type: ignore
@@ -70,7 +77,10 @@ class InMemoryCommandBus(ICommandBus):
         async def final_handler(cmd: t.Any) -> t.Any:
             return await handler.handle(cmd)
 
-        return await self._pipeline.execute(command, final_handler)
+        # `local_execution` consume el flag de worker: si el handler despacha otro
+        # `@background_command`, ese sí debe encolarse.
+        with local_execution():
+            return await self._pipeline.execute(command, final_handler)
 
 
 class InMemoryQueryBus(IQueryBus):
@@ -129,9 +139,15 @@ class InMemoryEventBus(IEventBus):
 
     async def publish(self, event: DomainEvent) -> None:
         handlers = self._handlers.get(type(event), [])
+        # Si el evento viene de un worker, sus handlers de background se ejecutan
+        # aquí; reencolarlos sería un bucle infinito.
+        in_worker = is_worker_execution()
 
         for event_handler in handlers:
-            is_background = getattr(event_handler, "__cqrs_background_handler__", False)
+            is_background = (
+                getattr(event_handler, "__cqrs_background_handler__", False)
+                and not in_worker
+            )
 
             if is_background:
                 # Enrutamiento hacia background
@@ -161,4 +177,5 @@ class InMemoryEventBus(IEventBus):
                 ) -> None:
                     await _h(evt)
 
-                await self._pipeline.execute(event, final_handler)
+                with local_execution():
+                    await self._pipeline.execute(event, final_handler)

--- a/hexcore/application/cqrs/registry.py
+++ b/hexcore/application/cqrs/registry.py
@@ -4,6 +4,7 @@ Mapea tipos de Command/Query a sus handlers correspondientes.
 """
 from __future__ import annotations
 
+import threading
 import typing as t
 
 from hexcore.domain.cqrs.commands import Command
@@ -16,15 +17,45 @@ from hexcore.domain.cqrs.exceptions import HandlerNotFoundError, DuplicateHandle
 CommandHandlerFactory = t.Callable[[], ICommandHandler[t.Any, t.Any]]
 QueryHandlerFactory = t.Callable[[], IQueryHandler[t.Any, t.Any]]
 
+TFactory = t.TypeVar("TFactory")
+
+
+class HandlerFactory(t.Generic[TFactory]):
+    """
+    Marcador explícito de "esto es un factory, no un handler".
+
+    `callable(entry) and not isinstance(entry, ICommandHandler)` es ambiguo: un handler
+    que implemente `__call__` se confundiría con un factory, y un factory que herede de
+    la interfaz se confundiría con un handler. Envolver el callable elimina la
+    heurística.
+
+    No es obligatorio: registrar un `lambda` sigue funcionando (se detecta por
+    heurística, igual que antes) y `HandlerRegistry.factory()` construye el marcador
+    por ti.
+    """
+
+    __slots__ = ("build",)
+
+    def __init__(self, build: t.Callable[[], TFactory]) -> None:
+        self.build = build
+
+    def __call__(self) -> TFactory:
+        return self.build()
+
 
 class HandlerRegistry:
     """
-    Registro thread-safe de handlers para Commands y Queries.
+    Registro de handlers para Commands y Queries.
 
     Soporta dos modos de registro:
 
     1. Registro directo de instancias (eager)
     2. Registro de factories (lazy, para DI containers)
+
+    **Thread-safety.** El registro y la resolución están protegidos por un
+    `threading.RLock`. Hace falta porque `resolve_*` hace lazy-init con escritura en el
+    dict: sin lock, dos hilos (o dos hilos reales bajo el free-threading de Python
+    3.14) pueden instanciar el mismo handler dos veces y quedarse cada uno con la suya.
 
     Uso::
 
@@ -33,8 +64,10 @@ class HandlerRegistry:
         # Registro directo
         registry.register_command_handler(CreateUserCommand, CreateUserHandler())
 
-        # Registro con factory (lazy)
-        registry.register_command_handler(CreateUserCommand, lambda: container.get(CreateUserHandler))
+        # Registro con factory (lazy) — marcador explícito
+        registry.register_command_handler(
+            CreateUserCommand, HandlerRegistry.factory(lambda: container.get(CreateUserHandler))
+        )
 
         # Resolución
         handler = registry.resolve_command_handler(CreateUserCommand)
@@ -48,6 +81,20 @@ class HandlerRegistry:
             type[Query[t.Any]], IQueryHandler[t.Any, t.Any] | QueryHandlerFactory
         ] = {}
         self._allow_override = allow_override
+        # Reentrante: un factory puede resolver otro handler del mismo registry.
+        self._lock = threading.RLock()
+
+    # ── Factories ─────────────────────────────────────────────────────────────
+
+    @staticmethod
+    def factory(build: t.Callable[[], t.Any]) -> HandlerFactory[t.Any]:
+        """
+        Envuelve un callable para registrarlo como factory sin ambigüedad.
+
+        Preferí esto a pasar el callable pelado cuando tu handler implementa
+        `__call__`, porque entonces la heurística no puede distinguirlos.
+        """
+        return HandlerFactory(build)
 
     # ── Command Handlers ──────────────────────────────────────────
 
@@ -57,24 +104,26 @@ class HandlerRegistry:
         handler: ICommandHandler[t.Any, t.Any] | CommandHandlerFactory,
     ) -> "HandlerRegistry":
         """Registra un handler (o factory) para un tipo de command. Retorna self para fluent API."""
-        if not self._allow_override and command_type in self._command_handlers:
-            raise DuplicateHandlerError(command_type)
-        self._command_handlers[command_type] = handler
+        with self._lock:
+            if not self._allow_override and command_type in self._command_handlers:
+                raise DuplicateHandlerError(command_type)
+            self._command_handlers[command_type] = handler
         return self
 
     def resolve_command_handler(
         self, command_type: type[Command]
     ) -> ICommandHandler[t.Any, t.Any]:
         """Resuelve el handler para el tipo de command dado."""
-        entry = self._command_handlers.get(command_type)
-        if entry is None:
-            raise HandlerNotFoundError(command_type)
-        if callable(entry) and not isinstance(entry, ICommandHandler):
-            # Es un factory, invocar y cachear la instancia
-            handler = entry()
-            self._command_handlers[command_type] = handler
-            return handler
-        return t.cast(ICommandHandler[t.Any, t.Any], entry)
+        with self._lock:
+            entry = self._command_handlers.get(command_type)
+            if entry is None:
+                raise HandlerNotFoundError(command_type)
+            if _is_factory(entry, ICommandHandler):
+                # Es un factory, invocar y cachear la instancia
+                handler = t.cast(CommandHandlerFactory, entry)()
+                self._command_handlers[command_type] = handler
+                return handler
+            return t.cast(ICommandHandler[t.Any, t.Any], entry)
 
     # ── Query Handlers ────────────────────────────────────────────
 
@@ -84,32 +133,53 @@ class HandlerRegistry:
         handler: IQueryHandler[t.Any, t.Any] | QueryHandlerFactory,
     ) -> "HandlerRegistry":
         """Registra un handler (o factory) para un tipo de query. Retorna self para fluent API."""
-        if not self._allow_override and query_type in self._query_handlers:
-            raise DuplicateHandlerError(query_type)
-        self._query_handlers[query_type] = handler
+        with self._lock:
+            if not self._allow_override and query_type in self._query_handlers:
+                raise DuplicateHandlerError(query_type)
+            self._query_handlers[query_type] = handler
         return self
 
     def resolve_query_handler(
         self, query_type: type[Query[t.Any]]
     ) -> IQueryHandler[t.Any, t.Any]:
         """Resuelve el handler para el tipo de query dado."""
-        entry = self._query_handlers.get(query_type)
-        if entry is None:
-            raise HandlerNotFoundError(query_type)
-        if callable(entry) and not isinstance(entry, IQueryHandler):
-            handler = entry()
-            self._query_handlers[query_type] = handler
-            return handler
-        return t.cast(IQueryHandler[t.Any, t.Any], entry)
+        with self._lock:
+            entry = self._query_handlers.get(query_type)
+            if entry is None:
+                raise HandlerNotFoundError(query_type)
+            if _is_factory(entry, IQueryHandler):
+                handler = t.cast(QueryHandlerFactory, entry)()
+                self._query_handlers[query_type] = handler
+                return handler
+            return t.cast(IQueryHandler[t.Any, t.Any], entry)
 
     # ── Introspección ─────────────────────────────────────────────
 
     @property
     def registered_commands(self) -> frozenset[type[Command]]:
         """Retorna los tipos de command registrados."""
-        return frozenset(self._command_handlers.keys())
+        with self._lock:
+            return frozenset(self._command_handlers.keys())
 
     @property
     def registered_queries(self) -> frozenset[type[Query[t.Any]]]:
         """Retorna los tipos de query registrados."""
-        return frozenset(self._query_handlers.keys())
+        with self._lock:
+            return frozenset(self._query_handlers.keys())
+
+
+def _is_factory(entry: t.Any, handler_interface: type) -> bool:
+    """
+    Decide si `entry` es un factory de handlers o el handler mismo.
+
+    El marcador `HandlerFactory` es inequívoco. Para los callables pelados se mantiene
+    la heurística anterior por retrocompatibilidad, con una comprobación extra: un
+    objeto con método `handle` es un handler aunque además sea callable.
+    """
+    if isinstance(entry, HandlerFactory):
+        return True
+    if isinstance(entry, handler_interface):
+        return False
+    if hasattr(entry, "handle"):
+        return False
+    return callable(entry)

--- a/hexcore/application/cqrs/scheduler.py
+++ b/hexcore/application/cqrs/scheduler.py
@@ -5,9 +5,10 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from datetime import datetime, timezone
+import warnings
+from datetime import datetime, timedelta, timezone
 
-from hexcore.domain.cqrs.cron import ICronJobRepository, ILockProvider
+from hexcore.domain.cqrs.cron import CronJobDefinition, ICronJobRepository, ILockProvider
 from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
 
 logger = logging.getLogger(__name__)
@@ -17,6 +18,18 @@ class DynamicScheduler:
     """
     Evalúa constantemente un repositorio de tareas periódicas y delega la ejecución
     al TaskEnqueuer (Celery/Procrastinate). Permite cambiar configuraciones cron en "caliente".
+
+    **Catch-up.** La decisión no es "¿la expresión cron coincide con el minuto
+    actual?" —que se salta el job cuando el tick deriva un segundo— sino "¿hubo
+    alguna ocurrencia entre la última ejecución y ahora?". Eso hace que:
+
+    - un minuto saltado por drift del tick no pierda la ejecución;
+    - el mismo minuto muestreado varias veces (``tick_interval_seconds < 60``) no
+      duplique el encolado, porque ``last_run_at`` deduplica de verdad.
+
+    El catch-up se acota con ``catch_up_window_seconds`` para que un scheduler que
+    estuvo caído mucho tiempo no dispare ocurrencias antiguas ni itere millones de
+    minutos.
     """
 
     def __init__(
@@ -24,76 +37,206 @@ class DynamicScheduler:
         repository: ICronJobRepository,
         enqueuer: ITaskEnqueuer,
         lock_provider: ILockProvider | None = None,
-        tick_interval_seconds: int = 30
+        tick_interval_seconds: int = 30,
+        *,
+        catch_up_window_seconds: int = 3600,
     ) -> None:
         self.repository = repository
         self.enqueuer = enqueuer
         self.lock_provider = lock_provider
         self.tick_interval_seconds = tick_interval_seconds
-        
+        self.catch_up_window_seconds = catch_up_window_seconds
+
         self._stop_event = asyncio.Event()
+        # Memoria local de la última ocurrencia encolada por job. Complementa a
+        # `last_run_at` del repositorio: si el repo tarda en reflejar la escritura,
+        # esto evita que el mismo minuto se encole dos veces en este proceso.
+        self._last_enqueued: dict[str, datetime] = {}
+
+        if tick_interval_seconds < 60 and lock_provider is None:
+            warnings.warn(
+                f"DynamicScheduler con tick_interval_seconds={tick_interval_seconds} "
+                "(<60) y sin lock_provider: el mismo minuto se muestrea varias veces. "
+                "En este proceso la deduplicación por last_run_at lo cubre, pero con "
+                "varias réplicas del scheduler el job se duplicará. Pasá un "
+                "lock_provider (RedisLockProvider / PostgresLockProvider) o subí el "
+                "tick a 60s.",
+                RuntimeWarning,
+                stacklevel=2,
+            )
 
     async def start(self) -> None:
         """Inicia el bucle infinito del scheduler."""
-        import croniter
-        
-        logger.info(f"[*] DynamicScheduler started (Tick interval: {self.tick_interval_seconds}s)")
+        logger.info(
+            "[*] DynamicScheduler started (Tick interval: %ss, catch-up window: %ss)",
+            self.tick_interval_seconds,
+            self.catch_up_window_seconds,
+        )
         self._stop_event.clear()
 
-        # El estado base es el momento en que se levantó el scheduler.
-        last_check_time = datetime.now(timezone.utc)
+        # Ancla inicial: el comienzo del minuto en curso, exclusivo. Así una
+        # ocurrencia de *este* minuto cuenta como pendiente (arrancar a las 03:00:30
+        # sí dispara el job de las 03:00), pero no se disparan ocurrencias
+        # anteriores al arranque. Si el job tiene `last_run_at`, manda ése.
+        last_check_time = _start_of_minute(datetime.now(timezone.utc)) - _EPSILON
 
         while not self._stop_event.is_set():
+            # El tick corre *antes* del sleep: con el sleep primero se perdía el
+            # primer tick entero.
             try:
-                # 1. Esperamos el tiempo del tick
-                await asyncio.sleep(self.tick_interval_seconds)
-                
-                current_time = datetime.now(timezone.utc)
-                
-                # 2. Obtenemos la configuración fresca de BD
-                active_jobs = await self.repository.get_active_jobs()
-                
-                for job in active_jobs:
-                    # Determinamos desde cuándo chequear. Si el job tiene `last_run_at`, lo usamos.
-                    # Sino, usamos el `last_check_time` global del bucle.
-                    base_time = job.last_run_at or last_check_time
-                    
-                    try:
-                        # 3. Comprobamos si la expresión cron cayó entre base_time y current_time
-                        if croniter.croniter.match(job.cron_expression, current_time):
-                            # Evitar múltiples encolados en el mismo tick (minuto)
-                            # Intentar adquirir lock si hay proveedor (Distributed Locks)
-                            if self.lock_provider:
-                                # Usamos el minuto actual (truncado) para evitar colisiones distribuidas
-                                minute_key = current_time.replace(second=0, microsecond=0).isoformat()
-                                lock_key = f"hexcore:cron_lock:{job.job_id}:{minute_key}"
-                                
-                                lock_acquired = await self.lock_provider.acquire_lock(lock_key, ttl_seconds=60)
-                                if not lock_acquired:
-                                    logger.debug(f"CronJob '{job.job_id}' ignorado (lock adquirido por otra réplica).")
-                                    continue
-                                    
-                            logger.info(f"Encolando CronJob '{job.job_id}' -> Task: {job.task_name}")
-                            
-                            await self.enqueuer.enqueue_task(
-                                task_name=job.task_name,
-                                payload=job.payload,
-                                queue=job.queue
-                            )
-                            
-                            # Actualizamos el timestamp en el repositorio
-                            await self.repository.update_last_run(job.job_id, current_time)
-                            
-                    except Exception as e:
-                        logger.error(f"Error procesando el cron job {job.job_id}: {e}")
-
-                last_check_time = current_time
-
+                # `current_time` del tick se reutiliza como ancla del siguiente, para
+                # que no quede un hueco sin cubrir entre dos ticks.
+                last_check_time = await self._tick(last_check_time)
             except asyncio.CancelledError:
                 break
-            except Exception as e:
-                logger.error(f"Error crítico en el bucle del scheduler: {e}")
+            except Exception:
+                logger.exception("Error en el tick del scheduler; el bucle continúa")
+                last_check_time = datetime.now(timezone.utc)
+
+            try:
+                await asyncio.wait_for(
+                    self._stop_event.wait(), timeout=self.tick_interval_seconds
+                )
+            except asyncio.TimeoutError:
+                continue
+            except asyncio.CancelledError:
+                break
+
+    async def _tick(self, last_check_time: datetime) -> datetime:
+        """
+        Evalúa todos los jobs activos una vez.
+
+        Returns:
+            El `current_time` usado, para que el siguiente tick lo tome como ancla.
+        """
+        current_time = datetime.now(timezone.utc)
+        active_jobs = await self.repository.get_active_jobs()
+
+        for job in active_jobs:
+            try:
+                await self._process_job(job, last_check_time, current_time)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                logger.exception("Error procesando el cron job %s", job.job_id)
+
+        return current_time
+
+    async def _process_job(
+        self,
+        job: CronJobDefinition,
+        last_check_time: datetime,
+        current_time: datetime,
+    ) -> None:
+        """Encola el job si le tocaba correr en algún momento desde su última ejecución."""
+        base_time = self._resolve_base_time(job, last_check_time, current_time)
+        occurrence = self._latest_due_occurrence(
+            job.cron_expression, base_time, current_time
+        )
+        if occurrence is None:
+            return
+
+        # El lock se toma sobre la *ocurrencia*, no sobre el minuto actual: dos
+        # réplicas con ticks desfasados compiten por la misma clave.
+        if self.lock_provider:
+            lock_key = f"hexcore:cron_lock:{job.job_id}:{occurrence.isoformat()}"
+            acquired = await self.lock_provider.acquire_lock(lock_key, ttl_seconds=60)
+            if not acquired:
+                logger.debug(
+                    "CronJob '%s' ignorado (lock adquirido por otra réplica).",
+                    job.job_id,
+                )
+                return
+
+        logger.info(
+            "Encolando CronJob '%s' -> Task: %s (ocurrencia %s)",
+            job.job_id,
+            job.task_name,
+            occurrence.isoformat(),
+        )
+
+        await self.enqueuer.enqueue_task(
+            task_name=job.task_name,
+            payload=job.payload,
+            queue=job.queue,
+        )
+
+        # Marcar *la ocurrencia*, no `current_time`: es lo que hace que el siguiente
+        # tick sepa que este minuto ya se sirvió.
+        self._last_enqueued[job.job_id] = occurrence
+        await self.repository.update_last_run(job.job_id, occurrence)
+
+    def _resolve_base_time(
+        self,
+        job: CronJobDefinition,
+        last_check_time: datetime,
+        current_time: datetime,
+    ) -> datetime:
+        """
+        Desde cuándo buscar ocurrencias pendientes.
+
+        Se toma la más reciente entre `last_run_at`, la memoria local de este proceso
+        y el arranque del bucle, y se acota con la ventana de catch-up.
+        """
+        candidates = [last_check_time]
+        if job.last_run_at is not None:
+            candidates.append(_as_utc(job.last_run_at))
+        local = self._last_enqueued.get(job.job_id)
+        if local is not None:
+            candidates.append(local)
+
+        base_time = max(candidates)
+        window_start = current_time - timedelta(seconds=self.catch_up_window_seconds)
+        return max(base_time, window_start)
+
+    def _latest_due_occurrence(
+        self,
+        cron_expression: str,
+        base_time: datetime,
+        current_time: datetime,
+    ) -> datetime | None:
+        """
+        Última ocurrencia de `cron_expression` en el intervalo `(base_time, current_time]`.
+
+        Devuelve `None` si no hubo ninguna. Se encola una sola vez aunque se hayan
+        saltado varias ocurrencias: para una tarea periódica, correr N veces seguidas
+        para "recuperar" es casi siempre peor que correr una.
+        """
+        import croniter
+
+        try:
+            iterator = croniter.croniter(cron_expression, base_time)
+        except (croniter.CroniterBadCronError, croniter.CroniterBadDateError) as exc:
+            logger.error("Expresión cron inválida '%s': %s", cron_expression, exc)
+            return None
+
+        latest: datetime | None = None
+        while True:
+            try:
+                candidate = iterator.get_next(datetime)
+            except croniter.CroniterBadDateError:
+                # Expresión que no vuelve a ocurrir (p. ej. "0 0 31 2 *").
+                break
+            if candidate > current_time:
+                break
+            latest = candidate
+
+        return latest
 
     def stop(self) -> None:
         """Detiene el bucle del scheduler de forma segura."""
         self._stop_event.set()
+
+
+_EPSILON = timedelta(microseconds=1)
+
+
+def _as_utc(value: datetime) -> datetime:
+    """Normaliza a UTC: un `last_run_at` naive de la BD rompería las comparaciones."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _start_of_minute(value: datetime) -> datetime:
+    return value.replace(second=0, microsecond=0)

--- a/hexcore/domain/cqrs/__init__.py
+++ b/hexcore/domain/cqrs/__init__.py
@@ -22,6 +22,8 @@ from .buses import ICommandBus, IQueryBus, IEventBus
 from .middleware import IMiddleware
 from .serializer import ISerializer
 from .cron import CronJobDefinition, ICronJobRepository, ILockProvider
+from .context import IN_WORKER, is_worker_execution, local_execution, worker_execution
+from .resolution import build_fqn, resolve_dotted
 
 __all__ = [
     # Nombres canónicos (Abstract*)
@@ -39,6 +41,13 @@ __all__ = [
     "CronJobDefinition",
     "ICronJobRepository",
     "ILockProvider",
+    # Contexto de ejecución y resolución de FQN
+    "IN_WORKER",
+    "is_worker_execution",
+    "local_execution",
+    "worker_execution",
+    "build_fqn",
+    "resolve_dotted",
     # Aliases (I*)
     "ICommandHandler",
     "IQueryHandler",

--- a/hexcore/domain/cqrs/context.py
+++ b/hexcore/domain/cqrs/context.py
@@ -1,0 +1,61 @@
+"""
+Contexto de ejecución de mensajes CQRS.
+
+Los buses con Smart Routing necesitan saber si el mensaje que están despachando
+*viene* de una cola de tareas o si lo está originando el proceso actual. Sin esa
+distinción, un worker que recibe un ``@background_command`` lo vuelve a encolar
+en lugar de ejecutarlo, y el comando nunca corre (bucle infinito silencioso).
+
+Semántica del flag:
+
+- ``IN_WORKER`` sólo está activo alrededor de la **resolución** del mensaje entrante.
+- El primer bus que lo lee lo **consume**: lo pone en ``False`` antes de invocar
+  middlewares y handler. Así, un handler que despacha a propósito otro
+  ``@background_command`` sigue encolándolo, que es la semántica esperada.
+"""
+from __future__ import annotations
+
+import typing as t
+from contextlib import contextmanager
+from contextvars import ContextVar
+
+__all__ = ["IN_WORKER", "worker_execution", "local_execution", "is_worker_execution"]
+
+
+IN_WORKER: ContextVar[bool] = ContextVar("hexcore_in_worker", default=False)
+
+
+def is_worker_execution() -> bool:
+    """Indica si el mensaje en curso proviene de un worker de background."""
+    return IN_WORKER.get()
+
+
+@contextmanager
+def worker_execution() -> t.Iterator[None]:
+    """
+    Marca el bloque como "ejecución dentro de un worker".
+
+    Lo usan los consumidores (``CQRSConsumer``) alrededor del despacho del mensaje
+    que acaban de sacar de la cola.
+    """
+    token = IN_WORKER.set(True)
+    try:
+        yield
+    finally:
+        IN_WORKER.reset(token)
+
+
+@contextmanager
+def local_execution() -> t.Iterator[None]:
+    """
+    Consume el flag de worker: dentro de este bloque ``IN_WORKER`` es ``False``.
+
+    Lo usan los buses antes de entrar al pipeline/handler, para que el despacho
+    explícito de otro mensaje de background desde dentro del handler se encole
+    en vez de ejecutarse inline.
+    """
+    token = IN_WORKER.set(False)
+    try:
+        yield
+    finally:
+        IN_WORKER.reset(token)

--- a/hexcore/domain/cqrs/decorators.py
+++ b/hexcore/domain/cqrs/decorators.py
@@ -6,6 +6,13 @@ from __future__ import annotations
 
 import typing as t
 
+from .resolution import build_fqn, ensure_resolvable_qualname
+
+
+def _unwrap(func: t.Any) -> t.Any:
+    """Descarta envoltorios (`staticmethod`/`classmethod`) para leer el objeto real."""
+    return getattr(func, "__func__", func)
+
 
 def background_command(queue: str = "default") -> t.Callable[[t.Type[t.Any]], t.Type[t.Any]]:
     """
@@ -21,6 +28,8 @@ def background_command(queue: str = "default") -> t.Callable[[t.Type[t.Any]], t.
             ...
     """
     def wrapper(cls: t.Type[t.Any]) -> t.Type[t.Any]:
+        # El worker tiene que poder importar la clase para deserializar el payload.
+        ensure_resolvable_qualname(cls, decorator="background_command")
         cls.__cqrs_background__ = True
         cls.__cqrs_queue__ = queue
         return cls
@@ -42,15 +51,17 @@ def background_handler(queue: str = "default") -> t.Callable[[t.Callable[..., t.
             ...
     """
     def wrapper(func: t.Callable[..., t.Any]) -> t.Callable[..., t.Any]:
-        func.__cqrs_background_handler__ = True
-        func.__cqrs_queue__ = queue
-        
-        # Guardamos el nombre calificado del handler para poder resolverlo luego en el Worker
-        if not hasattr(func, "__qualname__"):
-            func.__cqrs_handler_name__ = func.__name__
-        else:
-            func.__cqrs_handler_name__ = f"{func.__module__}.{func.__qualname__}"
-            
+        target = _unwrap(func)
+        ensure_resolvable_qualname(target, decorator="background_handler")
+
+        target.__cqrs_background_handler__ = True
+        target.__cqrs_queue__ = queue
+
+        # Guardamos el nombre calificado del handler para poder resolverlo luego en
+        # el Worker. `build_fqn` conserva el __qualname__ completo (métodos incluidos)
+        # y `resolve_dotted` sabe resolverlo del otro lado.
+        target.__cqrs_handler_name__ = build_fqn(target)
+
         return func
 
     return wrapper
@@ -65,14 +76,13 @@ def background_task(queue: str = "default") -> t.Callable[[t.Callable[..., t.Any
     `TaskManager` de HexCore o ejecutada directamente usando el `ITaskEnqueuer`.
     """
     def wrapper(func: t.Callable[..., t.Any]) -> t.Callable[..., t.Any]:
-        func.__cqrs_background_task__ = True
-        func.__cqrs_queue__ = queue
-        
-        if not hasattr(func, "__qualname__"):
-            func.__cqrs_task_name__ = func.__name__
-        else:
-            func.__cqrs_task_name__ = f"{func.__module__}.{func.__qualname__}"
-            
+        target = _unwrap(func)
+        ensure_resolvable_qualname(target, decorator="background_task")
+
+        target.__cqrs_background_task__ = True
+        target.__cqrs_queue__ = queue
+        target.__cqrs_task_name__ = build_fqn(target)
+
         return func
 
     return wrapper

--- a/hexcore/domain/cqrs/resolution.py
+++ b/hexcore/domain/cqrs/resolution.py
@@ -1,0 +1,87 @@
+"""
+Resolución de referencias por nombre calificado (FQN).
+
+Un ``__qualname__`` puede contener puntos (clases y funciones anidadas), así que
+``fqn.rsplit(".", 1)`` produce un module path inválido: ``"app.Outer.Inner"`` se
+parte en ``("app.Outer", "Inner")`` y el import falla con
+``No module named 'app.Outer'``.
+
+Este módulo centraliza la resolución correcta: probar prefijos de módulo de más
+largo a más corto y luego caminar los atributos restantes.
+"""
+from __future__ import annotations
+
+import importlib
+import typing as t
+
+__all__ = ["resolve_dotted", "build_fqn", "ensure_resolvable_qualname"]
+
+
+def resolve_dotted(fqn: str) -> t.Any:
+    """
+    Resuelve un FQN (``"paquete.modulo.Clase.Anidada"``) al objeto que referencia.
+
+    Soporta clases y funciones anidadas: prueba el prefijo de módulo más largo
+    que sea importable y después recorre los atributos restantes.
+
+    Raises:
+        LookupError: Si no se puede resolver ningún prefijo válido.
+    """
+    if not fqn or not isinstance(fqn, str):
+        raise LookupError(f"FQN inválido: {fqn!r}")
+
+    parts = fqn.split(".")
+    if len(parts) == 1:
+        # Sin módulo no hay nada que importar; sólo puede ser un builtin.
+        import builtins
+
+        try:
+            return getattr(builtins, parts[0])
+        except AttributeError as exc:
+            raise LookupError(f"No se pudo resolver '{fqn}': {exc}") from exc
+
+    last_error: Exception | None = None
+    # De más específico a más genérico: "a.b.c" → módulos "a.b.c", "a.b", "a".
+    for split_at in range(len(parts) - 1, 0, -1):
+        module_path = ".".join(parts[:split_at])
+        try:
+            obj: t.Any = importlib.import_module(module_path)
+        except ImportError as exc:
+            last_error = exc
+            continue
+
+        try:
+            for attr in parts[split_at:]:
+                obj = getattr(obj, attr)
+        except AttributeError as exc:
+            last_error = exc
+            continue
+        return obj
+
+    raise LookupError(f"No se pudo resolver '{fqn}': {last_error}")
+
+
+def build_fqn(obj: t.Any) -> str:
+    """Construye el FQN de una clase o función (``modulo.QualName``)."""
+    qualname = getattr(obj, "__qualname__", None) or obj.__name__
+    return f"{obj.__module__}.{qualname}"
+
+
+def ensure_resolvable_qualname(obj: t.Any, *, decorator: str) -> None:
+    """
+    Valida que ``obj`` pueda resolverse desde otro proceso.
+
+    Una función definida dentro de otra función lleva ``<locals>`` en su
+    ``__qualname__`` y **nunca** será importable desde el worker. Es mucho mejor
+    fallar al decorar que fallar en el primer job de producción.
+
+    Raises:
+        ValueError: Si el ``__qualname__`` contiene ``<locals>``.
+    """
+    qualname = getattr(obj, "__qualname__", "") or ""
+    if "<locals>" in qualname:
+        raise ValueError(
+            f"@{decorator} no se puede aplicar a '{qualname}': está definida dentro "
+            "de otra función, así que el worker no podrá importarla. Muévela al nivel "
+            "de módulo (o a un método de una clase de módulo)."
+        )

--- a/hexcore/infrastructure/api/utils.py
+++ b/hexcore/infrastructure/api/utils.py
@@ -30,6 +30,27 @@ async def get_session() -> AsyncGenerator[AsyncSession, None]:
 async def get_sql_uow(
     session: AsyncSession = Depends(get_session),
 ) -> AsyncGenerator[IUnitOfWork, None]:
+    """
+    Cede un `SqlAlchemyUnitOfWork` **sin entrar** en él.
+
+    Es la convención de los ejemplos de use case: el use case hace su propio
+    ``async with self.uow:`` y controla el commit. Si esta dependencia entrara al UoW,
+    ese ``async with`` del use case anidaría contextos.
+
+    Si necesitás el UoW ya abierto en el endpoint, usá `get_sql_uow_open`.
+    """
+    yield SqlAlchemyUnitOfWork(session=session)
+
+
+async def get_sql_uow_open(
+    session: AsyncSession = Depends(get_session),
+) -> AsyncGenerator[IUnitOfWork, None]:
+    """
+    Cede un `SqlAlchemyUnitOfWork` ya **abierto** (dentro de ``async with``).
+
+    Para endpoints que operan sobre el UoW directamente, sin pasar por un use case.
+    No comitea: el commit sigue siendo explícito.
+    """
     async with SqlAlchemyUnitOfWork(session=session) as uow:
         yield uow
 

--- a/hexcore/infrastructure/cqrs/middlewares.py
+++ b/hexcore/infrastructure/cqrs/middlewares.py
@@ -100,33 +100,42 @@ class ValidationMiddleware(IMiddleware):
 class TransactionMiddleware(IMiddleware):
     """
     Middleware que envuelve la ejecución del handler en un contexto transaccional
-    usando el Unit of Work de Hexcore.
+    usando el Unit of Work de Hexcore, y comitea al terminar.
 
-    Requiere que el handler tenga acceso al UoW (inyectado vía constructor).
-    Este middleware se encarga del commit/rollback.
+    **Es para handlers que NO gestionan su propia transacción.** Si tu handler ya
+    hace ``async with self.uow:`` y ``await self.uow.commit()`` —el patrón que
+    enseña `DOCS.md` para los use cases— no uses este middleware: comitearías dos
+    veces.
+
+    ``uow_factory`` es obligatorio. Antes existía un default que armaba la sesión
+    con el session factory *interno* de HexCore en vez del engine de la aplicación,
+    lo que producía transacciones contra un engine distinto al del resto del
+    request. Adivinar aquí es peor que no funcionar.
+
+    Uso::
+
+        TransactionMiddleware(uow_factory=lambda: SqlAlchemyUnitOfWork(session=my_factory()))
     """
 
     def __init__(self, uow_factory: t.Callable[[], t.Any] | None = None) -> None:
         """
         Args:
-            uow_factory: Callable que retorna un IUnitOfWork context manager.
-                         Si es None, usa un factory por defecto (intenta SQL, luego NoSQL).
-        """
-        self._uow_factory = uow_factory or self._default_uow_factory
+            uow_factory: Callable que retorna un IUnitOfWork usable como context
+                manager. Obligatorio.
 
-    @staticmethod
-    def _default_uow_factory() -> t.Any:
-        from hexcore.config import LazyConfig
-        from hexcore.infrastructure.uow import SqlAlchemyUnitOfWork, NoSqlUnitOfWork
-        
-        config = LazyConfig.get_config()
-        # Heurística simple: Si hay una URL de SQL (por defecto siempre la hay), asume SQL.
-        # En una app real de Hexcore se puede inyectar esto mejor, pero provee un default funcional.
-        if config.sql_database_url:
-            from hexcore.infrastructure.repositories.orms.sqlalchemy.session import get_session_factory
-            factory = get_session_factory()
-            return SqlAlchemyUnitOfWork(session=factory())
-        return NoSqlUnitOfWork()
+        Raises:
+            ValueError: Si no se provee `uow_factory`.
+        """
+        if uow_factory is None:
+            raise ValueError(
+                "TransactionMiddleware requiere un 'uow_factory' explícito. "
+                "Pasá un callable que construya el UoW con el engine de tu "
+                "aplicación, p. ej. "
+                "TransactionMiddleware(uow_factory=lambda: SqlAlchemyUnitOfWork(session=session_factory())). "
+                "Recordá que este middleware comitea: no lo uses con handlers que "
+                "ya gestionan su propia transacción."
+            )
+        self._uow_factory = uow_factory
 
     async def handle(self, message: t.Any, next_handler: NextHandler) -> t.Any:
         uow = self._uow_factory()

--- a/hexcore/infrastructure/cqrs/postgres_bus.py
+++ b/hexcore/infrastructure/cqrs/postgres_bus.py
@@ -10,6 +10,7 @@ import logging
 import typing as t
 
 from hexcore.domain.cqrs.buses import IEventBus
+from hexcore.domain.cqrs.context import is_worker_execution, local_execution
 from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
 from hexcore.domain.events import DomainEvent
 
@@ -107,17 +108,24 @@ class PostgresEventBus(IEventBus):
             event = self._serializer.deserialize(payload_dict)
             handlers = self._handlers.get(event_type, [])
             
+            # Si ya estamos dentro de un worker, el mensaje viene de la cola:
+            # ejecutar en vez de reencolar (ver hexcore.domain.cqrs.context).
+            in_worker = is_worker_execution()
             for handler in handlers:
-                is_background = getattr(handler, "__cqrs_background_handler__", False)
+                is_background = (
+                    getattr(handler, "__cqrs_background_handler__", False)
+                    and not in_worker
+                )
                 if is_background:
                     queue_name = getattr(handler, "__cqrs_queue__", "default")
                     if not self.enqueuer:
                         raise RuntimeError(f"El handler asíncrono {handler.__name__} requiere un enqueuer.")
-                    
+
                     handler_ref = getattr(handler, "__cqrs_handler_name__", f"{handler.__module__}.{handler.__name__}")
                     await self.enqueuer.enqueue_handler(handler_ref, payload_dict, queue_name)
                 else:
-                    await handler(event)
+                    with local_execution():
+                        await handler(event)
                     
         except Exception as e:
             logger.error(f"Error parseando o ejecutando evento de PostgreSQL NOTIFY: {e}")

--- a/hexcore/infrastructure/cqrs/postgres_lock.py
+++ b/hexcore/infrastructure/cqrs/postgres_lock.py
@@ -22,34 +22,86 @@ class PostgresLockProvider(ILockProvider):
     Implementación de ILockProvider basada en PostgreSQL (vía asyncpg).
     Utiliza una tabla `hexcore_cron_locks` para gestionar la exclusión mutua
     con soporte para TTL atómico.
+
+    **Crecimiento de la tabla.** El `DynamicScheduler` usa una clave por
+    `(job_id, minuto)`, así que cada minuto genera filas nuevas: con 7 jobs son del
+    orden de 10.000 filas/día. Las filas expiradas ya no sirven para nada, así que
+    este provider las purga solo:
+
+    - en `setup()`,
+    - y cada `purge_every` adquisiciones (por defecto 100, ~1 query extra por 100).
+
+    `purge_expired()` es pública si preferís purgar desde un job propio; poné
+    `purge_every=0` para desactivar la purga automática.
     """
 
-    def __init__(self, pool: asyncpg.Pool | asyncpg.Connection, table_name: str = "hexcore_cron_locks") -> None:
+    def __init__(
+        self,
+        pool: asyncpg.Pool | asyncpg.Connection,
+        table_name: str = "hexcore_cron_locks",
+        *,
+        purge_every: int = 100,
+        purge_grace_seconds: int = 3600,
+    ) -> None:
         """
         Args:
             pool: Pool de conexiones o conexión simple de `asyncpg`.
             table_name: Nombre de la tabla a utilizar para los locks.
+            purge_every: Cada cuántas adquisiciones purgar lo expirado. 0 desactiva.
+            purge_grace_seconds: Margen antes de borrar una fila expirada. Evita
+                borrar locks que acaban de vencer y que otra réplica podría estar
+                evaluando en este mismo instante.
         """
         self.pool = pool
         self.table_name = table_name
+        self.purge_every = purge_every
+        self.purge_grace_seconds = purge_grace_seconds
+        self._acquisitions_since_purge = 0
 
     async def setup(self) -> None:
         """
-        Crea la tabla necesaria para los locks si no existe.
+        Crea la tabla y el índice necesarios para los locks si no existen,
+        y purga lo que haya quedado de ejecuciones anteriores.
         Debe llamarse al inicio de la aplicación.
         """
-        query = f"""
+        if not hasattr(self.pool, "execute"):
+            return
+
+        create_table = f"""
         CREATE TABLE IF NOT EXISTS {self.table_name} (
             lock_key TEXT PRIMARY KEY,
             expires_at TIMESTAMP WITH TIME ZONE NOT NULL
         )
         """
+        # El índice es lo que hace que la purga no degrade con el tamaño de la tabla.
+        create_index = f"""
+        CREATE INDEX IF NOT EXISTS {self.table_name}_expires_at_idx
+        ON {self.table_name} (expires_at)
+        """
         try:
-            if hasattr(self.pool, "execute"):
-                await self.pool.execute(query) # type: ignore
+            await self.pool.execute(create_table) # type: ignore
+            await self.pool.execute(create_index) # type: ignore
         except Exception as e:
             logger.error(f"Error creando tabla de locks en Postgres: {e}")
             raise
+
+        await self.purge_expired()
+
+    async def purge_expired(self) -> None:
+        """
+        Borra las filas cuyo `expires_at` venció hace más de `purge_grace_seconds`.
+
+        No propaga errores: una purga fallida no debe tumbar el scheduler.
+        """
+        query = f"""
+        DELETE FROM {self.table_name}
+        WHERE expires_at < NOW() - ($1 || ' seconds')::interval
+        """
+        try:
+            await self.pool.execute(query, str(self.purge_grace_seconds)) # type: ignore
+            self._acquisitions_since_purge = 0
+        except Exception as e:
+            logger.warning(f"Error purgando locks expirados de Postgres: {e}")
 
     async def acquire_lock(self, lock_key: str, ttl_seconds: int) -> bool:
         """
@@ -79,10 +131,21 @@ class PostgresLockProvider(ILockProvider):
         try:
             # fetchrow returns a record if RETURNING gave something, else None
             result = await self.pool.fetchrow(query, lock_key, str(ttl_seconds)) # type: ignore
-            return result is not None
+            acquired = result is not None
         except Exception as e:
             logger.error(f"Error intentando adquirir lock de Postgres para {lock_key}: {e}")
             return False
+
+        await self._maybe_purge()
+        return acquired
+
+    async def _maybe_purge(self) -> None:
+        """Purga amortizada: una query extra cada `purge_every` adquisiciones."""
+        if self.purge_every <= 0:
+            return
+        self._acquisitions_since_purge += 1
+        if self._acquisitions_since_purge >= self.purge_every:
+            await self.purge_expired()
 
     async def release_lock(self, lock_key: str) -> None:
         """

--- a/hexcore/infrastructure/cqrs/postgres_lock.py
+++ b/hexcore/infrastructure/cqrs/postgres_lock.py
@@ -6,7 +6,7 @@ sin necesidad de añadir Redis a tu stack.
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone, timedelta
+import typing as t
 from typing import TYPE_CHECKING
 
 from hexcore.domain.cqrs.cron import ILockProvider
@@ -15,6 +15,8 @@ if TYPE_CHECKING:
     import asyncpg
 
 logger = logging.getLogger(__name__)
+
+LockErrorPolicy = t.Literal["skip", "raise"]
 
 
 class PostgresLockProvider(ILockProvider):
@@ -33,6 +35,12 @@ class PostgresLockProvider(ILockProvider):
 
     `purge_expired()` es pública si preferís purgar desde un job propio; poné
     `purge_every=0` para desactivar la purga automática.
+
+    **Qué pasa si Postgres no responde.** Igual que en `RedisLockProvider`:
+    `on_error="skip"` (default) loguea `critical` y devuelve `False`, o sea que el
+    cron se detiene mientras la BD esté caída; `on_error="raise"` propaga para que el
+    supervisor del scheduler lo vea. El log distingue "no pude decidir" (`critical`)
+    de "el lock estaba tomado" (`debug`).
     """
 
     def __init__(
@@ -40,6 +48,7 @@ class PostgresLockProvider(ILockProvider):
         pool: asyncpg.Pool | asyncpg.Connection,
         table_name: str = "hexcore_cron_locks",
         *,
+        on_error: LockErrorPolicy = "skip",
         purge_every: int = 100,
         purge_grace_seconds: int = 3600,
     ) -> None:
@@ -47,6 +56,7 @@ class PostgresLockProvider(ILockProvider):
         Args:
             pool: Pool de conexiones o conexión simple de `asyncpg`.
             table_name: Nombre de la tabla a utilizar para los locks.
+            on_error: Qué hacer si Postgres no responde. Ver el docstring de la clase.
             purge_every: Cada cuántas adquisiciones purgar lo expirado. 0 desactiva.
             purge_grace_seconds: Margen antes de borrar una fila expirada. Evita
                 borrar locks que acaban de vencer y que otra réplica podría estar
@@ -54,6 +64,7 @@ class PostgresLockProvider(ILockProvider):
         """
         self.pool = pool
         self.table_name = table_name
+        self.on_error = on_error
         self.purge_every = purge_every
         self.purge_grace_seconds = purge_grace_seconds
         self._acquisitions_since_purge = 0
@@ -113,7 +124,11 @@ class PostgresLockProvider(ILockProvider):
             
         Returns:
             True si el lock fue adquirido con éxito.
-            False si el lock ya estaba tomado y aún no ha expirado.
+            False si el lock ya estaba tomado y aún no ha expirado, o si Postgres
+            falló y `on_error="skip"`.
+
+        Raises:
+            Exception: El error original de asyncpg, si `on_error="raise"`.
         """
         # Usamos UPSERT (ON CONFLICT) condicional
         # Si no existe, lo inserta.
@@ -133,8 +148,25 @@ class PostgresLockProvider(ILockProvider):
             result = await self.pool.fetchrow(query, lock_key, str(ttl_seconds)) # type: ignore
             acquired = result is not None
         except Exception as e:
-            logger.error(f"Error intentando adquirir lock de Postgres para {lock_key}: {e}")
+            if self.on_error == "raise":
+                logger.critical(
+                    "No se pudo decidir el lock de Postgres para %s: %s. "
+                    "on_error='raise': se propaga.",
+                    lock_key,
+                    e,
+                )
+                raise
+            # "No pude decidir" es un incidente de infraestructura, no un lock tomado.
+            logger.critical(
+                "No se pudo decidir el lock de Postgres para %s: %s. "
+                "on_error='skip': el job NO se ejecuta en este tick.",
+                lock_key,
+                e,
+            )
             return False
+
+        if not acquired:
+            logger.debug("Lock de Postgres %s ya estaba tomado por otro proceso.", lock_key)
 
         await self._maybe_purge()
         return acquired

--- a/hexcore/infrastructure/cqrs/pydantic_serializer.py
+++ b/hexcore/infrastructure/cqrs/pydantic_serializer.py
@@ -4,11 +4,11 @@ a través de backends asíncronos (Procrastinate, Celery, etc.).
 """
 from __future__ import annotations
 
-import importlib
 import typing as t
 
 from hexcore.domain.cqrs.serializer import ISerializer
 from hexcore.domain.cqrs.exceptions import DeserializationError
+from hexcore.domain.cqrs.resolution import build_fqn, resolve_dotted
 
 
 class PydanticSerializer(ISerializer):
@@ -25,7 +25,7 @@ class PydanticSerializer(ISerializer):
     """
 
     def serialize(self, message: t.Any) -> dict[str, t.Any]:
-        fqn = f"{type(message).__module__}.{type(message).__qualname__}"
+        fqn = build_fqn(type(message))
         return {
             "__type__": fqn,
             "__data__": message.model_dump(mode="json"),
@@ -40,10 +40,10 @@ class PydanticSerializer(ISerializer):
             )
 
         try:
-            module_path, class_name = fqn.rsplit(".", 1)
-            module = importlib.import_module(module_path)
-            cls = getattr(module, class_name)
-        except (ValueError, ModuleNotFoundError, AttributeError) as exc:
+            # `resolve_dotted` soporta clases anidadas ("app.Outer.InnerCommand"),
+            # donde un rsplit(".", 1) produciría un module path inválido.
+            cls = resolve_dotted(fqn)
+        except LookupError as exc:
             raise DeserializationError(
                 f"Cannot resolve type '{fqn}': {exc}"
             ) from exc

--- a/hexcore/infrastructure/cqrs/redis_bus.py
+++ b/hexcore/infrastructure/cqrs/redis_bus.py
@@ -11,6 +11,7 @@ import typing as t
 import uuid
 
 from hexcore.domain.cqrs.buses import IEventBus
+from hexcore.domain.cqrs.context import is_worker_execution, local_execution
 from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
 from hexcore.domain.events import DomainEvent
 
@@ -120,18 +121,25 @@ class RedisEventBus(IEventBus):
             event = self._serializer.deserialize(payload_dict)
             handlers = self._handlers.get(event_type, [])
             
-            # Ejecutar handlers (respetando Smart Routing)
+            # Ejecutar handlers (respetando Smart Routing).
+            # Si ya estamos dentro de un worker, el mensaje viene de la cola:
+            # ejecutar en vez de reencolar (ver hexcore.domain.cqrs.context).
+            in_worker = is_worker_execution()
             for handler in handlers:
-                is_background = getattr(handler, "__cqrs_background_handler__", False)
+                is_background = (
+                    getattr(handler, "__cqrs_background_handler__", False)
+                    and not in_worker
+                )
                 if is_background:
                     queue_name = getattr(handler, "__cqrs_queue__", "default")
                     if not self.enqueuer:
                         raise RuntimeError(f"El handler asíncrono {handler.__name__} requiere un enqueuer.")
-                    
+
                     handler_ref = getattr(handler, "__cqrs_handler_name__", f"{handler.__module__}.{handler.__name__}")
                     await self.enqueuer.enqueue_handler(handler_ref, payload_dict, queue_name)
                 else:
-                    await handler(event)
+                    with local_execution():
+                        await handler(event)
 
             # Confirmar mensaje
             await self.redis.xack(self.stream_name, self.group_name, message_id)

--- a/hexcore/infrastructure/cqrs/redis_lock.py
+++ b/hexcore/infrastructure/cqrs/redis_lock.py
@@ -5,6 +5,7 @@ Ideal para garantizar ejecución única de CronJobs en múltiples réplicas.
 from __future__ import annotations
 
 import logging
+import typing as t
 from typing import TYPE_CHECKING
 
 from hexcore.domain.cqrs.cron import ILockProvider
@@ -14,47 +15,94 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+LockErrorPolicy = t.Literal["skip", "raise"]
+
 
 class RedisLockProvider(ILockProvider):
     """
     Implementación de ILockProvider basada en Redis.
     Utiliza el comando SET NX EX para asegurar exclusión mutua de manera atómica
     y evitar "deadlocks" mediante la expiración (TTL).
+
+    **Qué pasa si Redis se cae.** `acquire_lock` no puede decidir, y las dos
+    respuestas posibles son malas de formas distintas: devolver `False` apaga el cron
+    completo (ningún job corre), devolver `True` deja que corran todas las réplicas
+    (jobs duplicados). El default es `on_error="skip"` (no correr), pero la decisión
+    es tuya y explícita:
+
+    - ``on_error="skip"``: log `critical` y `False`. El cron se detiene mientras Redis
+      esté caído. Correcto si duplicar es peor que no correr (cobros, envío de mail).
+    - ``on_error="raise"``: propaga la excepción para que el supervisor del scheduler
+      la vea y reinicie o alerte. Correcto si prefieres caerte ruidosamente.
+
+    El log distingue "no pude decidir" (`critical`) de "el lock estaba tomado"
+    (`debug`), que antes eran indistinguibles.
     """
 
-    def __init__(self, redis_client: Redis) -> None:
+    def __init__(
+        self,
+        redis_client: Redis,
+        *,
+        on_error: LockErrorPolicy = "skip",
+    ) -> None:
         """
         Args:
             redis_client: Instancia activa de `redis.asyncio.Redis`.
+            on_error: Qué hacer si Redis no responde. Ver el docstring de la clase.
         """
         self.redis = redis_client
+        self.on_error = on_error
 
     async def acquire_lock(self, lock_key: str, ttl_seconds: int) -> bool:
         """
         Intenta adquirir un lock en Redis.
-        
+
         Args:
             lock_key: La clave única del lock (ej. "hexcore:cron_lock:job_1:2026-07-28T01:02:00").
             ttl_seconds: Tiempo de vida del lock en segundos (evita deadlocks).
-            
+
         Returns:
             True si el lock fue adquirido con éxito (nadie lo tenía).
-            False si el lock ya estaba tomado por otro proceso.
+            False si el lock ya estaba tomado por otro proceso, o si Redis falló y
+            `on_error="skip"`.
+
+        Raises:
+            Exception: El error original de Redis, si `on_error="raise"`.
         """
         try:
             # SET key "1" NX (solo si no existe) EX ttl_seconds (expira automáticamente)
             # Retorna True (si lo seteó) o None/False (si ya existía)
             result = await self.redis.set(lock_key, "locked", nx=True, ex=ttl_seconds)
-            return bool(result)
         except Exception as e:
-            logger.error(f"Error intentando adquirir lock de Redis para {lock_key}: {e}")
-            # En caso de error de Redis, asumimos False para evitar ejecución duplicada por dudas,
-            # o podríamos dejar que explote. En un scheduler, es más seguro no correr.
+            if self.on_error == "raise":
+                logger.critical(
+                    "No se pudo decidir el lock de Redis para %s: %s. "
+                    "on_error='raise': se propaga.",
+                    lock_key,
+                    e,
+                )
+                raise
+            # "No pude decidir" es un incidente de infraestructura, no un lock tomado:
+            # va a critical para que se distinga en los logs y en las alertas.
+            logger.critical(
+                "No se pudo decidir el lock de Redis para %s: %s. "
+                "on_error='skip': el job NO se ejecuta en este tick.",
+                lock_key,
+                e,
+            )
             return False
+
+        acquired = bool(result)
+        if not acquired:
+            logger.debug("Lock de Redis %s ya estaba tomado por otro proceso.", lock_key)
+        return acquired
 
     async def release_lock(self, lock_key: str) -> None:
         """
         Libera el lock explícitamente.
+
+        No propaga nunca: el TTL libera el lock igual, así que un fallo aquí es un
+        retraso, no una pérdida de corrección.
         """
         try:
             await self.redis.delete(lock_key)

--- a/hexcore/infrastructure/repositories/orms/sqlalchemy/session.py
+++ b/hexcore/infrastructure/repositories/orms/sqlalchemy/session.py
@@ -1,5 +1,26 @@
+"""
+Engine y session factory de SQLAlchemy para HexCore.
+
+Punto de entrada recomendado: `init_engine()` en el arranque y `dispose_engine()` en
+el apagado. `get_engine()` / `get_session_factory()` siguen existiendo y hacen
+lazy-init con los defaults correctos, así que nada obliga a llamar a `init_engine`.
+
+Decisiones que **no** son parámetros porque son el comportamiento correcto:
+
+- ``expire_on_commit=False``. Con el default de SQLAlchemy (``True``) los atributos de
+  las entidades expiran al comitear, y el siguiente acceso dispara un lazy-load sobre
+  una sesión ya cerrada → ``MissingGreenlet`` / ``DetachedInstanceError``. Quien
+  necesite ``True`` construye su propio ``async_sessionmaker``.
+- La normalización del driver en el DSN. Un ``DATABASE_URL`` de PaaS viene como
+  ``postgresql://…`` y ``create_async_engine`` no lo acepta.
+"""
+from __future__ import annotations
+
+import threading
+import typing as t
 from collections.abc import AsyncGenerator
 
+from pydantic import BaseModel as PydanticBaseModel
 from sqlalchemy.ext.asyncio import (
     AsyncEngine,
     AsyncSession,
@@ -9,38 +30,164 @@ from sqlalchemy.ext.asyncio import (
 
 from hexcore.config import LazyConfig
 
+__all__ = [
+    "PoolSettings",
+    "init_engine",
+    "dispose_engine",
+    "get_engine",
+    "get_session_factory",
+    "get_async_db_session",
+    "normalize_async_dsn",
+    "reset_sqlalchemy_engine",
+]
+
+
+class PoolSettings(PydanticBaseModel):
+    """
+    Tuning del pool de conexiones.
+
+    ``pre_ping`` va en True por defecto a propósito: un pool sin pre-ping contra
+    Postgres detrás de un balanceador entrega conexiones muertas al primer failover.
+    """
+
+    size: int | None = None
+    max_overflow: int | None = None
+    pre_ping: bool = True
+    recycle: int | None = 1800
+
+
+# Mapeo de esquemas "síncronos" al driver async equivalente. Sólo se aplica cuando el
+# DSN no declara driver (`postgresql://`, no `postgresql+psycopg://`).
+_ASYNC_DRIVERS: dict[str, str] = {
+    "postgresql": "postgresql+asyncpg",
+    "postgres": "postgresql+asyncpg",
+    "sqlite": "sqlite+aiosqlite",
+    "mysql": "mysql+aiomysql",
+    "mariadb": "mariadb+aiomysql",
+}
+
 _engine: AsyncEngine | None = None
 _session_factory: async_sessionmaker[AsyncSession] | None = None
+# Los globals se tocan desde el lifespan, desde los workers y potencialmente desde
+# varios hilos (free-threading en 3.14): sin lock se pueden crear dos engines.
+_lock = threading.RLock()
+
+
+def normalize_async_dsn(url: str) -> str:
+    """
+    Devuelve un DSN utilizable por ``create_async_engine``.
+
+    ``postgresql://host/db`` → ``postgresql+asyncpg://host/db``. Si el DSN ya declara
+    un driver (``+asyncpg``, ``+psycopg``…) se deja intacto: puede que sea a propósito.
+    """
+    scheme, separator, rest = url.partition("://")
+    if not separator or "+" in scheme:
+        return url
+    replacement = _ASYNC_DRIVERS.get(scheme.lower())
+    if replacement is None:
+        return url
+    return f"{replacement}://{rest}"
+
+
+def init_engine(
+    url: str | None = None,
+    *,
+    pool: PoolSettings | None = None,
+    **engine_kwargs: t.Any,
+) -> AsyncEngine:
+    """
+    Crea (o devuelve) el engine asíncrono del proceso.
+
+    Args:
+        url: DSN explícito. Si es None, se usa ``config.async_sql_database_url``.
+            En ambos casos se normaliza el driver. Los workers, scripts y tests
+            necesitan poder pasarlo explícitamente.
+        pool: Tuning del pool. Ver `PoolSettings`.
+        **engine_kwargs: Se pasan tal cual a ``create_async_engine`` (``echo``,
+            ``connect_args``, ``json_serializer``…).
+
+    Returns:
+        El engine. Si ya había uno inicializado se devuelve ése **sin** aplicar los
+        parámetros nuevos: llamá a `dispose_engine()` antes si querés reconfigurar.
+    """
+    global _engine
+
+    with _lock:
+        if _engine is not None:
+            return _engine
+
+        dsn = normalize_async_dsn(url or LazyConfig.get_config().async_sql_database_url)
+        options = _pool_kwargs(dsn, pool or PoolSettings())
+        options.update(engine_kwargs)
+        _engine = create_async_engine(dsn, **options)
+        return _engine
+
+
+def _pool_kwargs(dsn: str, pool: PoolSettings) -> dict[str, t.Any]:
+    """
+    Traduce `PoolSettings` a kwargs de ``create_async_engine``.
+
+    SQLite no usa un pool con tamaño (``NullPool``/``StaticPool`` según el caso), y
+    pasarle ``pool_size`` es un ``TypeError``, así que esas dos opciones se omiten.
+    """
+    options: dict[str, t.Any] = {"pool_pre_ping": pool.pre_ping}
+    if pool.recycle is not None:
+        options["pool_recycle"] = pool.recycle
+
+    if dsn.startswith("sqlite"):
+        return options
+
+    if pool.size is not None:
+        options["pool_size"] = pool.size
+    if pool.max_overflow is not None:
+        options["max_overflow"] = pool.max_overflow
+    return options
+
+
+async def dispose_engine() -> None:
+    """
+    Cierra el pool de conexiones y deja el módulo re-inicializable.
+
+    Es lo que hay que llamar en el shutdown de un lifespan, y también antes de
+    reconfigurar el engine.
+    """
+    global _engine, _session_factory
+
+    with _lock:
+        engine, _engine = _engine, None
+        _session_factory = None
+
+    if engine is not None:
+        await engine.dispose()
 
 
 def get_engine() -> AsyncEngine:
     """
     Retorna el engine asíncrono de SQLAlchemy.
-    Se inicializa de forma lazy (solo cuando se solicita).
+    Se inicializa de forma lazy con los defaults de `init_engine()`.
     """
-    global _engine
-    if _engine is None:
-        _engine = create_async_engine(
-            LazyConfig.get_config().async_sql_database_url,
-            # echo=True,
-        )
-    return _engine
+    return init_engine()
 
 
 def get_session_factory() -> async_sessionmaker[AsyncSession]:
     """
     Retorna la factoría de sesiones de SQLAlchemy.
-    Se inicializa de forma lazy.
+    Se inicializa de forma lazy, con ``expire_on_commit=False``.
     """
     global _session_factory
-    if _session_factory is None:
-        _session_factory = async_sessionmaker(
-            autocommit=False,
-            autoflush=False,
-            bind=get_engine(),
-            class_=AsyncSession,
-        )
-    return _session_factory
+
+    with _lock:
+        if _session_factory is None:
+            _session_factory = async_sessionmaker(
+                autocommit=False,
+                autoflush=False,
+                bind=get_engine(),
+                class_=AsyncSession,
+                # Sin esto, acceder a un atributo después de `uow.commit()` dispara un
+                # lazy-load sobre una sesión cerrada.
+                expire_on_commit=False,
+            )
+        return _session_factory
 
 
 async def get_async_db_session() -> AsyncGenerator[AsyncSession, None]:
@@ -52,15 +199,10 @@ async def get_async_db_session() -> AsyncGenerator[AsyncSession, None]:
 
 async def reset_sqlalchemy_engine() -> None:
     """
-    Cierra el pool de conexiones actual y recrea el engine de forma lazy.
-    Crítico para inicializar asíncronamente workers (ej. RabbitMQ, Celery) 
-    y evitar el error de 'Task attached to a different loop'.
-    """
-    global _engine
-    global _session_factory
+    Alias legacy de `dispose_engine()`.
 
-    if _engine is not None:
-        await _engine.dispose()
-    
-    _engine = None
-    _session_factory = None
+    Se conserva porque los workers (RabbitMQ, Celery) lo llaman para re-atar el pool al
+    event loop nuevo. Para el shutdown de una app, `dispose_engine()` dice mejor lo que
+    hace.
+    """
+    await dispose_engine()

--- a/hexcore/infrastructure/task_queues/celery_adapter.py
+++ b/hexcore/infrastructure/task_queues/celery_adapter.py
@@ -39,9 +39,13 @@ class CeleryEnqueuer(ITaskEnqueuer):
         )
 
     async def enqueue_event(self, event_name: str, payload: dict[str, t.Any], queue: str) -> None:
-        # Los eventos genéricos (publish a todos los workers) rara vez se envían a Celery
-        # de esta forma. Normalmente se usa enqueue_handler. Se provee para completitud.
-        pass
+        raise NotImplementedError(
+            "CeleryEnqueuer no encola eventos completos: Celery es una cola de tareas, "
+            "no un bus de fan-out, así que un evento encolado aquí no llegaría a los "
+            "suscriptores. Para ejecutar un suscriptor concreto en background, "
+            "decoralo con @background_handler (el EventBus llamará a enqueue_handler). "
+            "Para fan-out real, usá RedisEventBus o PostgresEventBus."
+        )
 
     async def enqueue_handler(self, handler_name: str, payload: dict[str, t.Any], queue: str) -> None:
         await asyncio.to_thread(

--- a/hexcore/infrastructure/task_queues/celery_adapter.py
+++ b/hexcore/infrastructure/task_queues/celery_adapter.py
@@ -6,9 +6,13 @@ utilidades para auto-registrar las tareas asíncronas en el Worker.
 from __future__ import annotations
 
 import asyncio
+import logging
 import typing as t
+import weakref
 
 from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
+
+logger = logging.getLogger("hexcore.task_queues.celery")
 
 if t.TYPE_CHECKING:
     try:
@@ -64,15 +68,46 @@ class CeleryEnqueuer(ITaskEnqueuer):
         )
 
 
-def register_hexcore_celery_tasks(app: "Celery", consumer: "CQRSConsumer") -> None:
+HEXCORE_TASK_NAMES = (
+    "hexcore.process_command",
+    "hexcore.process_handler",
+    "hexcore.process_task",
+)
+
+_registered_apps: "weakref.WeakValueDictionary[int, t.Any]" = weakref.WeakValueDictionary()
+
+
+def is_registered(app: "Celery") -> bool:
+    """Indica si `register_hexcore_celery_tasks` ya corrió sobre esta app."""
+    return id(app) in _registered_apps
+
+
+def register_hexcore_celery_tasks(
+    app: "Celery",
+    consumer: "CQRSConsumer",
+    *,
+    force: bool = False,
+) -> bool:
     """
     Auto-registra las tareas base de HexCore en una aplicación Celery.
     Esto permite que un worker de Celery esté listo para recibir mensajes
     generados por el Smart Routing de HexCore.
-    
-    Dado que las tareas de Celery son síncronas y el Consumer de HexCore es 
+
+    Es **idempotente**: llamarla dos veces sobre la misma app no vuelve a registrar.
+    Antes cada aplicación tenía que protegerla con un flag de módulo.
+
+    Dado que las tareas de Celery son síncronas y el Consumer de HexCore es
     asíncrono, se envuelven en `asyncio.run()`.
+
+    Returns:
+        True si se registraron las tareas, False si ya estaban registradas.
     """
+    if not force and is_registered(app):
+        logger.debug(
+            "Las tareas de HexCore ya estaban registradas en esta app de Celery; "
+            "no se vuelven a registrar."
+        )
+        return False
 
     @app.task(name="hexcore.process_command", bind=True)
     def process_command(self: t.Any, payload: dict[str, t.Any]) -> None:
@@ -85,3 +120,9 @@ def register_hexcore_celery_tasks(app: "Celery", consumer: "CQRSConsumer") -> No
     @app.task(name="hexcore.process_task", bind=True)
     def process_task(self: t.Any, task_name: str, payload: dict[str, t.Any]) -> None:
         asyncio.run(consumer.process_task(task_name, payload))
+
+    try:
+        _registered_apps[id(app)] = app
+    except TypeError:
+        logger.debug("No se pudo memorizar el registro para esta app de Celery.")
+    return True

--- a/hexcore/infrastructure/task_queues/procrastinate_adapter.py
+++ b/hexcore/infrastructure/task_queues/procrastinate_adapter.py
@@ -5,9 +5,13 @@ utilidades para auto-registrar las tareas asíncronas en el Worker.
 """
 from __future__ import annotations
 
+import logging
 import typing as t
+import weakref
 
 from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
+
+logger = logging.getLogger("hexcore.task_queues.procrastinate")
 
 if t.TYPE_CHECKING:
     try:
@@ -49,10 +53,51 @@ class ProcrastinateEnqueuer(ITaskEnqueuer):
         await task.defer_async(task_name=task_name, payload=payload)
 
 
-def register_hexcore_procrastinate_tasks(app: "procrastinate.App", consumer: "CQRSConsumer") -> None:
+HEXCORE_TASK_NAMES = (
+    "hexcore.process_command",
+    "hexcore.process_handler",
+    "hexcore.process_task",
+)
+
+# Apps en las que ya se registraron las tareas. Se guarda por `id()` en un
+# WeakValueDictionary para no mantener viva la app y para tolerar varias apps en el
+# mismo proceso (tests, scripts que construyen y descartan apps).
+_registered_apps: "weakref.WeakValueDictionary[int, t.Any]" = weakref.WeakValueDictionary()
+
+
+def is_registered(app: "procrastinate.App") -> bool:
+    """Indica si `register_hexcore_procrastinate_tasks` ya corrió sobre esta app."""
+    return id(app) in _registered_apps
+
+
+def register_hexcore_procrastinate_tasks(
+    app: "procrastinate.App",
+    consumer: "CQRSConsumer",
+    *,
+    force: bool = False,
+) -> bool:
     """
     Auto-registra las tareas base de HexCore en una aplicación Procrastinate.
+
+    Es **idempotente**: llamarla dos veces sobre la misma app no hace nada la segunda
+    vez, en vez de reventar porque Procrastinate rechaza nombres duplicados. Antes cada
+    aplicación tenía que protegerla con un flag de módulo.
+
+    Args:
+        app: La aplicación de Procrastinate.
+        consumer: El `CQRSConsumer` que ejecutará los mensajes.
+        force: Registrar aunque ya se hubiera registrado. Útil para rebindear el
+            consumer; puede fallar si Procrastinate rechaza el nombre duplicado.
+
+    Returns:
+        True si se registraron las tareas, False si ya estaban registradas.
     """
+    if not force and is_registered(app):
+        logger.debug(
+            "Las tareas de HexCore ya estaban registradas en esta app de Procrastinate; "
+            "no se vuelven a registrar."
+        )
+        return False
 
     @app.task(name="hexcore.process_command")
     async def process_command(payload: dict[str, t.Any]) -> None:
@@ -65,3 +110,11 @@ def register_hexcore_procrastinate_tasks(app: "procrastinate.App", consumer: "CQ
     @app.task(name="hexcore.process_task")
     async def process_task(task_name: str, payload: dict[str, t.Any]) -> None:
         await consumer.process_task(task_name, payload)
+
+    try:
+        _registered_apps[id(app)] = app
+    except TypeError:
+        # Un objeto no referenciable débilmente (p. ej. un mock exótico): la
+        # idempotencia no se puede memorizar, pero el registro ya ocurrió.
+        logger.debug("No se pudo memorizar el registro para esta app de Procrastinate.")
+    return True

--- a/hexcore/infrastructure/task_queues/procrastinate_adapter.py
+++ b/hexcore/infrastructure/task_queues/procrastinate_adapter.py
@@ -32,7 +32,13 @@ class ProcrastinateEnqueuer(ITaskEnqueuer):
         await task.defer_async(payload=payload)
 
     async def enqueue_event(self, event_name: str, payload: dict[str, t.Any], queue: str) -> None:
-        pass
+        raise NotImplementedError(
+            "ProcrastinateEnqueuer no encola eventos completos: Procrastinate es una "
+            "cola de tareas, no un bus de fan-out, así que un evento encolado aquí no "
+            "llegaría a los suscriptores. Para ejecutar un suscriptor concreto en "
+            "background, decoralo con @background_handler (el EventBus llamará a "
+            "enqueue_handler). Para fan-out real, usá RedisEventBus o PostgresEventBus."
+        )
 
     async def enqueue_handler(self, handler_name: str, payload: dict[str, t.Any], queue: str) -> None:
         task = self.app.configure_task(name="hexcore.process_handler", queue=queue)

--- a/hexcore/infrastructure/uow/__init__.py
+++ b/hexcore/infrastructure/uow/__init__.py
@@ -187,3 +187,23 @@ class BeanieUnitOfWork(IUnitOfWork):
 
 # Alias por retrocompatibilidad
 NoSqlUnitOfWork = BeanieUnitOfWork
+
+
+# Scopes para código fuera de FastAPI (workers, cron, scripts, seeds).
+# Se importan al final: `scopes` sólo importa de este módulo de forma perezosa.
+from .scopes import (  # noqa: E402
+    nosql_uow_scope,
+    open_uow_scope,
+    session_scope,
+    uow_scope,
+)
+
+__all__ = [
+    "SqlAlchemyUnitOfWork",
+    "BeanieUnitOfWork",
+    "NoSqlUnitOfWork",
+    "session_scope",
+    "uow_scope",
+    "open_uow_scope",
+    "nosql_uow_scope",
+]

--- a/hexcore/infrastructure/uow/scopes.py
+++ b/hexcore/infrastructure/uow/scopes.py
@@ -1,0 +1,93 @@
+"""
+Scopes de sesión y Unit of Work para código que **no** es un request de FastAPI.
+
+`hexcore.infrastructure.api.utils` sólo ofrece dependencias FastAPI (`get_session`,
+`get_sql_uow`). Todo lo demás —workers, tasks de background, cron, scripts, seeds,
+migraciones de datos— se queda sin nada y termina reescribiendo estos dos context
+managers.
+
+`session_scope` no es un lujo: construir un `SqlAlchemyUnitOfWork` corre el
+auto-discovery e **instancia todos los repositorios de dominio**, un coste absurdo para
+leer una tabla de infraestructura como `cron_jobs`.
+
+Convención de `uow_scope`: **no** entra al UoW. Cede el UoW sin abrir la transacción,
+para que el use case controle su propio ``async with uow:``, que es la convención de
+los ejemplos de use case. Si querés el UoW ya abierto, usá `open_uow_scope`.
+"""
+from __future__ import annotations
+
+import typing as t
+from contextlib import asynccontextmanager
+
+if t.TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from hexcore.domain.uow import IUnitOfWork
+
+__all__ = ["session_scope", "uow_scope", "open_uow_scope", "nosql_uow_scope"]
+
+
+@asynccontextmanager
+async def session_scope() -> t.AsyncIterator["AsyncSession"]:
+    """
+    Cede una `AsyncSession` con su ciclo de vida gestionado.
+
+    No abre transacción ni comitea: eso lo decide quien la usa. Sirve para leer o
+    escribir tablas de infraestructura sin pagar el auto-discovery de repositorios.
+
+    Uso::
+
+        async with session_scope() as session:
+            rows = (await session.execute(select(CronJobModel))).scalars().all()
+    """
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (
+        get_session_factory,
+    )
+
+    factory = get_session_factory()
+    async with factory() as session:
+        yield session
+
+
+@asynccontextmanager
+async def uow_scope() -> t.AsyncIterator["IUnitOfWork"]:
+    """
+    Cede un `SqlAlchemyUnitOfWork` **sin entrar** en él.
+
+    Es la convención de los ejemplos de use case: el use case hace su propio
+    ``async with self.uow:`` y controla el commit. Entrar aquí y además allí anida
+    contextos.
+
+    Uso::
+
+        async with uow_scope() as uow:
+            await CerrarTicketUseCase(uow).execute(request)
+    """
+    from hexcore.infrastructure.uow import SqlAlchemyUnitOfWork
+
+    async with session_scope() as session:
+        yield SqlAlchemyUnitOfWork(session=session)
+
+
+@asynccontextmanager
+async def open_uow_scope() -> t.AsyncIterator["IUnitOfWork"]:
+    """
+    Como `uow_scope`, pero **entra** al UoW (abre la transacción) y hace rollback si
+    el bloque lanza.
+
+    Para código que no delega en un use case y quiere el UoW listo para usar. No
+    comitea: el commit sigue siendo explícito.
+    """
+    async with uow_scope() as uow:
+        async with uow:
+            yield uow
+
+
+@asynccontextmanager
+async def nosql_uow_scope() -> t.AsyncIterator["IUnitOfWork"]:
+    """Equivalente de `open_uow_scope` para el UoW de Beanie/MongoDB."""
+    from hexcore.infrastructure.uow import NoSqlUnitOfWork
+
+    uow: "IUnitOfWork" = NoSqlUnitOfWork()
+    async with uow:
+        yield uow

--- a/hexcore/infrastructure/workers/consumer.py
+++ b/hexcore/infrastructure/workers/consumer.py
@@ -3,11 +3,12 @@ Consumidor Universal para colas de tareas (Celery, Procrastinate).
 """
 from __future__ import annotations
 
-import importlib
 import logging
 import typing as t
 
 from hexcore.domain.cqrs.buses import AbstractCommandBus, AbstractEventBus
+from hexcore.domain.cqrs.context import worker_execution
+from hexcore.domain.cqrs.resolution import resolve_dotted
 from hexcore.domain.cqrs.serializer import ISerializer
 from hexcore.domain.events import DomainEvent
 
@@ -18,12 +19,15 @@ logger = logging.getLogger("hexcore.workers.consumer")
 
 
 def _resolve_callable(qualname: str) -> t.Callable[..., t.Any]:
-    """Resuelve un import por su nombre calificado (ej. 'myapp.events.on_user_created')."""
+    """
+    Resuelve un import por su nombre calificado (ej. 'myapp.events.on_user_created').
+
+    Soporta nombres anidados (``myapp.jobs.Jobs.cleanup``) delegando en
+    ``resolve_dotted``.
+    """
     try:
-        module_path, func_name = qualname.rsplit(".", 1)
-        module = importlib.import_module(module_path)
-        return getattr(module, func_name) # type: ignore
-    except (ValueError, ModuleNotFoundError, AttributeError) as exc:
+        return t.cast(t.Callable[..., t.Any], resolve_dotted(qualname))
+    except LookupError as exc:
         raise RuntimeError(f"No se pudo resolver el handler/tarea '{qualname}': {exc}") from exc
 
 
@@ -61,14 +65,19 @@ class CQRSConsumer:
     async def process_command(self, payload: dict[str, t.Any]) -> None:
         """
         Deserializa un payload de comando y lo despacha al bus local.
+
+        El despacho ocurre dentro de ``worker_execution()``, así que un bus con
+        Smart Routing **ejecuta** el comando en vez de reencolarlo. Esto permite
+        compartir el mismo bus entre el proceso web y el worker.
         """
         try:
             command = self._serializer.deserialize(payload)
             cmd = t.cast("Command", command)
-            
+
             logger.info("[CQRSConsumer] Procesando comando en background: %s", type(cmd).__qualname__)
-            await self._command_bus.dispatch(cmd)
-            
+            with worker_execution():
+                await self._command_bus.dispatch(cmd)
+
         except Exception as exc:
             logger.exception("[CQRSConsumer] Error procesando comando: %s", exc)
             raise
@@ -77,14 +86,19 @@ class CQRSConsumer:
         """
         Deserializa un payload de evento y lo publica en el bus local
         para que todos los handlers (suscriptores) locales lo consuman.
+
+        Igual que ``process_command``: se publica dentro de ``worker_execution()``,
+        así que los handlers marcados con ``@background_handler`` se ejecutan aquí
+        en vez de reencolarse.
         """
         try:
             event = self._serializer.deserialize(payload)
             evt = t.cast(DomainEvent, event)
-            
+
             logger.info("[CQRSConsumer] Procesando evento en background: %s", evt.event_name)
-            await self._event_bus.publish(evt)
-            
+            with worker_execution():
+                await self._event_bus.publish(evt)
+
         except Exception as exc:
             logger.exception("[CQRSConsumer] Error procesando evento: %s", exc)
             raise
@@ -93,6 +107,10 @@ class CQRSConsumer:
         """
         Deserializa el evento y ejecuta *específicamente* un handler decorado con `@background_handler`.
         Esto es inyectado por el Smart Routing del EventBus.
+
+        Nota: aquí **no** se activa ``worker_execution()``. El handler se invoca
+        directamente (no hay bus que consuma el flag), así que dejarlo activo haría
+        que los comandos que el handler despache a propósito se ejecutaran inline.
         """
         try:
             event = self._serializer.deserialize(payload)
@@ -110,6 +128,9 @@ class CQRSConsumer:
     async def process_task(self, task_name: str, payload: dict[str, t.Any]) -> None:
         """
         Ejecuta una tarea genérica de background decorada con `@background_task`.
+
+        Igual que ``process_handler``: la tarea se invoca directamente, sin activar
+        ``worker_execution()``.
         """
         try:
             logger.info("[CQRSConsumer] Ejecutando Task genérica en background: %s", task_name)

--- a/hexcore/infrastructure/workers/consumer.py
+++ b/hexcore/infrastructure/workers/consumer.py
@@ -36,31 +36,55 @@ class CQRSConsumer:
     Ayudante universal para recibir mensajes serializados desde un Worker 
     y despacharlos a los handlers locales usando buses en memoria.
     
-    Uso (ej. Procrastinate):
-    
-        consumer = CQRSConsumer(local_cmd_bus, local_evt_bus, serializer)
-        
-        @app.task(name="process_cqrs_command")
-        async def process_cqrs_command(payload: dict):
-            await consumer.process_command(payload)
+    Uso (ej. Procrastinate)::
+
+        consumer = CQRSConsumer(command_bus, event_bus)
+        register_hexcore_procrastinate_tasks(app, consumer)
+
+    Un worker sólo-comandos puede omitir el event bus::
+
+        consumer = CQRSConsumer(command_bus)
     """
 
     def __init__(
         self,
         command_bus: AbstractCommandBus,
-        event_bus: AbstractEventBus,
-        serializer: ISerializer,
+        event_bus: AbstractEventBus | None = None,
+        serializer: ISerializer | None = None,
     ) -> None:
         """
         Args:
             command_bus: El bus de comandos *local* (usualmente InMemoryCommandBus)
                          que tiene registrados los handlers.
             event_bus: El bus de eventos *local* (usualmente InMemoryEventBus).
-            serializer: El serializador usado (ej. PydanticSerializer).
+                       Opcional: un worker sólo-comandos no lo necesita, y antes había
+                       que pasar `cast(Any, None)` para satisfacer el tipo.
+            serializer: El serializador usado. Por defecto `PydanticSerializer`.
         """
+        if serializer is None:
+            from hexcore.infrastructure.cqrs.pydantic_serializer import PydanticSerializer
+
+            serializer = PydanticSerializer()
+
         self._command_bus = command_bus
         self._event_bus = event_bus
         self._serializer = serializer
+
+    @property
+    def event_bus(self) -> AbstractEventBus:
+        """
+        El event bus configurado.
+
+        Raises:
+            RuntimeError: Si el consumer se construyó sin event bus y llega un evento.
+        """
+        if self._event_bus is None:
+            raise RuntimeError(
+                "Llegó un evento pero este CQRSConsumer se construyó sin 'event_bus'. "
+                "Pasá un AbstractEventBus al construirlo si el worker tiene que "
+                "procesar eventos, o enrutá los eventos a otra cola."
+            )
+        return self._event_bus
 
     async def process_command(self, payload: dict[str, t.Any]) -> None:
         """
@@ -97,7 +121,7 @@ class CQRSConsumer:
 
             logger.info("[CQRSConsumer] Procesando evento en background: %s", evt.event_name)
             with worker_execution():
-                await self._event_bus.publish(evt)
+                await self.event_bus.publish(evt)
 
         except Exception as exc:
             logger.exception("[CQRSConsumer] Error procesando evento: %s", exc)

--- a/hexcore/infrastructure/workers/rabbitmq_worker.py
+++ b/hexcore/infrastructure/workers/rabbitmq_worker.py
@@ -16,17 +16,21 @@ logger = logging.getLogger("hexcore.workers.rabbitmq")
 @asynccontextmanager
 async def setup_sqlalchemy():
     """Context manager para inicializar y limpiar conexiones SQL en el worker."""
-    from hexcore.infrastructure.repositories.orms.sqlalchemy.session import reset_sqlalchemy_engine, engine
-    
-    # 1. Resetear el pool para atarlo a ESTE event loop
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (
+        dispose_engine,
+        init_engine,
+    )
+
+    # 1. Descartar cualquier pool heredado y crear el engine dentro de ESTE event loop.
     logger.info("[Worker Lifecycle] Inicializando engine de SQLAlchemy...")
-    await reset_sqlalchemy_engine()
-    
+    await dispose_engine()
+    init_engine()
+
     try:
         yield
     finally:
         logger.info("[Worker Lifecycle] Cerrando conexiones de SQLAlchemy...")
-        await engine.dispose()
+        await dispose_engine()
 
 
 @asynccontextmanager

--- a/tests/test_consumer_optional_event_bus.py
+++ b/tests/test_consumer_optional_event_bus.py
@@ -1,0 +1,68 @@
+"""
+P2-2: `CQRSConsumer` exigía un `event_bus` no-opcional, así que un worker
+sólo-comandos tenía que pasar `cast(Any, None)` para satisfacer el tipo.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hexcore.application.cqrs.in_memory_buses import InMemoryCommandBus
+from hexcore.application.cqrs.registry import HandlerRegistry
+from hexcore.domain.cqrs.commands import Command
+from hexcore.domain.events import DomainEvent
+from hexcore.infrastructure.cqrs.pydantic_serializer import PydanticSerializer
+from hexcore.infrastructure.workers.consumer import CQRSConsumer
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class OnlyCommand(Command):
+    value: str
+
+
+class OnlyCommandHandler:
+    def __init__(self) -> None:
+        self.seen: list[str] = []
+
+    async def handle(self, cmd: OnlyCommand) -> None:
+        self.seen.append(cmd.value)
+
+
+class StrayEvent(DomainEvent):
+    info: str
+
+
+def _command_only_consumer() -> tuple[CQRSConsumer, OnlyCommandHandler, PydanticSerializer]:
+    registry = HandlerRegistry()
+    handler = OnlyCommandHandler()
+    registry.register_command_handler(OnlyCommand, handler)
+    serializer = PydanticSerializer()
+    consumer = CQRSConsumer(InMemoryCommandBus(registry=registry, serializer=serializer))
+    return consumer, handler, serializer
+
+
+@pytest.mark.anyio
+async def test_command_only_worker_needs_no_event_bus():
+    consumer, handler, serializer = _command_only_consumer()
+
+    await consumer.process_command(serializer.serialize(OnlyCommand(value="x")))
+
+    assert handler.seen == ["x"]
+
+
+@pytest.mark.anyio
+async def test_event_without_event_bus_raises_a_clear_error():
+    consumer, _handler, serializer = _command_only_consumer()
+
+    with pytest.raises(RuntimeError, match="sin 'event_bus'"):
+        await consumer.process_event(serializer.serialize(StrayEvent(info="i")))
+
+
+def test_serializer_defaults_to_pydantic():
+    registry = HandlerRegistry()
+    consumer = CQRSConsumer(InMemoryCommandBus(registry=registry))
+
+    assert isinstance(consumer._serializer, PydanticSerializer)

--- a/tests/test_cqrs_factory.py
+++ b/tests/test_cqrs_factory.py
@@ -1,0 +1,141 @@
+"""
+P0-5: la vía oficial de construcción (`CQRSFactory`) debe producir buses capaces de
+Smart Routing. Antes construía `InMemoryCommandBus(registry=..., pipeline=...)` y
+nada más, así que el primer `@background_command` reventaba con `RuntimeError`.
+"""
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from hexcore.application.cqrs.config import BusConfig, CQRSConfig
+from hexcore.application.cqrs.factory import CQRSFactory
+from hexcore.application.cqrs.registry import HandlerRegistry
+from hexcore.domain.cqrs.commands import Command
+from hexcore.domain.cqrs.decorators import background_command, background_handler
+from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
+from hexcore.domain.events import DomainEvent
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class SpyEnqueuer(ITaskEnqueuer):
+    def __init__(self) -> None:
+        self.commands: list[tuple[str, dict[str, t.Any], str]] = []
+        self.handlers: list[tuple[str, dict[str, t.Any], str]] = []
+
+    async def enqueue_command(self, command_name: str, payload: dict[str, t.Any], queue: str) -> None:
+        self.commands.append((command_name, payload, queue))
+
+    async def enqueue_event(self, event_name: str, payload: dict[str, t.Any], queue: str) -> None:
+        raise NotImplementedError
+
+    async def enqueue_handler(self, handler_name: str, payload: dict[str, t.Any], queue: str) -> None:
+        self.handlers.append((handler_name, payload, queue))
+
+    async def enqueue_task(self, task_name: str, payload: dict[str, t.Any], queue: str) -> None:
+        raise NotImplementedError
+
+
+@background_command(queue="factory_queue")
+class FactoryBackgroundCommand(Command):
+    value: str
+
+
+class PlainCommand(Command):
+    value: str
+
+
+class PlainCommandHandler:
+    async def handle(self, cmd: PlainCommand) -> str:
+        return f"ok:{cmd.value}"
+
+
+class FactoryEvent(DomainEvent):
+    info: str
+
+
+@background_handler(queue="factory_events")
+async def on_factory_event(event: FactoryEvent) -> None:  # pragma: no cover
+    ...
+
+
+@pytest.mark.anyio
+async def test_factory_command_bus_can_route_background_commands():
+    registry = HandlerRegistry()
+    registry.register_command_handler(FactoryBackgroundCommand, PlainCommandHandler())
+    enqueuer = SpyEnqueuer()
+
+    factory = CQRSFactory(CQRSConfig(), registry, enqueuer=enqueuer)
+    bus = factory.create_command_bus()
+
+    await bus.dispatch(FactoryBackgroundCommand(value="x"))
+
+    assert [name for name, _p, _q in enqueuer.commands] == ["FactoryBackgroundCommand"]
+    assert enqueuer.commands[0][2] == "factory_queue"
+
+
+@pytest.mark.anyio
+async def test_factory_event_bus_can_route_background_handlers():
+    registry = HandlerRegistry()
+    enqueuer = SpyEnqueuer()
+
+    factory = CQRSFactory(CQRSConfig(), registry, enqueuer=enqueuer)
+    event_bus = factory.create_event_bus()
+    event_bus.subscribe(FactoryEvent, on_factory_event)
+
+    await event_bus.publish(FactoryEvent(info="i"))
+
+    assert len(enqueuer.handlers) == 1
+    assert enqueuer.handlers[0][2] == "factory_events"
+
+
+def test_factory_fails_at_construction_when_background_commands_have_no_enqueuer():
+    registry = HandlerRegistry()
+    registry.register_command_handler(FactoryBackgroundCommand, PlainCommandHandler())
+
+    factory = CQRSFactory(CQRSConfig(), registry)
+
+    with pytest.raises(RuntimeError, match="FactoryBackgroundCommand"):
+        factory.create_command_bus()
+
+
+def test_factory_without_enqueuer_still_works_without_background_commands():
+    registry = HandlerRegistry()
+    registry.register_command_handler(PlainCommand, PlainCommandHandler())
+
+    factory = CQRSFactory(CQRSConfig(), registry)
+
+    assert factory.create_command_bus() is not None
+
+
+@pytest.mark.anyio
+async def test_factory_command_bus_executes_plain_commands():
+    registry = HandlerRegistry()
+    registry.register_command_handler(PlainCommand, PlainCommandHandler())
+
+    bus = CQRSFactory(CQRSConfig(), registry).create_command_bus()
+
+    assert await bus.dispatch(PlainCommand(value="v")) == "ok:v"
+
+
+def test_factory_caches_the_serializer():
+    factory = CQRSFactory(CQRSConfig(), HandlerRegistry())
+
+    assert factory.create_serializer() is factory.create_serializer()
+
+
+def test_factory_reports_middlewares_that_need_configuration():
+    config = CQRSConfig(
+        command_bus=BusConfig(
+            middlewares=["hexcore.infrastructure.cqrs.middlewares.TransactionMiddleware"]
+        )
+    )
+    factory = CQRSFactory(config, HandlerRegistry())
+
+    with pytest.raises(ValueError, match="instancialo a mano"):
+        factory.create_command_bus()

--- a/tests/test_cqrs_middlewares.py
+++ b/tests/test_cqrs_middlewares.py
@@ -1,0 +1,61 @@
+"""
+P0-6: `TransactionMiddleware` ya no es el default de `CQRSConfig` y exige
+`uow_factory` explícito en vez de adivinar la sesión.
+"""
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from hexcore.application.cqrs.config import CQRSConfig
+from hexcore.infrastructure.cqrs.middlewares import TransactionMiddleware
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def test_cqrs_config_has_no_default_middlewares():
+    config = CQRSConfig()
+
+    assert config.command_bus.middlewares == []
+    assert config.query_bus.middlewares == []
+    assert config.event_bus.middlewares == []
+
+
+def test_transaction_middleware_requires_explicit_uow_factory():
+    with pytest.raises(ValueError, match="uow_factory"):
+        TransactionMiddleware()
+
+
+class FakeUoW:
+    def __init__(self) -> None:
+        self.entered = False
+        self.commits = 0
+
+    async def __aenter__(self) -> "FakeUoW":
+        self.entered = True
+        return self
+
+    async def __aexit__(self, *exc: t.Any) -> None:
+        return None
+
+    async def commit(self) -> None:
+        self.commits += 1
+
+
+@pytest.mark.anyio
+async def test_transaction_middleware_uses_the_injected_factory():
+    uow = FakeUoW()
+    middleware = TransactionMiddleware(uow_factory=lambda: uow)
+
+    async def next_handler(message: t.Any) -> str:
+        return f"handled:{message}"
+
+    result = await middleware.handle("msg", next_handler)
+
+    assert result == "handled:msg"
+    assert uow.entered is True
+    assert uow.commits == 1

--- a/tests/test_dotted_resolution.py
+++ b/tests/test_dotted_resolution.py
@@ -1,0 +1,138 @@
+"""
+P0-3: resolución de `__qualname__` para clases y funciones anidadas.
+
+Antes, `PydanticSerializer.deserialize` y `_resolve_callable` partían el FQN con
+`rsplit(".", 1)`. Para una clase anidada el `__qualname__` ya contiene puntos, así
+que el module path resultante era inválido y el mensaje fallaba **en el worker**,
+donde ya no se puede recuperar.
+"""
+from __future__ import annotations
+
+import pytest
+
+from hexcore.domain.cqrs.commands import Command
+from hexcore.domain.cqrs.decorators import (
+    background_command,
+    background_handler,
+    background_task,
+)
+from hexcore.domain.cqrs.resolution import build_fqn, resolve_dotted
+from hexcore.infrastructure.cqrs.pydantic_serializer import PydanticSerializer
+from hexcore.infrastructure.workers.consumer import _resolve_callable
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class Outer:
+    class InnerCommand(Command):
+        value: str
+
+    @staticmethod
+    def a_function() -> str:
+        return "inner-function"
+
+
+def module_level_function() -> str:
+    return "module-level"
+
+
+# ── resolve_dotted ─────────────────────────────────────────────────────────────
+
+
+def test_resolve_dotted_resolves_module_level_object():
+    resolved = resolve_dotted(f"{__name__}.module_level_function")
+    assert resolved is module_level_function
+
+
+def test_resolve_dotted_resolves_nested_class():
+    resolved = resolve_dotted(f"{__name__}.Outer.InnerCommand")
+    assert resolved is Outer.InnerCommand
+
+
+def test_resolve_dotted_resolves_nested_function():
+    resolved = resolve_dotted(f"{__name__}.Outer.a_function")
+    assert resolved() == "inner-function"
+
+
+def test_resolve_dotted_raises_lookup_error_for_unknown():
+    with pytest.raises(LookupError):
+        resolve_dotted(f"{__name__}.DoesNotExist")
+
+
+def test_resolve_dotted_raises_lookup_error_for_unknown_module():
+    with pytest.raises(LookupError):
+        resolve_dotted("no_such_module_at_all.Thing")
+
+
+def test_build_fqn_keeps_full_qualname():
+    assert (
+        build_fqn(Outer.InnerCommand)
+        == f"{__name__}.Outer.InnerCommand"
+    )
+
+
+# ── Round-trip del serializer ──────────────────────────────────────────────────
+
+
+def test_serializer_round_trip_of_nested_command():
+    serializer = PydanticSerializer()
+    payload = serializer.serialize(Outer.InnerCommand(value="nested"))
+
+    assert payload["__type__"] == f"{__name__}.Outer.InnerCommand"
+
+    restored = serializer.deserialize(payload)
+    assert isinstance(restored, Outer.InnerCommand)
+    assert restored.value == "nested"
+
+
+# ── _resolve_callable del consumer ─────────────────────────────────────────────
+
+
+class TaskHolder:
+    ran: list[str] = []
+
+    @staticmethod
+    @background_task(queue="q")
+    async def cleanup() -> None:
+        TaskHolder.ran.append("cleanup")
+
+
+def test_consumer_resolves_nested_static_task():
+    task_name = getattr(TaskHolder.cleanup, "__cqrs_task_name__")
+    assert task_name == f"{__name__}.TaskHolder.cleanup"
+    assert _resolve_callable(task_name) is not None
+
+
+def test_consumer_resolve_callable_raises_runtime_error_on_unknown():
+    with pytest.raises(RuntimeError):
+        _resolve_callable(f"{__name__}.nope")
+
+
+# ── Rechazo en tiempo de decoración de objetos no resolubles ───────────────────
+
+
+def test_background_task_rejects_local_function():
+    with pytest.raises(ValueError, match="<locals>"):
+
+        @background_task(queue="q")
+        async def local_task() -> None:  # pragma: no cover - nunca se decora
+            ...
+
+
+def test_background_handler_rejects_local_function():
+    with pytest.raises(ValueError, match="<locals>"):
+
+        @background_handler(queue="q")
+        async def local_handler(event: object) -> None:  # pragma: no cover
+            ...
+
+
+def test_background_command_rejects_local_class():
+    with pytest.raises(ValueError, match="<locals>"):
+
+        @background_command(queue="q")
+        class LocalCommand(Command):  # pragma: no cover
+            value: str

--- a/tests/test_handler_registry.py
+++ b/tests/test_handler_registry.py
@@ -1,0 +1,199 @@
+"""
+P1-5: el `HandlerRegistry` decía ser thread-safe y no lo era.
+
+`resolve_*` hace lazy-init con escritura en el dict, sin ningún lock. Con dos hilos
+(y con el free-threading de Python 3.14 son hilos reales) el handler se instanciaba
+dos veces y cada hilo se quedaba con la suya.
+
+También cubre la ambigüedad de `callable(entry) and not isinstance(entry, ICommandHandler)`
+cuando un handler implementa `__call__`.
+"""
+from __future__ import annotations
+
+import threading
+import typing as t
+
+import pytest
+
+from hexcore.application.cqrs.registry import HandlerRegistry
+from hexcore.domain.cqrs.commands import Command
+from hexcore.domain.cqrs.exceptions import DuplicateHandlerError, HandlerNotFoundError
+from hexcore.domain.cqrs.queries import Query
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class SomeCommand(Command):
+    value: str
+
+
+class SomeQuery(Query[str]):
+    value: str
+
+
+class SomeHandler:
+    instances = 0
+
+    def __init__(self) -> None:
+        type(self).instances += 1
+
+    async def handle(self, message: t.Any) -> str:
+        return "ok"
+
+
+class CallableHandler:
+    """Handler que además implementa `__call__`: el caso ambiguo del plan."""
+
+    async def handle(self, message: t.Any) -> str:
+        return "handled"
+
+    def __call__(self) -> "CallableHandler":  # pragma: no cover - no debe invocarse
+        raise AssertionError("se trató un handler callable como si fuera un factory")
+
+
+# ── Thread-safety ──────────────────────────────────────────────────────────────
+
+
+def test_concurrent_resolution_instantiates_the_handler_once():
+    SomeHandler.instances = 0
+    registry = HandlerRegistry()
+    ready = threading.Barrier(8)
+    resolved: list[object] = []
+    lock = threading.Lock()
+
+    def build() -> SomeHandler:
+        return SomeHandler()
+
+    registry.register_command_handler(SomeCommand, HandlerRegistry.factory(build))
+
+    def worker() -> None:
+        ready.wait()
+        handler = registry.resolve_command_handler(SomeCommand)
+        with lock:
+            resolved.append(handler)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert SomeHandler.instances == 1, "el handler se instanció más de una vez"
+    assert len({id(handler) for handler in resolved}) == 1, "los hilos vieron instancias distintas"
+
+
+def test_concurrent_registration_of_distinct_types_does_not_lose_entries():
+    registry = HandlerRegistry()
+    command_types = [
+        type(f"Cmd{i}", (Command,), {"__annotations__": {"value": str}})
+        for i in range(50)
+    ]
+    ready = threading.Barrier(5)
+
+    def worker(chunk: list[type[Command]]) -> None:
+        ready.wait()
+        for command_type in chunk:
+            registry.register_command_handler(command_type, SomeHandler())
+
+    chunks = [command_types[i::5] for i in range(5)]
+    threads = [threading.Thread(target=worker, args=(chunk,)) for chunk in chunks]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(registry.registered_commands) == 50
+
+
+def test_factory_can_resolve_another_handler_reentrantly():
+    """El lock es reentrante: un factory puede pedirle otro handler al registry."""
+    registry = HandlerRegistry()
+    registry.register_command_handler(SomeCommand, SomeHandler())
+
+    def build() -> SomeHandler:
+        registry.resolve_command_handler(SomeCommand)
+        return SomeHandler()
+
+    other = type("OtherCommand", (Command,), {"__annotations__": {"value": str}})
+    registry.register_command_handler(other, HandlerRegistry.factory(build))
+
+    assert registry.resolve_command_handler(other) is not None
+
+
+# ── Marcador explícito de factory ──────────────────────────────────────────────
+
+
+def test_callable_handler_is_not_mistaken_for_a_factory():
+    registry = HandlerRegistry()
+    handler = CallableHandler()
+    registry.register_command_handler(SomeCommand, handler)
+
+    assert registry.resolve_command_handler(SomeCommand) is handler
+
+
+def test_explicit_factory_marker_is_invoked_and_cached():
+    SomeHandler.instances = 0
+    registry = HandlerRegistry()
+    registry.register_command_handler(
+        SomeCommand, HandlerRegistry.factory(lambda: SomeHandler())
+    )
+
+    first = registry.resolve_command_handler(SomeCommand)
+    second = registry.resolve_command_handler(SomeCommand)
+
+    assert first is second
+    assert SomeHandler.instances == 1
+
+
+def test_bare_lambda_factory_still_works():
+    """Retrocompatibilidad: el callable pelado sigue detectándose por heurística."""
+    SomeHandler.instances = 0
+    registry = HandlerRegistry()
+    registry.register_command_handler(SomeCommand, lambda: SomeHandler())
+
+    assert registry.resolve_command_handler(SomeCommand) is not None
+    assert SomeHandler.instances == 1
+
+
+def test_query_factory_marker_works_too():
+    SomeHandler.instances = 0
+    registry = HandlerRegistry()
+    registry.register_query_handler(
+        SomeQuery, HandlerRegistry.factory(lambda: SomeHandler())
+    )
+
+    first = registry.resolve_query_handler(SomeQuery)
+
+    assert first is registry.resolve_query_handler(SomeQuery)
+    assert SomeHandler.instances == 1
+
+
+# ── Comportamiento existente que no debe cambiar ───────────────────────────────
+
+
+def test_duplicate_registration_still_raises():
+    registry = HandlerRegistry()
+    registry.register_command_handler(SomeCommand, SomeHandler())
+
+    with pytest.raises(DuplicateHandlerError):
+        registry.register_command_handler(SomeCommand, SomeHandler())
+
+
+def test_allow_override_still_works():
+    registry = HandlerRegistry(allow_override=True)
+    first = SomeHandler()
+    second = SomeHandler()
+    registry.register_command_handler(SomeCommand, first)
+    registry.register_command_handler(SomeCommand, second)
+
+    assert registry.resolve_command_handler(SomeCommand) is second
+
+
+def test_missing_handler_still_raises():
+    registry = HandlerRegistry()
+
+    with pytest.raises(HandlerNotFoundError):
+        registry.resolve_command_handler(SomeCommand)

--- a/tests/test_lock_error_policy.py
+++ b/tests/test_lock_error_policy.py
@@ -1,0 +1,132 @@
+"""
+P1-2: los lock providers ya no apagan el cron entero en silencio.
+
+Ambos capturaban `Exception` y devolvían `False`. Si Redis (o Postgres) se caía,
+`acquire_lock` devolvía `False` para **todos** los jobs → el cron completo dejaba de
+funcionar, con un `logger.error` por job y por tick indistinguible de "el lock estaba
+tomado por otra réplica", que es el caso normal y esperado.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+from unittest.mock import AsyncMock
+
+from hexcore.infrastructure.cqrs.postgres_lock import PostgresLockProvider
+from hexcore.infrastructure.cqrs.redis_lock import RedisLockProvider
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── Redis ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_redis_skip_is_the_default_and_returns_false():
+    client = AsyncMock()
+    client.set.side_effect = ConnectionError("redis down")
+    provider = RedisLockProvider(client)
+
+    assert provider.on_error == "skip"
+    assert await provider.acquire_lock("k", 60) is False
+
+
+@pytest.mark.anyio
+async def test_redis_raise_propagates_the_error():
+    client = AsyncMock()
+    client.set.side_effect = ConnectionError("redis down")
+    provider = RedisLockProvider(client, on_error="raise")
+
+    with pytest.raises(ConnectionError):
+        await provider.acquire_lock("k", 60)
+
+
+@pytest.mark.anyio
+async def test_redis_undecidable_logs_critical(caplog):
+    client = AsyncMock()
+    client.set.side_effect = ConnectionError("redis down")
+    provider = RedisLockProvider(client)
+
+    with caplog.at_level(logging.DEBUG):
+        await provider.acquire_lock("k", 60)
+
+    criticals = [r for r in caplog.records if r.levelno == logging.CRITICAL]
+    assert len(criticals) == 1
+    assert "No se pudo decidir" in criticals[0].getMessage()
+
+
+@pytest.mark.anyio
+async def test_redis_lock_already_taken_is_only_debug(caplog):
+    """El caso normal no debe generar ruido de nivel error/critical."""
+    client = AsyncMock()
+    client.set.return_value = None  # otro proceso lo tiene
+    provider = RedisLockProvider(client)
+
+    with caplog.at_level(logging.DEBUG):
+        assert await provider.acquire_lock("k", 60) is False
+
+    assert [r for r in caplog.records if r.levelno >= logging.ERROR] == []
+    assert any("ya estaba tomado" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.anyio
+async def test_redis_acquire_success():
+    client = AsyncMock()
+    client.set.return_value = True
+    provider = RedisLockProvider(client)
+
+    assert await provider.acquire_lock("k", 60) is True
+
+
+# ── Postgres ───────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_postgres_skip_is_the_default_and_returns_false():
+    pool = AsyncMock()
+    pool.fetchrow.side_effect = ConnectionError("pg down")
+    provider = PostgresLockProvider(pool)
+
+    assert provider.on_error == "skip"
+    assert await provider.acquire_lock("k", 60) is False
+
+
+@pytest.mark.anyio
+async def test_postgres_raise_propagates_the_error():
+    pool = AsyncMock()
+    pool.fetchrow.side_effect = ConnectionError("pg down")
+    provider = PostgresLockProvider(pool, on_error="raise")
+
+    with pytest.raises(ConnectionError):
+        await provider.acquire_lock("k", 60)
+
+
+@pytest.mark.anyio
+async def test_postgres_undecidable_logs_critical(caplog):
+    pool = AsyncMock()
+    pool.fetchrow.side_effect = ConnectionError("pg down")
+    provider = PostgresLockProvider(pool)
+
+    with caplog.at_level(logging.DEBUG):
+        await provider.acquire_lock("k", 60)
+
+    criticals = [r for r in caplog.records if r.levelno == logging.CRITICAL]
+    assert len(criticals) == 1
+    assert "No se pudo decidir" in criticals[0].getMessage()
+
+
+@pytest.mark.anyio
+async def test_postgres_lock_already_taken_is_only_debug(caplog):
+    pool = AsyncMock()
+    pool.fetchrow.return_value = None
+    provider = PostgresLockProvider(pool, purge_every=0)
+
+    with caplog.at_level(logging.DEBUG):
+        assert await provider.acquire_lock("k", 60) is False
+
+    assert [r for r in caplog.records if r.levelno >= logging.ERROR] == []
+    assert any("ya estaba tomado" in r.getMessage() for r in caplog.records)

--- a/tests/test_postgres_lock.py
+++ b/tests/test_postgres_lock.py
@@ -23,10 +23,16 @@ def mock_pool():
 async def test_postgres_lock_setup(mock_pool):
     provider = PostgresLockProvider(mock_pool)
     await provider.setup()
-    
-    mock_pool.execute.assert_awaited_once()
-    query = mock_pool.execute.call_args[0][0]
-    assert "CREATE TABLE IF NOT EXISTS hexcore_cron_locks" in query
+
+    queries = [call.args[0] for call in mock_pool.execute.await_args_list]
+    assert any("CREATE TABLE IF NOT EXISTS hexcore_cron_locks" in q for q in queries)
+    # P0-4: el índice sobre expires_at es lo que hace la purga barata.
+    assert any(
+        "CREATE INDEX IF NOT EXISTS hexcore_cron_locks_expires_at_idx" in q
+        for q in queries
+    )
+    # P0-4: setup() arrastra la basura de ejecuciones anteriores.
+    assert any("DELETE FROM hexcore_cron_locks" in q for q in queries)
 
 
 @pytest.mark.anyio
@@ -70,8 +76,77 @@ async def test_postgres_lock_acquire_exception(mock_pool):
 async def test_postgres_lock_release(mock_pool):
     provider = PostgresLockProvider(mock_pool)
     await provider.release_lock("my_lock")
-    
+
     mock_pool.execute.assert_awaited_once()
     args = mock_pool.execute.call_args[0]
     assert "DELETE FROM" in args[0]
     assert args[1] == "my_lock"
+
+
+# ── P0-4: la tabla de locks no puede crecer sin límite ─────────────────────────
+
+
+@pytest.mark.anyio
+async def test_acquire_lock_purges_expired_rows_periodically(mock_pool):
+    mock_pool.fetchrow.return_value = {"lock_key": "k"}
+    provider = PostgresLockProvider(mock_pool, purge_every=5)
+
+    for i in range(5):
+        await provider.acquire_lock(f"job:{i}", ttl_seconds=60)
+
+    deletes = [
+        call.args[0]
+        for call in mock_pool.execute.await_args_list
+        if "DELETE FROM hexcore_cron_locks" in call.args[0]
+    ]
+    assert len(deletes) == 1, "la purga no se disparó al alcanzar purge_every"
+    assert "expires_at <" in deletes[0]
+
+
+@pytest.mark.anyio
+async def test_acquire_lock_does_not_purge_before_threshold(mock_pool):
+    mock_pool.fetchrow.return_value = {"lock_key": "k"}
+    provider = PostgresLockProvider(mock_pool, purge_every=100)
+
+    for i in range(10):
+        await provider.acquire_lock(f"job:{i}", ttl_seconds=60)
+
+    assert mock_pool.execute.await_count == 0
+
+
+@pytest.mark.anyio
+async def test_purge_every_zero_disables_automatic_purge(mock_pool):
+    mock_pool.fetchrow.return_value = {"lock_key": "k"}
+    provider = PostgresLockProvider(mock_pool, purge_every=0)
+
+    for i in range(200):
+        await provider.acquire_lock(f"job:{i}", ttl_seconds=60)
+
+    assert mock_pool.execute.await_count == 0
+
+
+@pytest.mark.anyio
+async def test_purge_expired_respects_grace_period(mock_pool):
+    provider = PostgresLockProvider(mock_pool, purge_grace_seconds=7200)
+    await provider.purge_expired()
+
+    args = mock_pool.execute.call_args[0]
+    assert "DELETE FROM hexcore_cron_locks" in args[0]
+    assert args[1] == "7200"
+
+
+@pytest.mark.anyio
+async def test_purge_expired_does_not_propagate_errors(mock_pool):
+    mock_pool.execute.side_effect = Exception("DB down")
+    provider = PostgresLockProvider(mock_pool)
+
+    await provider.purge_expired()  # no debe lanzar
+
+
+@pytest.mark.anyio
+async def test_purge_failure_does_not_break_acquisition(mock_pool):
+    mock_pool.fetchrow.return_value = {"lock_key": "k"}
+    mock_pool.execute.side_effect = Exception("DB down")
+    provider = PostgresLockProvider(mock_pool, purge_every=1)
+
+    assert await provider.acquire_lock("job", ttl_seconds=60) is True

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -38,6 +38,8 @@ def anyio_backend():
 
 
 @pytest.mark.anyio
+# tick=1s sin lock_provider avisa a propósito (P1-1); aquí es intencional.
+@pytest.mark.filterwarnings("ignore:DynamicScheduler con tick_interval_seconds:RuntimeWarning")
 async def test_dynamic_scheduler_enqueues_matched_jobs():
     enqueuer = AsyncMock()
     

--- a/tests/test_scheduler_catchup.py
+++ b/tests/test_scheduler_catchup.py
@@ -1,0 +1,361 @@
+"""
+P1-1: el `DynamicScheduler` decide por catch-up real, no por "¿coincide con el
+minuto actual?".
+
+Antes, `base_time` y `last_check_time` se calculaban y no se usaban: la decisión era
+`croniter.match(expr, current_time)`. Con `tick=60s` el drift acumulado terminaba
+saltándose un minuto entero (y el job no corría); con `tick<60s` el mismo minuto se
+muestreaba varias veces y el job se duplicaba si no había lock.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from hexcore.application.cqrs.scheduler import DynamicScheduler
+from hexcore.domain.cqrs.cron import CronJobDefinition, ICronJobRepository, ILockProvider
+from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class FakeRepo(ICronJobRepository):
+    def __init__(self, jobs: list[CronJobDefinition]) -> None:
+        self.jobs = jobs
+        self.last_runs: list[tuple[str, datetime]] = []
+
+    async def get_active_jobs(self) -> list[CronJobDefinition]:
+        return self.jobs
+
+    async def update_last_run(self, job_id: str, run_time: datetime) -> None:
+        self.last_runs.append((job_id, run_time))
+        for job in self.jobs:
+            if job.job_id == job_id:
+                job.last_run_at = run_time
+
+
+class FakeEnqueuer(ITaskEnqueuer):
+    def __init__(self) -> None:
+        self.tasks: list[tuple[str, dict, str]] = []
+
+    async def enqueue_command(self, command_name: str, payload: dict, queue: str) -> None:
+        raise NotImplementedError
+
+    async def enqueue_event(self, event_name: str, payload: dict, queue: str) -> None:
+        raise NotImplementedError
+
+    async def enqueue_handler(self, handler_name: str, payload: dict, queue: str) -> None:
+        raise NotImplementedError
+
+    async def enqueue_task(self, task_name: str, payload: dict, queue: str) -> None:
+        self.tasks.append((task_name, payload, queue))
+
+
+class SharedLockProvider(ILockProvider):
+    """Lock in-memory compartido: simula dos réplicas contra el mismo Redis."""
+
+    def __init__(self) -> None:
+        self.held: set[str] = set()
+        self.attempts: list[str] = []
+
+    async def acquire_lock(self, lock_key: str, ttl_seconds: int) -> bool:
+        self.attempts.append(lock_key)
+        if lock_key in self.held:
+            return False
+        self.held.add(lock_key)
+        return True
+
+    async def release_lock(self, lock_key: str) -> None:
+        self.held.discard(lock_key)
+
+
+def _job(cron: str = "* * * * *", **kwargs) -> CronJobDefinition:
+    defaults = dict(job_id="j1", task_name="my_task", cron_expression=cron)
+    defaults.update(kwargs)
+    return CronJobDefinition(**defaults)  # type: ignore[arg-type]
+
+
+def _make(repo: FakeRepo, **kwargs) -> tuple[DynamicScheduler, FakeEnqueuer]:
+    enqueuer = FakeEnqueuer()
+    kwargs.setdefault("tick_interval_seconds", 60)
+    scheduler = DynamicScheduler(repository=repo, enqueuer=enqueuer, **kwargs)
+    return scheduler, enqueuer
+
+
+# ── Catch-up: el minuto saltado no se pierde ───────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_job_runs_even_if_its_minute_was_skipped():
+    """
+    El caso que motivó el ítem: un cierre contable diario cuyo minuto exacto se
+    saltó por drift del tick. La ocurrencia sigue pendiente y debe encolarse.
+    """
+    now = datetime(2026, 7, 29, 3, 5, 0, tzinfo=timezone.utc)
+    # El job era a las 03:00. El tick anterior fue a las 02:59:50, el actual a las
+    # 03:05: 03:00 quedó entre ambos y `croniter.match(expr, 03:05)` no lo vería.
+    repo = FakeRepo([_job("0 3 * * *")])
+    scheduler, enqueuer = _make(repo)
+
+    await scheduler._process_job(
+        repo.jobs[0],
+        last_check_time=now - timedelta(minutes=5, seconds=10),
+        current_time=now,
+    )
+
+    assert len(enqueuer.tasks) == 1
+    assert repo.last_runs == [("j1", datetime(2026, 7, 29, 3, 0, tzinfo=timezone.utc))]
+
+
+@pytest.mark.anyio
+async def test_job_is_not_enqueued_when_no_occurrence_is_due():
+    now = datetime(2026, 7, 29, 3, 5, 0, tzinfo=timezone.utc)
+    repo = FakeRepo([_job("0 3 * * *")])
+    scheduler, enqueuer = _make(repo)
+
+    # El job ya corrió a las 03:00; entre 03:00 y 03:05 no hay otra ocurrencia.
+    repo.jobs[0].last_run_at = datetime(2026, 7, 29, 3, 0, tzinfo=timezone.utc)
+
+    await scheduler._process_job(
+        repo.jobs[0],
+        last_check_time=now - timedelta(minutes=1),
+        current_time=now,
+    )
+
+    assert enqueuer.tasks == []
+
+
+@pytest.mark.anyio
+async def test_catch_up_window_bounds_ancient_occurrences():
+    """Un scheduler caído mucho tiempo no debe disparar ocurrencias antiguas."""
+    now = datetime(2026, 7, 29, 12, 0, 0, tzinfo=timezone.utc)
+    repo = FakeRepo([_job("0 3 * * *")])
+    # Última ejecución hace un mes; la ventana de catch-up es de 1h por defecto.
+    repo.jobs[0].last_run_at = now - timedelta(days=30)
+    scheduler, enqueuer = _make(repo, catch_up_window_seconds=3600)
+
+    await scheduler._process_job(
+        repo.jobs[0], last_check_time=now - timedelta(days=30), current_time=now
+    )
+
+    assert enqueuer.tasks == []
+
+
+@pytest.mark.anyio
+async def test_multiple_missed_occurrences_enqueue_only_once():
+    """Recuperar N veces seguidas es peor que recuperar una."""
+    now = datetime(2026, 7, 29, 3, 30, 0, tzinfo=timezone.utc)
+    repo = FakeRepo([_job("* * * * *")])  # 30 ocurrencias perdidas
+    scheduler, enqueuer = _make(repo)
+
+    await scheduler._process_job(
+        repo.jobs[0], last_check_time=now - timedelta(minutes=30), current_time=now
+    )
+
+    assert len(enqueuer.tasks) == 1
+    # Se marca la ocurrencia más reciente, no la más antigua.
+    assert repo.last_runs[0][1] == now
+
+
+# ── Deduplicación con tick < 60s ───────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_sub_minute_ticks_do_not_duplicate_the_same_occurrence():
+    repo = FakeRepo([_job("* * * * *")])
+    scheduler, enqueuer = _make(
+        repo, tick_interval_seconds=15, lock_provider=SharedLockProvider()
+    )
+
+    anchor = datetime(2026, 7, 29, 3, 0, 0, tzinfo=timezone.utc) - timedelta(microseconds=1)
+    # Cuatro muestreos del mismo minuto, como haría un tick de 15s.
+    for offset in (1, 16, 31, 46):
+        await scheduler._process_job(
+            repo.jobs[0],
+            last_check_time=anchor,
+            current_time=datetime(2026, 7, 29, 3, 0, offset, tzinfo=timezone.utc),
+        )
+
+    assert len(enqueuer.tasks) == 1, "el mismo minuto se encoló más de una vez"
+
+
+@pytest.mark.anyio
+async def test_local_memory_dedupes_even_if_repository_does_not_persist():
+    """Si el repo ignora `update_last_run`, la memoria local sigue deduplicando."""
+
+    class ForgetfulRepo(FakeRepo):
+        async def update_last_run(self, job_id: str, run_time: datetime) -> None:
+            return None  # no persiste nada
+
+    repo = ForgetfulRepo([_job("* * * * *")])
+    scheduler, enqueuer = _make(repo, tick_interval_seconds=60)
+
+    anchor = datetime(2026, 7, 29, 3, 0, 0, tzinfo=timezone.utc) - timedelta(microseconds=1)
+    for offset in (1, 20, 40):
+        await scheduler._process_job(
+            repo.jobs[0],
+            last_check_time=anchor,
+            current_time=datetime(2026, 7, 29, 3, 0, offset, tzinfo=timezone.utc),
+        )
+
+    assert len(enqueuer.tasks) == 1
+
+
+# ── Locks: dos réplicas, un solo encolado ──────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_two_concurrent_schedulers_with_a_shared_lock_enqueue_once():
+    lock = SharedLockProvider()
+    now = datetime(2026, 7, 29, 3, 0, 30, tzinfo=timezone.utc)
+    anchor = datetime(2026, 7, 29, 3, 0, 0, tzinfo=timezone.utc) - timedelta(microseconds=1)
+
+    repo_a = FakeRepo([_job("* * * * *")])
+    repo_b = FakeRepo([_job("* * * * *")])
+    scheduler_a, enqueuer_a = _make(repo_a, lock_provider=lock)
+    scheduler_b, enqueuer_b = _make(repo_b, lock_provider=lock)
+
+    await asyncio.gather(
+        scheduler_a._process_job(repo_a.jobs[0], anchor, now),
+        scheduler_b._process_job(repo_b.jobs[0], anchor, now),
+    )
+
+    assert len(enqueuer_a.tasks) + len(enqueuer_b.tasks) == 1
+
+
+@pytest.mark.anyio
+async def test_lock_key_is_built_from_the_occurrence_not_the_current_minute():
+    """
+    Dos réplicas con ticks desfasados (una a las 03:00:59, otra a las 03:01:01)
+    deben competir por la misma clave, o el job se duplica.
+    """
+    lock = SharedLockProvider()
+    anchor = datetime(2026, 7, 29, 3, 0, 0, tzinfo=timezone.utc) - timedelta(microseconds=1)
+
+    repo = FakeRepo([_job("0 3 * * *")])
+    scheduler, enqueuer = _make(repo, lock_provider=lock)
+
+    await scheduler._process_job(
+        repo.jobs[0], anchor, datetime(2026, 7, 29, 3, 0, 59, tzinfo=timezone.utc)
+    )
+
+    assert lock.attempts == ["hexcore:cron_lock:j1:2026-07-29T03:00:00+00:00"]
+    assert len(enqueuer.tasks) == 1
+
+
+# ── Avisos y robustez ──────────────────────────────────────────────────────────
+
+
+def test_warns_when_sub_minute_tick_has_no_lock_provider():
+    repo = FakeRepo([])
+    with pytest.warns(RuntimeWarning, match="lock_provider"):
+        DynamicScheduler(
+            repository=repo, enqueuer=FakeEnqueuer(), tick_interval_seconds=30
+        )
+
+
+def test_does_not_warn_with_lock_provider():
+    repo = FakeRepo([])
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        DynamicScheduler(
+            repository=repo,
+            enqueuer=FakeEnqueuer(),
+            tick_interval_seconds=30,
+            lock_provider=SharedLockProvider(),
+        )
+
+
+def test_does_not_warn_with_minute_tick():
+    repo = FakeRepo([])
+    import warnings
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        DynamicScheduler(
+            repository=repo, enqueuer=FakeEnqueuer(), tick_interval_seconds=60
+        )
+
+
+@pytest.mark.anyio
+async def test_invalid_cron_expression_is_logged_and_skipped(caplog):
+    repo = FakeRepo([_job("no soy un cron")])
+    scheduler, enqueuer = _make(repo)
+    now = datetime(2026, 7, 29, 3, 0, 0, tzinfo=timezone.utc)
+
+    await scheduler._process_job(repo.jobs[0], now - timedelta(minutes=5), now)
+
+    assert enqueuer.tasks == []
+    assert any("inválida" in record.getMessage() for record in caplog.records)
+
+
+@pytest.mark.anyio
+async def test_naive_last_run_at_is_treated_as_utc():
+    """Un `last_run_at` naive de la BD no debe romper las comparaciones."""
+    now = datetime(2026, 7, 29, 3, 5, 0, tzinfo=timezone.utc)
+    repo = FakeRepo([_job("0 3 * * *")])
+    repo.jobs[0].last_run_at = datetime(2026, 7, 29, 3, 0, 0)  # sin tzinfo
+    scheduler, enqueuer = _make(repo)
+
+    await scheduler._process_job(repo.jobs[0], now - timedelta(minutes=10), now)
+
+    assert enqueuer.tasks == []
+
+
+@pytest.mark.anyio
+async def test_one_failing_job_does_not_stop_the_others():
+    class BoomEnqueuer(FakeEnqueuer):
+        async def enqueue_task(self, task_name: str, payload: dict, queue: str) -> None:
+            if task_name == "boom":
+                raise RuntimeError("broker down")
+            await super().enqueue_task(task_name, payload, queue)
+
+    repo = FakeRepo(
+        [
+            _job("* * * * *", job_id="bad", task_name="boom"),
+            _job("* * * * *", job_id="good", task_name="fine"),
+        ]
+    )
+    scheduler = DynamicScheduler(
+        repository=repo, enqueuer=BoomEnqueuer(), tick_interval_seconds=60
+    )
+    enqueuer = scheduler.enqueuer
+
+    anchor = datetime(2026, 7, 29, 3, 0, 0, tzinfo=timezone.utc) - timedelta(microseconds=1)
+    await scheduler._tick(anchor)
+
+    assert [name for name, _p, _q in enqueuer.tasks] == ["fine"]  # type: ignore[attr-defined]
+
+
+@pytest.mark.anyio
+async def test_first_tick_runs_without_waiting_for_the_interval():
+    """El sleep era la primera sentencia del bucle: se perdía el primer tick."""
+    repo = FakeRepo([_job("* * * * *")])
+    scheduler, enqueuer = _make(repo, tick_interval_seconds=3600)
+
+    task = asyncio.create_task(scheduler.start())
+    await asyncio.sleep(0.05)
+    scheduler.stop()
+    await asyncio.wait_for(task, timeout=1)
+
+    assert len(enqueuer.tasks) == 1
+
+
+@pytest.mark.anyio
+async def test_stop_interrupts_the_wait_without_waiting_the_full_interval():
+    repo = FakeRepo([])
+    scheduler, _enqueuer = _make(repo, tick_interval_seconds=3600)
+
+    task = asyncio.create_task(scheduler.start())
+    await asyncio.sleep(0.05)
+    scheduler.stop()
+
+    # Si el sleep no fuera interrumpible, esto haría timeout.
+    await asyncio.wait_for(task, timeout=1)

--- a/tests/test_smart_routing.py
+++ b/tests/test_smart_routing.py
@@ -91,37 +91,36 @@ async def test_smart_routing_event_bus_enqueues_background_handlers():
 
 
 @pytest.mark.anyio
-async def test_cqrs_consumer_processes_handler_resolution():
+async def test_cqrs_consumer_processes_handler_resolution(monkeypatch):
     # En este test simulamos la recepción de un mensaje de "handler individual"
     local_cmd_bus = AsyncMock()
     local_evt_bus = AsyncMock()
     serializer = PydanticSerializer()
-    
+
     consumer = CQRSConsumer(
         command_bus=local_cmd_bus,
         event_bus=local_evt_bus,
         serializer=serializer
     )
-    
+
     evt = DummyTaskEvent(info="consumed_event")
     payload = serializer.serialize(evt)
-    
+
     # Modificamos dummy_event_handler temporalmente para comprobar si fue llamado
     dummy_event_handler_was_called = False
-    
-    # Necesitamos mockear la funcion porque el import module va a buscar `dummy_event_handler` real
-    # Pero el resolve import funciona sobre modulos. Como esto es un script de tests,
-    # probaremos usando un modulo global conocido o un mock a _resolve_callable.
+
+    # Parcheamos la resolución con monkeypatch para que se restaure al terminar:
+    # asignar directamente sobre el módulo contamina los tests posteriores (P3-2).
     import hexcore.infrastructure.workers.consumer as consumer_module
-    
+
     async def mock_handler(e):
         nonlocal dummy_event_handler_was_called
         dummy_event_handler_was_called = True
-    
-    consumer_module._resolve_callable = lambda x: mock_handler
-    
-    await consumer.process_handler("tests.test_smart_routing.dummy_event_handler", payload)
-    
+
+    monkeypatch.setattr(consumer_module, "_resolve_callable", lambda x: mock_handler)
+
+    await consumer.process_handler(f"{__name__}.dummy_event_handler", payload)
+
     assert dummy_event_handler_was_called is True
 
 
@@ -190,29 +189,40 @@ async def test_background_handler_raises_if_no_enqueuer():
 
 
 @pytest.mark.anyio
-async def test_cqrs_consumer_processes_generic_task():
+async def test_cqrs_consumer_processes_generic_task(monkeypatch):
     local_cmd_bus = AsyncMock()
     local_evt_bus = AsyncMock()
     serializer = PydanticSerializer()
-    
+
     consumer = CQRSConsumer(
         command_bus=local_cmd_bus,
         event_bus=local_evt_bus,
         serializer=serializer
     )
-    
+
     generic_task_was_called = False
-    
+
     import hexcore.infrastructure.workers.consumer as consumer_module
-    
+
     async def mock_task(**kwargs):
         nonlocal generic_task_was_called
         assert kwargs["days"] == 30
         generic_task_was_called = True
-    
-    consumer_module._resolve_callable = lambda x: mock_task
-    
+
+    monkeypatch.setattr(consumer_module, "_resolve_callable", lambda x: mock_task)
+
     await consumer.process_task("my_maintenance_task", {"days": 30})
-    
+
     assert generic_task_was_called is True
+
+
+def test_resolve_callable_is_not_left_patched():
+    """
+    P3-2: los tests anteriores parcheaban `_resolve_callable` sin restaurarlo, así
+    que cualquier test posterior en el mismo proceso veía el parche.
+    """
+    from hexcore.infrastructure.workers.consumer import _resolve_callable
+
+    with pytest.raises(RuntimeError):
+        _resolve_callable("modulo.que.no.existe.jamas")
 

--- a/tests/test_sql_session_layer.py
+++ b/tests/test_sql_session_layer.py
@@ -1,0 +1,338 @@
+"""
+F2 y F3: la capa de sesión SQL tiene que ser usable en producción, y los scopes
+tienen que existir fuera de FastAPI.
+
+Defectos que cubren estos tests:
+1. `expire_on_commit` no se pasaba → quedaba en True (default de SQLAlchemy), así que
+   tras `commit()` los atributos expiraban y el siguiente acceso disparaba un lazy-load
+   sobre una sesión cerrada (`MissingGreenlet` / `DetachedInstanceError`).
+2. Sin tuning del pool (`pre_ping`, `recycle`, `size`, `max_overflow`).
+3. Sin normalización del DSN: `postgresql://…` reventaba en `create_async_engine`.
+4. No se podía pasar la URL explícitamente.
+5. Sin cierre ordenado con un nombre que lo dijera.
+6. Globals sin lock.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+sqlalchemy = pytest.importorskip("sqlalchemy")
+pytest.importorskip("aiosqlite")
+
+from sqlalchemy import String, select  # noqa: E402
+from sqlalchemy.orm import Mapped, mapped_column  # noqa: E402
+
+from hexcore.infrastructure.repositories.orms.sqlalchemy import Base  # noqa: E402
+from hexcore.infrastructure.repositories.orms.sqlalchemy import session as session_module  # noqa: E402
+from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (  # noqa: E402
+    PoolSettings,
+    dispose_engine,
+    get_engine,
+    get_session_factory,
+    init_engine,
+    normalize_async_dsn,
+    reset_sqlalchemy_engine,
+)
+from hexcore.infrastructure.uow.scopes import session_scope  # noqa: E402
+
+SQLITE_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _clean_engine():
+    # Fixture síncrono a propósito: los tests de concurrencia no son async y una
+    # fixture async no se resolvería para ellos.
+    asyncio.run(dispose_engine())
+    yield
+    asyncio.run(dispose_engine())
+
+
+class Widget(Base):
+    __tablename__ = "f2_widgets"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    name: Mapped[str] = mapped_column(String(50))
+
+
+# ── Normalización del DSN (defecto 3) ──────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    ("raw", "expected"),
+    [
+        ("postgresql://u:p@h/db", "postgresql+asyncpg://u:p@h/db"),
+        ("postgres://u:p@h/db", "postgresql+asyncpg://u:p@h/db"),
+        ("sqlite:///./db.sqlite3", "sqlite+aiosqlite:///./db.sqlite3"),
+        ("mysql://u:p@h/db", "mysql+aiomysql://u:p@h/db"),
+    ],
+)
+def test_normalize_async_dsn_adds_the_async_driver(raw, expected):
+    assert normalize_async_dsn(raw) == expected
+
+
+@pytest.mark.parametrize(
+    "already_async",
+    [
+        "postgresql+asyncpg://u:p@h/db",
+        "sqlite+aiosqlite:///./db.sqlite3",
+        # Un driver explícito distinto se respeta: puede ser a propósito.
+        "postgresql+psycopg://u:p@h/db",
+    ],
+)
+def test_normalize_async_dsn_leaves_explicit_drivers_alone(already_async):
+    assert normalize_async_dsn(already_async) == already_async
+
+
+def test_normalize_async_dsn_leaves_unknown_schemes_alone():
+    assert normalize_async_dsn("oracle://u:p@h/db") == "oracle://u:p@h/db"
+    assert normalize_async_dsn("not-a-dsn") == "not-a-dsn"
+
+
+# ── URL explícita y pool (defectos 2 y 4) ──────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_init_engine_accepts_an_explicit_url():
+    engine = init_engine(SQLITE_URL)
+
+    assert engine.url.database == ":memory:"
+    assert engine.url.drivername == "sqlite+aiosqlite"
+
+
+@pytest.mark.anyio
+async def test_init_engine_normalizes_the_explicit_url():
+    engine = init_engine("sqlite:///:memory:")
+
+    assert engine.url.drivername == "sqlite+aiosqlite"
+
+
+@pytest.mark.anyio
+async def test_pool_pre_ping_is_on_by_default():
+    engine = init_engine(SQLITE_URL)
+
+    assert engine.pool._pre_ping is True  # type: ignore[attr-defined]
+
+
+@pytest.mark.anyio
+async def test_pool_settings_are_applied_for_non_sqlite():
+    engine = init_engine(
+        "postgresql+asyncpg://u:p@localhost/db",
+        pool=PoolSettings(size=7, max_overflow=3, recycle=60),
+    )
+
+    assert engine.pool.size() == 7  # type: ignore[attr-defined]
+    assert engine.pool._max_overflow == 3  # type: ignore[attr-defined]
+    assert engine.pool._recycle == 60  # type: ignore[attr-defined]
+
+
+@pytest.mark.anyio
+async def test_sqlite_ignores_pool_size_instead_of_crashing():
+    """SQLite no usa un pool con tamaño; pasarle pool_size es un TypeError."""
+    engine = init_engine(SQLITE_URL, pool=PoolSettings(size=10, max_overflow=5))
+
+    assert engine is not None
+
+
+@pytest.mark.anyio
+async def test_engine_kwargs_are_forwarded():
+    engine = init_engine(SQLITE_URL, echo=True)
+
+    assert engine.echo is True
+
+
+# ── expire_on_commit (defecto 1) ───────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_session_factory_sets_expire_on_commit_to_false():
+    init_engine(SQLITE_URL)
+    factory = get_session_factory()
+
+    assert factory.kw["expire_on_commit"] is False
+
+
+@pytest.mark.anyio
+async def test_attribute_access_after_commit_does_not_lazy_load():
+    """
+    El síntoma real: con expire_on_commit=True esto lanza MissingGreenlet, porque el
+    acceso al atributo dispara IO sobre una sesión ya comiteada.
+    """
+    engine = init_engine(SQLITE_URL)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+    factory = get_session_factory()
+    async with factory() as session:
+        widget = Widget(name="gizmo")
+        session.add(widget)
+        await session.commit()
+        # Sin expire_on_commit=False, este acceso revienta.
+        assert widget.name == "gizmo"
+
+
+@pytest.mark.anyio
+async def test_entity_survives_outside_the_session_block():
+    engine = init_engine(SQLITE_URL)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+    factory = get_session_factory()
+    async with factory() as session:
+        widget = Widget(name="detached")
+        session.add(widget)
+        await session.commit()
+
+    # Fuera del bloque la sesión está cerrada: sin el arreglo, DetachedInstanceError.
+    assert widget.name == "detached"
+
+
+# ── Ciclo de vida (defecto 5) ──────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_dispose_engine_leaves_the_module_reinitialisable():
+    first = init_engine(SQLITE_URL)
+    await dispose_engine()
+    second = init_engine(SQLITE_URL)
+
+    assert first is not second
+
+
+@pytest.mark.anyio
+async def test_dispose_engine_clears_the_session_factory_too():
+    init_engine(SQLITE_URL)
+    first_factory = get_session_factory()
+    await dispose_engine()
+    init_engine(SQLITE_URL)
+
+    assert get_session_factory() is not first_factory
+
+
+@pytest.mark.anyio
+async def test_dispose_engine_is_safe_without_an_engine():
+    await dispose_engine()
+    await dispose_engine()
+
+
+@pytest.mark.anyio
+async def test_reset_sqlalchemy_engine_is_still_available():
+    init_engine(SQLITE_URL)
+    await reset_sqlalchemy_engine()
+
+    assert session_module._engine is None
+
+
+@pytest.mark.anyio
+async def test_init_engine_is_idempotent():
+    first = init_engine(SQLITE_URL)
+    second = init_engine(SQLITE_URL)
+
+    assert first is second
+
+
+@pytest.mark.anyio
+async def test_get_engine_lazily_initialises():
+    assert session_module._engine is None
+    engine = get_engine()
+
+    assert engine is not None
+    assert session_module._engine is engine
+
+
+# ── Globals con lock (defecto 6) ───────────────────────────────────────────────
+
+
+def test_concurrent_init_engine_creates_a_single_engine():
+    asyncio.run(dispose_engine())
+    ready = threading.Barrier(8)
+    engines: list[object] = []
+    lock = threading.Lock()
+
+    def worker() -> None:
+        ready.wait()
+        engine = init_engine(SQLITE_URL)
+        with lock:
+            engines.append(engine)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len({id(engine) for engine in engines}) == 1
+    asyncio.run(dispose_engine())
+
+
+def test_concurrent_get_session_factory_creates_a_single_factory():
+    asyncio.run(dispose_engine())
+    init_engine(SQLITE_URL)
+    ready = threading.Barrier(8)
+    factories: list[object] = []
+    lock = threading.Lock()
+
+    def worker() -> None:
+        ready.wait()
+        factory = get_session_factory()
+        with lock:
+            factories.append(factory)
+
+    threads = [threading.Thread(target=worker) for _ in range(8)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len({id(factory) for factory in factories}) == 1
+    asyncio.run(dispose_engine())
+
+
+# ── F3: session_scope fuera de FastAPI ─────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_session_scope_yields_a_usable_session():
+    engine = init_engine(SQLITE_URL)
+    async with engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+    async with session_scope() as session:
+        session.add(Widget(name="from-scope"))
+        await session.commit()
+
+    async with session_scope() as session:
+        names = (await session.execute(select(Widget.name))).scalars().all()
+
+    assert "from-scope" in names
+
+
+@pytest.mark.anyio
+async def test_session_scope_closes_the_session_on_exit():
+    init_engine(SQLITE_URL)
+
+    async with session_scope() as session:
+        pass
+
+    assert session.is_active is False or not session.in_transaction()
+
+
+@pytest.mark.anyio
+async def test_session_scope_does_not_instantiate_repositories():
+    """
+    El punto de F3: construir un UoW corre el auto-discovery e instancia todos los
+    repositorios de dominio. `session_scope` no debe hacer nada de eso — de hecho
+    funciona sin `repository_discovery_paths` configurado, que es lo que haría fallar
+    a un UoW.
+    """
+    init_engine(SQLITE_URL)
+
+    async with session_scope() as session:
+        assert not hasattr(session, "repositories")

--- a/tests/test_task_queues_adapters.py
+++ b/tests/test_task_queues_adapters.py
@@ -7,6 +7,7 @@ from unittest.mock import MagicMock, AsyncMock, ANY
 sys.modules["celery"] = MagicMock()
 sys.modules["procrastinate"] = MagicMock()
 
+from hexcore.infrastructure.task_queues import celery_adapter, procrastinate_adapter
 from hexcore.infrastructure.task_queues.celery_adapter import CeleryEnqueuer, register_hexcore_celery_tasks
 from hexcore.infrastructure.task_queues.procrastinate_adapter import ProcrastinateEnqueuer, register_hexcore_procrastinate_tasks
 
@@ -99,3 +100,63 @@ async def test_celery_enqueue_event_raises_instead_of_losing_the_event():
 
     with pytest.raises(NotImplementedError, match="background_handler"):
         await enqueuer.enqueue_event("SomeEvent", {"data": 1}, "default")
+
+
+# ── P1-6: registrar dos veces no debe reventar ─────────────────────────────────
+
+
+class FakeApp:
+    """App mínima referenciable débilmente que rechaza nombres duplicados."""
+
+    def __init__(self) -> None:
+        self.registered: list[str] = []
+
+    def task(self, *args, **kwargs):
+        name = kwargs.get("name")
+
+        def decorator(func):
+            if name in self.registered:
+                raise ValueError(f"Task name already registered: {name}")
+            self.registered.append(name)
+            return func
+
+        return decorator
+
+
+def test_register_procrastinate_tasks_is_idempotent():
+    app = FakeApp()
+    consumer = MagicMock()
+
+    assert register_hexcore_procrastinate_tasks(app, consumer) is True
+    assert procrastinate_adapter.is_registered(app) is True
+    # Sin idempotencia, esta segunda llamada revienta con "already registered".
+    assert register_hexcore_procrastinate_tasks(app, consumer) is False
+    assert app.registered == list(procrastinate_adapter.HEXCORE_TASK_NAMES)
+
+
+def test_register_celery_tasks_is_idempotent():
+    app = FakeApp()
+    consumer = MagicMock()
+
+    assert register_hexcore_celery_tasks(app, consumer) is True
+    assert celery_adapter.is_registered(app) is True
+    assert register_hexcore_celery_tasks(app, consumer) is False
+    assert app.registered == list(celery_adapter.HEXCORE_TASK_NAMES)
+
+
+def test_is_registered_is_per_app():
+    app_a, app_b = FakeApp(), FakeApp()
+    register_hexcore_procrastinate_tasks(app_a, MagicMock())
+
+    assert procrastinate_adapter.is_registered(app_a) is True
+    assert procrastinate_adapter.is_registered(app_b) is False
+
+
+def test_force_reregisters():
+    app = FakeApp()
+    register_hexcore_celery_tasks(app, MagicMock())
+
+    # `force` reintenta el registro; esta app lo rechaza, que es justo lo que
+    # documenta el parámetro.
+    with pytest.raises(ValueError, match="already registered"):
+        register_hexcore_celery_tasks(app, MagicMock(), force=True)

--- a/tests/test_task_queues_adapters.py
+++ b/tests/test_task_queues_adapters.py
@@ -72,11 +72,30 @@ async def test_procrastinate_enqueuer():
 def test_register_procrastinate_tasks():
     mock_app = MagicMock()
     mock_consumer = MagicMock()
-    
+
     register_hexcore_procrastinate_tasks(mock_app, mock_consumer)
-    
+
     assert mock_app.task.call_count == 3
     args = [call.kwargs.get("name") for call in mock_app.task.call_args_list]
     assert "hexcore.process_command" in args
     assert "hexcore.process_handler" in args
     assert "hexcore.process_task" in args
+
+
+# ── P1-3: enqueue_event no puede tragarse el evento en silencio ───────────────
+
+
+@pytest.mark.anyio
+async def test_procrastinate_enqueue_event_raises_instead_of_losing_the_event():
+    enqueuer = ProcrastinateEnqueuer(MagicMock())
+
+    with pytest.raises(NotImplementedError, match="background_handler"):
+        await enqueuer.enqueue_event("SomeEvent", {"data": 1}, "default")
+
+
+@pytest.mark.anyio
+async def test_celery_enqueue_event_raises_instead_of_losing_the_event():
+    enqueuer = CeleryEnqueuer(MagicMock())
+
+    with pytest.raises(NotImplementedError, match="background_handler"):
+        await enqueuer.enqueue_event("SomeEvent", {"data": 1}, "default")

--- a/tests/test_worker_bus_integration.py
+++ b/tests/test_worker_bus_integration.py
@@ -1,0 +1,271 @@
+"""
+Tests de integración bus + consumer con buses **reales** (no AsyncMock).
+
+Cubre P0-1 y P0-2 del plan de mejora: el worker debe *ejecutar* los mensajes de
+background que saca de la cola, no reencolarlos. Con un `AsyncMock` como bus estos
+bugs son invisibles, que es exactamente por qué pasaron el CI.
+"""
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from hexcore.application.cqrs.in_memory_buses import InMemoryCommandBus, InMemoryEventBus
+from hexcore.application.cqrs.registry import HandlerRegistry
+from hexcore.domain.cqrs.commands import Command
+from hexcore.domain.cqrs.decorators import (
+    background_command,
+    background_handler,
+    background_task,
+)
+from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
+from hexcore.domain.events import DomainEvent
+from hexcore.infrastructure.cqrs.pydantic_serializer import PydanticSerializer
+from hexcore.infrastructure.workers.consumer import CQRSConsumer
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class SpyEnqueuer(ITaskEnqueuer):
+    """Enqueuer que sólo anota lo que se le pide encolar."""
+
+    def __init__(self) -> None:
+        self.commands: list[tuple[str, dict[str, t.Any], str]] = []
+        self.events: list[tuple[str, dict[str, t.Any], str]] = []
+        self.handlers: list[tuple[str, dict[str, t.Any], str]] = []
+        self.tasks: list[tuple[str, dict[str, t.Any], str]] = []
+
+    async def enqueue_command(self, command_name: str, payload: dict[str, t.Any], queue: str) -> None:
+        self.commands.append((command_name, payload, queue))
+
+    async def enqueue_event(self, event_name: str, payload: dict[str, t.Any], queue: str) -> None:
+        self.events.append((event_name, payload, queue))
+
+    async def enqueue_handler(self, handler_name: str, payload: dict[str, t.Any], queue: str) -> None:
+        self.handlers.append((handler_name, payload, queue))
+
+    async def enqueue_task(self, task_name: str, payload: dict[str, t.Any], queue: str) -> None:
+        self.tasks.append((task_name, payload, queue))
+
+
+# ── Mensajes y handlers a nivel de módulo (resolubles desde un worker) ──────────
+
+HANDLED: list[str] = []
+NESTED_HANDLED: list[str] = []
+EVENT_HANDLED: list[str] = []
+
+
+@background_command(queue="reactive")
+class ReactiveCommand(Command):
+    value: str
+
+
+class ReactiveCommandHandler:
+    async def handle(self, cmd: ReactiveCommand) -> str:
+        HANDLED.append(cmd.value)
+        return f"ok:{cmd.value}"
+
+
+@background_command(queue="nested")
+class NestedCommand(Command):
+    value: str
+
+
+class NestedCommandHandler:
+    async def handle(self, cmd: NestedCommand) -> None:
+        NESTED_HANDLED.append(cmd.value)
+
+
+class SyncCommand(Command):
+    value: str
+
+
+class DispatchingCommandHandler:
+    """Handler síncrono que despacha *a propósito* un comando de background."""
+
+    def __init__(self, bus: InMemoryCommandBus) -> None:
+        self._bus = bus
+
+    async def handle(self, cmd: SyncCommand) -> None:
+        HANDLED.append(cmd.value)
+        await self._bus.dispatch(NestedCommand(value=f"nested:{cmd.value}"))
+
+
+class IntegrationEvent(DomainEvent):
+    info: str
+
+
+@background_handler(queue="analytics")
+async def on_integration_event(event: IntegrationEvent) -> None:
+    EVENT_HANDLED.append(event.info)
+
+
+@pytest.fixture(autouse=True)
+def _reset_spies():
+    HANDLED.clear()
+    NESTED_HANDLED.clear()
+    EVENT_HANDLED.clear()
+    yield
+    HANDLED.clear()
+    NESTED_HANDLED.clear()
+    EVENT_HANDLED.clear()
+
+
+def _build(registry: HandlerRegistry | None = None):
+    registry = registry or HandlerRegistry()
+    enqueuer = SpyEnqueuer()
+    serializer = PydanticSerializer()
+    command_bus = InMemoryCommandBus(
+        registry=registry, enqueuer=enqueuer, serializer=serializer
+    )
+    event_bus = InMemoryEventBus(enqueuer=enqueuer, serializer=serializer)
+    consumer = CQRSConsumer(
+        command_bus=command_bus, event_bus=event_bus, serializer=serializer
+    )
+    return registry, enqueuer, serializer, command_bus, event_bus, consumer
+
+
+# ── P0-1 ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_worker_executes_background_command_instead_of_reenqueueing():
+    """El bug original: el worker reencolaba el comando en bucle infinito."""
+    registry, enqueuer, serializer, _bus, _evt, consumer = _build()
+    registry.register_command_handler(ReactiveCommand, ReactiveCommandHandler())
+
+    await consumer.process_command(serializer.serialize(ReactiveCommand(value="x")))
+
+    assert HANDLED == ["x"], "el handler del comando de background no se ejecutó"
+    assert enqueuer.commands == [], "el worker reencoló el comando en vez de ejecutarlo"
+
+
+@pytest.mark.anyio
+async def test_same_bus_outside_worker_still_enqueues():
+    """Fuera del worker, el mismo bus debe seguir encolando."""
+    registry, enqueuer, _ser, bus, _evt, _consumer = _build()
+    registry.register_command_handler(ReactiveCommand, ReactiveCommandHandler())
+
+    result = await bus.dispatch(ReactiveCommand(value="y"))
+
+    assert result is None
+    assert HANDLED == []
+    assert [name for name, _p, _q in enqueuer.commands] == ["ReactiveCommand"]
+    assert enqueuer.commands[0][2] == "reactive"
+
+
+@pytest.mark.anyio
+async def test_nested_dispatch_from_handler_still_enqueues():
+    """
+    El contextvar no debe convertir el worker en "todo local para siempre":
+    un comando que el handler despacha a propósito sigue yendo a la cola.
+    """
+    registry, enqueuer, serializer, bus, _evt, consumer = _build()
+    registry.register_command_handler(SyncCommand, DispatchingCommandHandler(bus))
+    registry.register_command_handler(NestedCommand, NestedCommandHandler())
+
+    await consumer.process_command(serializer.serialize(SyncCommand(value="outer")))
+
+    assert HANDLED == ["outer"]
+    assert NESTED_HANDLED == [], "el comando anidado se ejecutó inline en vez de encolarse"
+    assert [name for name, _p, _q in enqueuer.commands] == ["NestedCommand"]
+
+
+@pytest.mark.anyio
+async def test_worker_context_is_reset_after_processing():
+    """Tras procesar, el proceso vuelve a encolar los comandos de background."""
+    registry, enqueuer, serializer, bus, _evt, consumer = _build()
+    registry.register_command_handler(ReactiveCommand, ReactiveCommandHandler())
+
+    await consumer.process_command(serializer.serialize(ReactiveCommand(value="a")))
+    await bus.dispatch(ReactiveCommand(value="b"))
+
+    assert HANDLED == ["a"]
+    assert len(enqueuer.commands) == 1
+
+
+# ── P0-2 ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_worker_executes_background_event_handler():
+    """Mismo bucle que P0-1, por la vía del EventBus."""
+    _registry, enqueuer, serializer, _bus, event_bus, consumer = _build()
+    event_bus.subscribe(IntegrationEvent, on_integration_event)
+
+    await consumer.process_event(serializer.serialize(IntegrationEvent(info="evt")))
+
+    assert EVENT_HANDLED == ["evt"]
+    assert enqueuer.handlers == [], "el worker reencoló el event handler de background"
+
+
+@pytest.mark.anyio
+async def test_event_bus_outside_worker_still_enqueues_background_handler():
+    _registry, enqueuer, _ser, _bus, event_bus, _consumer = _build()
+    event_bus.subscribe(IntegrationEvent, on_integration_event)
+
+    await event_bus.publish(IntegrationEvent(info="evt"))
+
+    assert EVENT_HANDLED == []
+    assert len(enqueuer.handlers) == 1
+    assert enqueuer.handlers[0][2] == "analytics"
+
+
+@pytest.mark.anyio
+async def test_sync_event_handler_runs_in_worker_and_outside():
+    _registry, enqueuer, serializer, _bus, event_bus, consumer = _build()
+    seen: list[str] = []
+
+    async def sync_handler(event: IntegrationEvent) -> None:
+        seen.append(event.info)
+
+    event_bus.subscribe(IntegrationEvent, sync_handler)
+
+    await event_bus.publish(IntegrationEvent(info="local"))
+    await consumer.process_event(serializer.serialize(IntegrationEvent(info="worker")))
+
+    assert seen == ["local", "worker"]
+    assert enqueuer.handlers == []
+
+
+# ── Camino de handler individual y tarea genérica (con resolución real) ────────
+
+
+@pytest.mark.anyio
+async def test_consumer_resolves_module_level_handler():
+    _registry, _enq, serializer, _bus, _evt, consumer = _build()
+
+    await consumer.process_handler(
+        f"{__name__}.on_integration_event",
+        serializer.serialize(IntegrationEvent(info="direct")),
+    )
+
+    assert EVENT_HANDLED == ["direct"]
+
+
+class Jobs:
+    """Contenedor de tareas: ejercita la resolución de __qualname__ anidado (P0-3)."""
+
+    ran: list[int] = []
+
+    @staticmethod
+    @background_task(queue="maintenance")
+    async def cleanup(days: int) -> None:
+        Jobs.ran.append(days)
+
+
+@pytest.mark.anyio
+async def test_consumer_resolves_nested_static_method_task():
+    _registry, _enq, _ser, _bus, _evt, consumer = _build()
+    Jobs.ran.clear()
+
+    task_name = getattr(Jobs.cleanup, "__cqrs_task_name__")
+    assert task_name == f"{__name__}.Jobs.cleanup"
+
+    await consumer.process_task(task_name, {"days": 30})
+
+    assert Jobs.ran == [30]

--- a/uv.lock
+++ b/uv.lock
@@ -453,6 +453,7 @@ sql = [
 
 [package.dev-dependencies]
 dev = [
+    { name = "anyio" },
     { name = "commitizen" },
     { name = "pyright" },
     { name = "pytest" },
@@ -491,6 +492,7 @@ provides-extras = ["api", "redis", "mongo", "sql", "rabbitmq", "procrastinate", 
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "anyio", specifier = ">=4.0.0" },
     { name = "commitizen", specifier = ">=4.9.1" },
     { name = "pyright", specifier = ">=1.1.405" },
     { name = "pytest", specifier = ">=8.4.2" },


### PR DESCRIPTION
**2º de 4.** Reemplaza a #30 (que se mergeó contra `release/2.5.1-correcciones`, no a `master`).
Descripción detallada por ítem en **#30**.

**Ítems del plan:** P0-5, P1-1, P1-2, P1-5, P1-6, P2-2, F2, F3 (Fase 2).

> **Mergear #33 primero.** Este PR muestra ahora 15 commits porque incluye los 7 de #33; en
> cuanto #33 entre en `master`, el diff se reduce a sus 8 propios. Va contra `master` a
> propósito, no contra la rama anterior: así cada merge a `master` dispara su propio
> `bump_ver` y su publicación, y un merge fuera de orden da un diff más grande, nunca
> contenido en el sitio equivocado.

## Contenido (8 commits propios)

| Ítem | Qué arregla |
| :-- | :-- |
| **P0-5** | `CQRSFactory` construía el bus sin enqueuer ni serializer: **la vía oficial de construcción reventaba en el primer `@background_command`**. Ahora los propaga y falla **al construir** si faltan, no en el primer dispatch. |
| **P1-1** | En `DynamicScheduler`, `base_time` y `last_check_time` se calculaban y **no se usaban**: con `tick=60s` el drift se saltaba un minuto entero y el job no corría; con `tick<60s` se duplicaba. Catch-up real + dedup por ocurrencia. |
| **P1-2** | Los lock providers devolvían `False` ante cualquier error, así que una caída de Redis **apagaba el cron entero** con un log indistinguible del caso normal. `on_error` + logs diferenciados. |
| **P1-5** | `HandlerRegistry` decía "thread-safe" y no tenía ningún lock, con lazy-init escribiendo en el dict. |
| **P1-6** | `register_hexcore_*_tasks` reventaba a la segunda llamada. |
| **P2-2** | `CQRSConsumer` exigía `event_bus`: un worker sólo-comandos escribía `cast(Any, None)`. |
| **F2** | La capa de sesión SQL era inutilizable en producción — seis defectos, empezando por `expire_on_commit` sin pasar. |
| **F3** | No había scopes fuera de FastAPI: workers, cron, scripts y seeds se quedaban sin nada. |

## Riesgo / compatibilidad

⚠️ **BEHAVIOR CHANGE:**
- `expire_on_commit=False` (F2). Con el default de SQLAlchemy (`True`), tras `commit()` el
  siguiente acceso a un atributo lanza `MissingGreenlet`/`DetachedInstanceError` — y la doc
  ya enseñaba `False`, así que doc e implementación no coincidían.
- `get_sql_uow` ya no entra al UoW (F3), para que el `async with self.uow:` del use case no
  anide. Hay `get_sql_uow_open` para el comportamiento anterior.
- Cambia **cuándo** corre un cron job (P1-1). Arrancar a las 03:00:30 sigue disparando el job
  de las 03:00.
- Un proyecto con `@background_command` y sin enqueuer ahora falla al arrancar (P0-5).

De paso se arregla `rabbitmq_worker.setup_sqlalchemy`, que importaba un símbolo `engine`
inexistente: su `await engine.dispose()` nunca podía ejecutarse.

## Verificación

`248 passed, 0 skipped`. Verificado además que con `expire_on_commit=True` los 3 tests de F2
fallan con `DetachedInstanceError`, y que los tests de concurrencia (8 hilos con barrera)
detectan la doble instanciación sin el lock.
