### PR TITLE
release 2.7.0 — factories y utilidades FastAPI (F1, F4–F16)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,29 @@
   acotar el catch-up, aviso `RuntimeWarning` si el tick es sub-minuto y no hay
   `lock_provider`, primer tick sin esperar el intervalo, `stop()` interrumpible al
   instante, y `except` que loguean traceback en vez de tragarse el error (P1-1)
+- **api**: `register_exception_handlers(app, mapping=..., include_detail=...)` mapea las
+  excepciones de dominio a HTTP. El default cubre `InactiveEntityException`→409,
+  `DeserializationError`→400, `HandlerNotFoundError`→501 y `ValueError`→422 — este último
+  antes sólo se capturaba **dentro** de `build_query_endpoint`, así que una query
+  construida a mano devolvía 500 (F5)
+- **api**: providers CQRS en `hexcore.infrastructure.api.cqrs`: `configure_cqrs()`,
+  `provide_command_bus` / `provide_query_bus` / `provide_event_bus` / `provide_registry`
+  y `CQRSContainer.build_consumer()`, que construye el consumer del worker sobre los
+  mismos buses que la app web — una sola fuente de verdad. Son funciones para poder
+  sobreescribirlos con `app.dependency_overrides` en los tests (F6)
+- **api**: `rate_limit(limit, window_seconds, key=..., cache=...)` como dependencia,
+  sobre el puerto `ICache` (funciona con `MemoryCache` en tests). Devuelve **429 con
+  `Retry-After`**, y la política ante un backend caído es explícita
+  (`on_backend_error="allow" | "deny"`) en vez de una decisión enterrada en un `except`
+  (F12)
+- **api**: `sse_stream()` con heartbeat y cabeceras anti-buffering, `format_sse_event()`,
+  `ws_heartbeat()` y `connection_slot()` en `hexcore.infrastructure.api.streaming`.
+  `connection_slot` libera el slot aunque el bloque lance o se cancele, que es el bug
+  clásico de los límites de conexión por usuario (F14)
+- **api**: `check_health(deep=...)` y `register_health_routes(app)`. `{path}` es liveness
+  (200 sin I/O) y `{path}/ready` es readiness: sondea SQL, Redis y Mongo con timeout
+  propio por sonda y devuelve **503** con el detalle y la latencia por dependencia. Una
+  dependencia no crítica reporta `degraded` en vez de `down` (F16)
 - **cqrs**: implementación SQL del cron de serie en
   `hexcore.infrastructure.cqrs.cron_sql` (extra `[sql]`): `CronJobModel` /
   `CronJobModelMixin`, `SqlAlchemyCronJobRepository`, `seed_cron_jobs()` idempotente y no

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,14 @@
   acotar el catch-up, aviso `RuntimeWarning` si el tick es sub-minuto y no hay
   `lock_provider`, primer tick sin esperar el intervalo, `stop()` interrumpible al
   instante, y `except` que loguean traceback en vez de tragarse el error (P1-1)
+- **api**: `RequestIDMiddleware` y `TimingMiddleware` de serie, en
+  `hexcore.infrastructure.api.middlewares`. El request-id se reusa del header entrante
+  si viene, se expone por `ContextVar` (`get_request_id()`) y por `request.state`, y hay
+  un `RequestIDLogFilter` + `install_request_id_logging()` que lo inyectan en cada línea
+  de log — sin eso, tener el header no correlaciona nada (F11)
+- **api**: `build_root_router(prefix, children, dependencies=..., tags=...)` y
+  `mount_routers(app, routers)` en `hexcore.infrastructure.api.routing`, para declarar
+  la composición de routers en vez de escribir un `*_root_router.py` por área (F13)
 - **sql**: capa de sesión usable en producción. `init_engine(url=None, *, pool=PoolSettings(), **engine_kwargs)`
   y `dispose_engine()`; `PoolSettings` (`size`, `max_overflow`, `pre_ping`, `recycle`)
   con `pre_ping=True` por defecto; normalización del DSN (`postgresql://` →

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,18 @@
   acotar el catch-up, aviso `RuntimeWarning` si el tick es sub-minuto y no hay
   `lock_provider`, primer tick sin esperar el intervalo, `stop()` interrumpible al
   instante, y `except` que loguean traceback en vez de tragarse el error (P1-1)
+- **cqrs**: implementación SQL del cron de serie en
+  `hexcore.infrastructure.cqrs.cron_sql` (extra `[sql]`): `CronJobModel` /
+  `CronJobModelMixin`, `SqlAlchemyCronJobRepository`, `seed_cron_jobs()` idempotente y no
+  destructivo, `create_cron_tables()` y `cron_job()`, que deriva el `task_name` de
+  `__cqrs_task_name__` en vez de escribirlo a mano. El modelo no hereda de `BaseModel[T]`
+  y el repositorio no hereda de `BaseSQLAlchemyRepository`, para que ni el UoW ni el
+  auto-discovery los traten como dominio (F7)
+- **workers**: `run_cqrs_worker(*loops, scheduler=..., on_startup=..., on_shutdown=...)`
+  y el atajo `run_procrastinate_worker(app, queues=..., concurrency=...)`. Si cualquiera
+  de los bucles muere se cancela el resto y el proceso sale con `WorkerDied`, para que el
+  orquestador lo reinicie completo; incluye manejo de SIGTERM/SIGINT para drenaje
+  ordenado (F8)
 - **api**: `RequestIDMiddleware` y `TimingMiddleware` de serie, en
   `hexcore.infrastructure.api.middlewares`. El request-id se reusa del header entrante
   si viene, se expone por `ContextVar` (`get_request_id()`) y por `request.state`, y hay

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@
   Nuevo contextvar `hexcore.domain.cqrs.context.IN_WORKER` (P0-1)
 - **cqrs**: mismo arreglo para los suscriptores marcados con `@background_handler`
   cuando el evento llega por `CQRSConsumer.process_event` (P0-2)
+- **cqrs**: los buses in-memory comprueban `enqueuer is None` en vez de su truthiness. Un
+  enqueuer que implemente `__len__` o `__bool__` (un doble de test que cuenta lo encolado)
+  es falsy cuando está vacío, y se descartaba justo al empezar un test, lanzando
+  `RuntimeError` en el primer `@background_command`
 - **cqrs**: los FQN con `__qualname__` anidado (clases dentro de clases, tasks como
   `@staticmethod`) ya se resuelven bien. Antes `rsplit(".", 1)` producía un module
   path inválido y el mensaje se encolaba correctamente para **fallar en el worker**.
@@ -26,6 +30,28 @@
 
 ### Feat
 
+- **api**: `create_app()` — factory de la aplicación FastAPI. Sin argumentos ya produce
+  una app usable (`title`/`version` de `ServerConfig`, CORS de `config.allow_origins`,
+  `/health`). Los interruptores van en un único `AppFeatures` en vez de ocho keywords, y
+  los `**fastapi_kwargs` se reenvían tal cual. Nuevos campos `app_title` y `app_version`
+  en `ServerConfig` (F1)
+- **api**: `build_lifespan(*steps, on_error=...)` con teardown en orden inverso,
+  garantizado sólo para los steps que arrancaron, y `on_error="warn"` por step. Steps de
+  serie: `SqlEngineStep`, `BeanieStep`, `EventBusStep`, `CacheStep`,
+  `ProcrastinateStep`, `CronSeedStep` y `CallableStep` (F4)
+- **api**: `register_query_endpoint` acepta `dependencies` (auth), `response_model`,
+  `extra_params` y `**route_kwargs`; los parámetros de lista usan `default_factory=list`
+  en vez de una lista mutable compartida; y los errores de campo inválido salen como un
+  422 estructurado (`message`, `field`, `allowed`) vía la nueva
+  `UnsupportedQueryFieldError` (F10)
+- **dtos**: paginación por cursor — `CursorPageDTO`, `CursorRequestDTO`,
+  `encode_cursor`/`decode_cursor` (cursor opaco base64url de `(sort_key, id)`) y
+  `query_cursor()` en el repositorio SQLAlchemy. `QueryResponseDTO` no cambia: se añade,
+  no se sustituye (F15)
+- **testing**: nuevo paquete `hexcore.testing` con `InMemoryTaskEnqueuer`,
+  `FakeLockProvider`, `build_test_buses()`, `override_cqrs()` y las fixtures de pytest
+  en `hexcore.testing.fixtures` (`cqrs_buses`, `sqlite_engine`, `sqlite_session`, `uow`).
+  Se importa sin dependencias opcionales duras (F9)
 - **cqrs**: `DynamicScheduler` implementa el catch-up que la versión anterior sólo
   insinuaba: decide por "¿hubo alguna ocurrencia entre la última ejecución y ahora?"
   en vez de `croniter.match(expr, minuto_actual)`. Con eso un minuto saltado por

--- a/hexcore/application/cqrs/in_memory_buses.py
+++ b/hexcore/application/cqrs/in_memory_buses.py
@@ -56,7 +56,10 @@ class InMemoryCommandBus(ICommandBus):
         is_background = getattr(cmd_type, "__cqrs_background__", False)
 
         if is_background and not is_worker_execution():
-            if not self._enqueuer or not self._serializer:
+            # `is None` y no truthiness: un enqueuer que implemente `__len__` o
+            # `__bool__` (un doble de test que cuenta lo encolado, p. ej.) es falsy
+            # cuando está vacío, y con `not self._enqueuer` se descartaría.
+            if self._enqueuer is None or self._serializer is None:
                 raise RuntimeError(
                     f"El comando '{cmd_type.__name__}' requiere ejecución en background, "
                     "pero el InMemoryCommandBus no tiene configurado un 'enqueuer' o 'serializer'."
@@ -150,8 +153,9 @@ class InMemoryEventBus(IEventBus):
             )
 
             if is_background:
-                # Enrutamiento hacia background
-                if not self._enqueuer or not self._serializer:
+                # Enrutamiento hacia background. `is None` por el mismo motivo que en
+                # `InMemoryCommandBus.dispatch`.
+                if self._enqueuer is None or self._serializer is None:
                     raise RuntimeError(
                         f"El handler de eventos '{event_handler.__name__}' requiere ejecución en background, "
                         "pero el InMemoryEventBus no tiene configurado un 'enqueuer' o 'serializer'."

--- a/hexcore/application/dtos/cursor.py
+++ b/hexcore/application/dtos/cursor.py
@@ -1,0 +1,110 @@
+"""
+Paginación por cursor.
+
+`limit`/`offset` degrada en tablas grandes: un `OFFSET 100000` obliga a la base a
+escanear y descartar 100.000 filas antes de devolver la primera. Para los listados
+grandes (tickets, líneas, movimientos) hace falta la variante por cursor, que salta
+directo con un `WHERE (sort_key, id) > (...)`.
+
+Se **añade**, no sustituye a `QueryResponseDTO`.
+
+El cursor es opaco a propósito: codifica `(sort_key, id)` en base64url. Si fuera legible,
+los clientes empezarían a construirlo a mano y quedaría congelado como API pública.
+"""
+from __future__ import annotations
+
+import base64
+import binascii
+import json
+import typing as t
+
+from pydantic import Field
+
+from .base import DTO
+from .query import FilterConditionDTO, SortDirection
+
+T = t.TypeVar("T")
+
+__all__ = [
+    "CursorPageDTO",
+    "CursorRequestDTO",
+    "encode_cursor",
+    "decode_cursor",
+    "InvalidCursorError",
+]
+
+
+class InvalidCursorError(ValueError):
+    """El cursor recibido no se puede decodificar."""
+
+
+class CursorPageDTO(DTO, t.Generic[T]):
+    """
+    Una página por cursor.
+
+    `next_cursor` es None cuando no hay más resultados, que es la única señal de fin que
+    necesita el cliente: no hay `total`, porque contar es justamente lo que esta
+    paginación evita.
+    """
+
+    items: list[T] = Field(default_factory=list)
+    next_cursor: str | None = None
+
+
+class CursorRequestDTO(DTO):
+    """Petición de una página por cursor."""
+
+    limit: int = Field(default=50, ge=1, le=500)
+    cursor: str | None = None
+    sort_field: str = "created_at"
+    direction: SortDirection = SortDirection.DESC
+    search: str | None = None
+    search_fields: list[str] = Field(default_factory=list)
+    filters: list[FilterConditionDTO] = Field(default_factory=list)
+
+
+def encode_cursor(sort_value: t.Any, entity_id: t.Any) -> str:
+    """
+    Codifica la posición de la última fila de la página.
+
+    Se incluye el `id` además del campo de orden para desempatar: con sólo el `sort_key`,
+    varias filas con el mismo `created_at` se saltarían o se repetirían.
+    """
+    payload = json.dumps(
+        {"k": _jsonable(sort_value), "i": _jsonable(entity_id)},
+        separators=(",", ":"),
+    )
+    return base64.urlsafe_b64encode(payload.encode()).decode().rstrip("=")
+
+
+def decode_cursor(cursor: str) -> tuple[t.Any, t.Any]:
+    """
+    Decodifica un cursor a `(sort_value, entity_id)`.
+
+    Raises:
+        InvalidCursorError: Si el cursor está corrupto o no tiene la forma esperada. Es
+            un `ValueError`, así que los handlers de F5 lo traducen a 422.
+    """
+    try:
+        padding = "=" * (-len(cursor) % 4)
+        payload = base64.urlsafe_b64decode(cursor + padding).decode()
+        data = json.loads(payload)
+    except (binascii.Error, UnicodeDecodeError, json.JSONDecodeError, ValueError) as exc:
+        raise InvalidCursorError(f"Cursor inválido: {cursor!r}") from exc
+
+    if not isinstance(data, dict) or "k" not in data or "i" not in data:
+        raise InvalidCursorError(f"Cursor inválido: {cursor!r}")
+
+    return data["k"], data["i"]
+
+
+def _jsonable(value: t.Any) -> t.Any:
+    """Normaliza a algo serializable en JSON conservando el orden lexicográfico."""
+    if value is None or isinstance(value, (str, int, float, bool)):
+        return value
+    isoformat = getattr(value, "isoformat", None)
+    if callable(isoformat):
+        # ISO-8601 ordena lexicográficamente igual que cronológicamente, que es lo que
+        # necesita la comparación del WHERE.
+        return isoformat()
+    return str(value)

--- a/hexcore/application/dtos/errors.py
+++ b/hexcore/application/dtos/errors.py
@@ -1,0 +1,30 @@
+"""
+Errores de validación de campos de query, con datos estructurados.
+
+`ValueError("Campo de orden no soportado: nope")` sólo se puede mostrar; el cliente no
+puede señalar el input concreto ni ofrecer las alternativas. Esta subclase lleva `field` y
+`allowed`, y sigue siendo un `ValueError`, así que todo el código que ya lo capturaba
+—incluidos los handlers de F5— sigue funcionando.
+"""
+from __future__ import annotations
+
+import typing as t
+
+__all__ = ["UnsupportedQueryFieldError"]
+
+
+class UnsupportedQueryFieldError(ValueError):
+    """Un campo de filtro, orden o búsqueda que el modelo no expone."""
+
+    def __init__(
+        self,
+        field: str,
+        context: str,
+        allowed: t.Iterable[str] | None = None,
+    ) -> None:
+        self.field = field
+        self.context = context
+        self.allowed: list[str] = sorted(allowed) if allowed is not None else []
+        # Se conserva el mensaje anterior palabra por palabra: hay tests y logs que lo
+        # buscan, y cambiarlo no aporta nada.
+        super().__init__(f"Campo de {context} no soportado: {field}")

--- a/hexcore/config.py
+++ b/hexcore/config.py
@@ -21,6 +21,11 @@ class ServerConfig(BaseModel):
     port: int = 8000
     debug: bool = True
 
+    # Identidad de la app. La usa `create_app()` para el título y la versión de FastAPI,
+    # de modo que el camino feliz no necesite pasarlos.
+    app_title: str = "HexCore API"
+    app_version: str = "0.1.0"
+
     # DB CONFIG
     sql_database_url: str = "sqlite:///./db.sqlite3"
     async_sql_database_url: str = "sqlite+aiosqlite:///./db.sqlite3"

--- a/hexcore/infrastructure/api/__init__.py
+++ b/hexcore/infrastructure/api/__init__.py
@@ -1,3 +1,25 @@
+from .middlewares import (
+    REQUEST_ID,
+    RequestIDLogFilter,
+    RequestIDMiddleware,
+    TimingMiddleware,
+    get_request_id,
+    install_request_id_logging,
+)
+from .routing import build_root_router, mount_routers
 from .utils import build_query_endpoint, register_query_endpoint
 
-__all__ = ["build_query_endpoint", "register_query_endpoint"]
+__all__ = [
+    "build_query_endpoint",
+    "register_query_endpoint",
+    # Middlewares (F11)
+    "REQUEST_ID",
+    "RequestIDMiddleware",
+    "TimingMiddleware",
+    "RequestIDLogFilter",
+    "get_request_id",
+    "install_request_id_logging",
+    # Routing (F13)
+    "build_root_router",
+    "mount_routers",
+]

--- a/hexcore/infrastructure/api/__init__.py
+++ b/hexcore/infrastructure/api/__init__.py
@@ -1,3 +1,25 @@
+from .cqrs import (
+    CQRSContainer,
+    configure_cqrs,
+    get_cqrs_container,
+    provide_command_bus,
+    provide_event_bus,
+    provide_query_bus,
+    provide_registry,
+    reset_cqrs,
+)
+from .exception_handlers import (
+    DEFAULT_EXCEPTION_STATUS_MAP,
+    register_exception_handlers,
+)
+from .health import (
+    DependencyReport,
+    HealthReport,
+    Probe,
+    check_health,
+    default_probes,
+    register_health_routes,
+)
 from .middlewares import (
     REQUEST_ID,
     RequestIDLogFilter,
@@ -6,7 +28,9 @@ from .middlewares import (
     get_request_id,
     install_request_id_logging,
 )
+from .rate_limit import client_ip_key, rate_limit
 from .routing import build_root_router, mount_routers
+from .streaming import connection_slot, format_sse_event, sse_stream, ws_heartbeat
 from .utils import build_query_endpoint, register_query_endpoint
 
 __all__ = [
@@ -22,4 +46,31 @@ __all__ = [
     # Routing (F13)
     "build_root_router",
     "mount_routers",
+    # Handlers de excepción (F5)
+    "DEFAULT_EXCEPTION_STATUS_MAP",
+    "register_exception_handlers",
+    # Providers CQRS (F6)
+    "CQRSContainer",
+    "configure_cqrs",
+    "get_cqrs_container",
+    "reset_cqrs",
+    "provide_command_bus",
+    "provide_query_bus",
+    "provide_event_bus",
+    "provide_registry",
+    # Rate limiting (F12)
+    "rate_limit",
+    "client_ip_key",
+    # Streaming (F14)
+    "sse_stream",
+    "format_sse_event",
+    "ws_heartbeat",
+    "connection_slot",
+    # Health checks (F16)
+    "check_health",
+    "register_health_routes",
+    "default_probes",
+    "HealthReport",
+    "DependencyReport",
+    "Probe",
 ]

--- a/hexcore/infrastructure/api/app.py
+++ b/hexcore/infrastructure/api/app.py
@@ -1,0 +1,131 @@
+"""
+Factory de la aplicación FastAPI.
+
+Cada app repite CORS, middleware de request-id, handlers de excepción y health checks.
+Aplicando las reglas de simplicidad del plan: el camino feliz es cero configuración
+(`create_app()` a secas produce una app usable), y los interruptores van agrupados en un
+solo objeto en vez de ocho keywords.
+"""
+from __future__ import annotations
+
+import typing as t
+
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel
+
+from .exception_handlers import register_exception_handlers
+from .health import Probe, register_health_routes
+from .middlewares import RequestIDMiddleware, TimingMiddleware
+from .routing import MountableRouter, mount_routers
+
+__all__ = ["AppFeatures", "create_app"]
+
+
+class AppFeatures(BaseModel):
+    """
+    Qué cablea `create_app()`. Todo activado por defecto.
+
+    Desactivar es explícito y localizado: ``create_app(features=AppFeatures(cors=False))``.
+    """
+
+    cors: bool = True
+    """CORS con `config.allow_origins` / `allow_methods` / `allow_headers`."""
+
+    request_id: bool = True
+    """Middleware `X-Request-ID` (F11)."""
+
+    timing: bool = True
+    """Middleware `X-Response-Time-ms` (F11)."""
+
+    exception_handlers: bool = True
+    """Mapeo de excepciones de dominio a HTTP (F5)."""
+
+    health: bool = True
+    """Rutas `/health` y `/health/ready` (F16)."""
+
+
+def create_app(
+    lifespan: t.Any | None = None,
+    *,
+    features: AppFeatures | None = None,
+    routers: t.Sequence[MountableRouter] | None = None,
+    health_probes: t.Sequence[Probe] | None = None,
+    exception_mapping: dict[type[Exception], int] | None = None,
+    **fastapi_kwargs: t.Any,
+) -> FastAPI:
+    """
+    Construye una `FastAPI` con lo que toda app necesita ya cableado.
+
+    `create_app()` sin argumentos ya da una app usable: `title` y `version` salen de
+    `ServerConfig`, CORS de `config.allow_origins`, y `/health` existe.
+
+    Args:
+        lifespan: El lifespan. Típicamente de `build_lifespan(...)` (F4).
+        features: Qué cablear. Ver `AppFeatures`.
+        routers: Routers a montar. Acepta `APIRouter` o `(APIRouter, kwargs)` (F13).
+        health_probes: Sondas para `/health/ready`. Por defecto, las deducidas de la
+            configuración (F16).
+        exception_mapping: Excepciones extra a mapear, fusionadas con el default (F5).
+        **fastapi_kwargs: Se pasan tal cual a `FastAPI` (`title`, `version`,
+            `docs_url`, `openapi_tags`…). Lo que pases gana sobre los defaults derivados
+            de la configuración.
+
+    Returns:
+        La aplicación, lista para servir.
+    """
+    resolved_features = features or AppFeatures()
+    config = _config()
+
+    app = FastAPI(lifespan=lifespan, **{**_fastapi_defaults(config), **fastapi_kwargs})
+
+    # Los middlewares de Starlette se ejecutan en orden inverso al de registro, así que
+    # el request-id se añade último para que envuelva a todo lo demás y su ContextVar
+    # esté disponible en el resto de la pila.
+    if resolved_features.cors:
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=list(getattr(config, "allow_origins", ["*"])),
+            allow_credentials=bool(getattr(config, "allow_credentials", True)),
+            allow_methods=list(getattr(config, "allow_methods", ["*"])),
+            allow_headers=list(getattr(config, "allow_headers", ["*"])),
+        )
+    if resolved_features.timing:
+        app.add_middleware(TimingMiddleware)
+    if resolved_features.request_id:
+        app.add_middleware(RequestIDMiddleware)
+
+    if resolved_features.exception_handlers:
+        register_exception_handlers(app, mapping=exception_mapping)
+
+    if resolved_features.health:
+        register_health_routes(app, probes=health_probes)
+
+    if routers:
+        mount_routers(app, list(routers))
+
+    return app
+
+
+def _fastapi_defaults(config: t.Any) -> dict[str, t.Any]:
+    """
+    Defaults derivados de `ServerConfig`.
+
+    `debug` gobierna la documentación interactiva: en producción, `/docs` abierto es una
+    decisión que hay que tomar a propósito, no heredar.
+    """
+    debug = bool(getattr(config, "debug", False))
+    return {
+        "title": getattr(config, "app_title", None) or "HexCore API",
+        "version": getattr(config, "app_version", None) or "0.1.0",
+        "debug": debug,
+        "docs_url": "/docs" if debug else None,
+        "redoc_url": "/redoc" if debug else None,
+        "openapi_url": "/openapi.json" if debug else None,
+    }
+
+
+def _config() -> t.Any:
+    from hexcore.config import LazyConfig
+
+    return LazyConfig.get_config()

--- a/hexcore/infrastructure/api/cqrs.py
+++ b/hexcore/infrastructure/api/cqrs.py
@@ -1,0 +1,195 @@
+"""
+Providers FastAPI para los buses CQRS.
+
+Existen como funciones —y no como accesos directos al contenedor— por una única razón:
+`app.dependency_overrides[provide_command_bus] = ...` en los tests. Si el endpoint
+tocara el singleton, no habría nada que sobreescribir.
+
+**Una sola fuente de verdad.** El contenedor que leen estos providers es el mismo que
+usa el worker: se configura una vez con `configure_cqrs(...)` y tanto la app web como el
+entrypoint del worker lo consumen. Duplicar la construcción es cómo se acaba con un
+registry en el web que no tiene los handlers del worker.
+"""
+from __future__ import annotations
+
+import threading
+import typing as t
+
+from hexcore.domain.cqrs.buses import (
+    AbstractCommandBus,
+    AbstractEventBus,
+    AbstractQueryBus,
+)
+
+if t.TYPE_CHECKING:
+    from hexcore.application.cqrs.factory import CQRSFactory
+    from hexcore.application.cqrs.registry import HandlerRegistry
+    from hexcore.domain.cqrs.serializer import ISerializer
+    from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
+    from hexcore.infrastructure.workers.consumer import CQRSConsumer
+
+__all__ = [
+    "CQRSContainer",
+    "configure_cqrs",
+    "get_cqrs_container",
+    "reset_cqrs",
+    "provide_command_bus",
+    "provide_query_bus",
+    "provide_event_bus",
+    "provide_registry",
+]
+
+
+class CQRSContainer:
+    """
+    Contenedor perezoso de los buses CQRS.
+
+    Construye los buses la primera vez que se piden y los cachea. Perezoso a propósito:
+    `configure_cqrs()` se puede llamar en import time sin tocar la BD ni el broker.
+    """
+
+    def __init__(
+        self,
+        factory: "CQRSFactory",
+    ) -> None:
+        self._factory = factory
+        self._command_bus: AbstractCommandBus | None = None
+        self._query_bus: AbstractQueryBus | None = None
+        self._event_bus: AbstractEventBus | None = None
+        self._lock = threading.RLock()
+
+    @property
+    def registry(self) -> "HandlerRegistry":
+        return self._factory._registry  # noqa: SLF001 - misma capa lógica
+
+    @property
+    def serializer(self) -> "ISerializer":
+        return self._factory.create_serializer()
+
+    def command_bus(self) -> AbstractCommandBus:
+        with self._lock:
+            if self._command_bus is None:
+                self._command_bus = t.cast(
+                    AbstractCommandBus, self._factory.create_command_bus()
+                )
+            return self._command_bus
+
+    def query_bus(self) -> AbstractQueryBus:
+        with self._lock:
+            if self._query_bus is None:
+                self._query_bus = t.cast(
+                    AbstractQueryBus, self._factory.create_query_bus()
+                )
+            return self._query_bus
+
+    def event_bus(self) -> AbstractEventBus:
+        with self._lock:
+            if self._event_bus is None:
+                self._event_bus = t.cast(
+                    AbstractEventBus, self._factory.create_event_bus()
+                )
+            return self._event_bus
+
+    def build_consumer(self) -> "CQRSConsumer":
+        """
+        Construye el `CQRSConsumer` del worker sobre **estos mismos** buses.
+
+        Es lo que garantiza que el worker y la app web comparten registry y serializer.
+        """
+        from hexcore.infrastructure.workers.consumer import CQRSConsumer
+
+        return CQRSConsumer(
+            command_bus=self.command_bus(),
+            event_bus=self.event_bus(),
+            serializer=self.serializer,
+        )
+
+
+_container: CQRSContainer | None = None
+_container_lock = threading.RLock()
+
+
+def configure_cqrs(
+    registry: "HandlerRegistry",
+    *,
+    config: t.Any = None,
+    enqueuer: "ITaskEnqueuer | None" = None,
+) -> CQRSContainer:
+    """
+    Configura el contenedor CQRS del proceso. Llamalo una vez, al arrancar.
+
+    Args:
+        registry: El registry con los handlers ya registrados.
+        config: Un `CQRSConfig`. Por defecto, el de `ServerConfig.cqrs` si está, o
+            `CQRSConfig()`.
+        enqueuer: El `ITaskEnqueuer` para el Smart Routing. Sin él, un
+            `@background_command` registrado hace fallar la construcción del bus (P0-5).
+
+    Returns:
+        El contenedor, por si querés usarlo directamente (p. ej. `build_consumer()`).
+    """
+    from hexcore.application.cqrs.config import CQRSConfig
+    from hexcore.application.cqrs.factory import CQRSFactory
+
+    global _container
+
+    if config is None:
+        from hexcore.config import LazyConfig
+
+        config = getattr(LazyConfig.get_config(), "cqrs", None) or CQRSConfig()
+
+    with _container_lock:
+        _container = CQRSContainer(
+            CQRSFactory(config, registry, enqueuer=enqueuer)
+        )
+        return _container
+
+
+def get_cqrs_container() -> CQRSContainer:
+    """
+    El contenedor configurado.
+
+    Raises:
+        RuntimeError: Si nadie llamó a `configure_cqrs()`.
+    """
+    with _container_lock:
+        if _container is None:
+            raise RuntimeError(
+                "El CQRS no está configurado. Llamá a "
+                "hexcore.infrastructure.api.cqrs.configure_cqrs(registry, enqueuer=...) "
+                "al arrancar la aplicación (o el worker), antes de resolver cualquier bus."
+            )
+        return _container
+
+
+def reset_cqrs() -> None:
+    """Descarta el contenedor. Para tests y para reconfigurar en un worker."""
+    global _container
+
+    with _container_lock:
+        _container = None
+
+
+# ── Dependencias FastAPI ──────────────────────────────────────────────────────
+# Deliberadamente triviales: su valor está en ser un objeto sobre el que hacer
+# `app.dependency_overrides[...] = ...`.
+
+
+def provide_command_bus() -> AbstractCommandBus:
+    """Dependencia FastAPI: el CommandBus del proceso."""
+    return get_cqrs_container().command_bus()
+
+
+def provide_query_bus() -> AbstractQueryBus:
+    """Dependencia FastAPI: el QueryBus del proceso."""
+    return get_cqrs_container().query_bus()
+
+
+def provide_event_bus() -> AbstractEventBus:
+    """Dependencia FastAPI: el EventBus del proceso."""
+    return get_cqrs_container().event_bus()
+
+
+def provide_registry() -> "HandlerRegistry":
+    """Dependencia FastAPI: el `HandlerRegistry` del proceso."""
+    return get_cqrs_container().registry

--- a/hexcore/infrastructure/api/exception_handlers.py
+++ b/hexcore/infrastructure/api/exception_handlers.py
@@ -1,0 +1,131 @@
+"""
+Mapeo de excepciones de dominio a respuestas HTTP.
+
+Cada app escribe los mismos cuatro `@app.exception_handler` para traducir sus
+excepciones a 404/409/422/500. HexCore ya define `hexcore.domain.exceptions` y las de
+CQRS, así que tiene la información para hacerlo por defecto.
+"""
+from __future__ import annotations
+
+import logging
+import typing as t
+
+from fastapi import FastAPI, Request
+from fastapi.responses import JSONResponse
+
+from hexcore.domain.cqrs.exceptions import (
+    DeserializationError,
+    DuplicateHandlerError,
+    HandlerNotFoundError,
+)
+from hexcore.domain.exceptions import InactiveEntityException
+
+logger = logging.getLogger("hexcore.api.exceptions")
+
+__all__ = [
+    "DEFAULT_EXCEPTION_STATUS_MAP",
+    "register_exception_handlers",
+]
+
+
+# `ValueError` → 422 porque es lo que lanza la validación de campos de las queries.
+# Hasta ahora sólo se capturaba **dentro** de `build_query_endpoint`, así que una query
+# construida a mano devolvía 500.
+DEFAULT_EXCEPTION_STATUS_MAP: dict[type[Exception], int] = {
+    InactiveEntityException: 409,
+    DeserializationError: 400,
+    HandlerNotFoundError: 501,
+    DuplicateHandlerError: 500,
+    ValueError: 422,
+}
+
+DetailFactory = t.Callable[[Exception], str]
+
+
+def register_exception_handlers(
+    app: FastAPI,
+    *,
+    mapping: dict[type[Exception], int] | None = None,
+    include_detail: bool | DetailFactory = True,
+) -> None:
+    """
+    Registra handlers que traducen excepciones a respuestas JSON.
+
+    Args:
+        app: La aplicación FastAPI.
+        mapping: Excepciones extra o overrides. Se **fusiona** con
+            `DEFAULT_EXCEPTION_STATUS_MAP`; lo que pases gana.
+        include_detail: Qué poner en el campo ``detail`` de la respuesta.
+            ``True`` → ``str(exc)``. ``False`` → un mensaje genérico por status, para no
+            filtrar internals en una API pública. Un callable → lo que devuelva.
+
+    El cuerpo es siempre ``{"detail": ..., "error": "<NombreDeLaExcepción>"}``, para que
+    el cliente pueda distinguir el caso sin parsear el texto.
+
+    Uso::
+
+        register_exception_handlers(app, mapping={MiNotFound: 404})
+    """
+    resolved = {**DEFAULT_EXCEPTION_STATUS_MAP, **(mapping or {})}
+
+    # De más específico a más genérico. Starlette resuelve por MRO de la excepción
+    # lanzada, pero registrar en este orden mantiene el comportamiento estable si dos
+    # entradas están emparentadas (p. ej. `ValueError` y una subclase propia).
+    for exc_type in sorted(resolved, key=_specificity, reverse=True):
+        app.add_exception_handler(
+            exc_type,
+            _build_handler(exc_type, resolved[exc_type], include_detail),
+        )
+
+
+def _specificity(exc_type: type[Exception]) -> int:
+    """Cuántos niveles de herencia tiene: más profundo = más específico."""
+    return len(exc_type.__mro__)
+
+
+def _build_handler(
+    exc_type: type[Exception],
+    status_code: int,
+    include_detail: bool | DetailFactory,
+) -> t.Callable[[Request, Exception], t.Awaitable[JSONResponse]]:
+    async def handler(request: Request, exc: Exception) -> JSONResponse:
+        if status_code >= 500:
+            logger.exception(
+                "%s %s → %s (%s)",
+                request.method,
+                request.url.path,
+                status_code,
+                type(exc).__name__,
+            )
+        else:
+            logger.info(
+                "%s %s → %s (%s: %s)",
+                request.method,
+                request.url.path,
+                status_code,
+                type(exc).__name__,
+                exc,
+            )
+
+        return JSONResponse(
+            status_code=status_code,
+            content={
+                "detail": _detail_for(exc, status_code, include_detail),
+                "error": type(exc).__name__,
+            },
+        )
+
+    handler.__name__ = f"handle_{exc_type.__name__}"
+    return handler
+
+
+def _detail_for(
+    exc: Exception,
+    status_code: int,
+    include_detail: bool | DetailFactory,
+) -> str:
+    if callable(include_detail):
+        return include_detail(exc)
+    if include_detail:
+        return str(exc)
+    return "Internal server error" if status_code >= 500 else "Request rejected"

--- a/hexcore/infrastructure/api/health.py
+++ b/hexcore/infrastructure/api/health.py
@@ -1,0 +1,255 @@
+"""
+Health checks: liveness sin I/O, readiness que sondea de verdad.
+
+Un `/health/detailed` que devuelve `{"status": "ok"}` hardcodeado es un health check que
+no puede fallar, y eso es **peor** que no tenerlo: el orquestador lo lee como "sano" con
+la base de datos caída y sigue mandándole tráfico.
+
+La librería sabe qué dependencias hay configuradas, así que puede sondearlas. Cada sonda
+tiene su propio timeout: un health check que se cuelga es un health check que tumba el
+deploy.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import typing as t
+
+from fastapi import FastAPI, Response
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger("hexcore.api.health")
+
+__all__ = [
+    "HealthStatus",
+    "DependencyReport",
+    "HealthReport",
+    "Probe",
+    "check_health",
+    "register_health_routes",
+    "default_probes",
+]
+
+HealthStatus = t.Literal["ok", "degraded", "down"]
+
+
+class DependencyReport(BaseModel):
+    """Resultado de sondear una dependencia."""
+
+    name: str
+    status: HealthStatus
+    latency_ms: float
+    detail: str | None = None
+
+
+class HealthReport(BaseModel):
+    """Resultado global. `status` es el peor de las dependencias."""
+
+    status: HealthStatus
+    deep: bool = False
+    dependencies: list[DependencyReport] = Field(default_factory=list)
+
+    @property
+    def http_status(self) -> int:
+        """503 si algo está caído; 200 en el resto de los casos."""
+        return 503 if self.status == "down" else 200
+
+
+class Probe(t.NamedTuple):
+    """Una sonda con nombre y timeout propio."""
+
+    name: str
+    check: t.Callable[[], t.Awaitable[None]]
+    timeout: float = 2.0
+    # Una dependencia no crítica reporta "degraded" en vez de "down": un cache caído
+    # ralentiza, no impide servir.
+    critical: bool = True
+
+
+async def check_health(
+    *,
+    deep: bool = False,
+    probes: t.Sequence[Probe] | None = None,
+) -> HealthReport:
+    """
+    Evalúa la salud del proceso.
+
+    Args:
+        deep: ``False`` → liveness: responde siempre 200 sin tocar nada, que es lo que
+            un liveness probe debe hacer (si sondea dependencias, un Redis caído provoca
+            que Kubernetes reinicie una app perfectamente sana). ``True`` → readiness:
+            sondea las dependencias configuradas.
+        probes: Sondas a ejecutar. Por defecto, las que `default_probes()` deduzca de la
+            configuración.
+
+    Returns:
+        El informe, con el estado y la latencia por dependencia.
+    """
+    if not deep:
+        return HealthReport(status="ok", deep=False)
+
+    selected = list(probes) if probes is not None else default_probes()
+    if not selected:
+        return HealthReport(status="ok", deep=True)
+
+    reports = await asyncio.gather(*(_run_probe(probe) for probe in selected))
+
+    if any(report.status == "down" for report in reports):
+        overall: HealthStatus = "down"
+    elif any(report.status == "degraded" for report in reports):
+        overall = "degraded"
+    else:
+        overall = "ok"
+
+    return HealthReport(status=overall, deep=True, dependencies=list(reports))
+
+
+async def _run_probe(probe: Probe) -> DependencyReport:
+    start = time.perf_counter()
+    try:
+        await asyncio.wait_for(probe.check(), timeout=probe.timeout)
+    except asyncio.TimeoutError:
+        return DependencyReport(
+            name=probe.name,
+            status="down" if probe.critical else "degraded",
+            latency_ms=_elapsed_ms(start),
+            detail=f"timeout tras {probe.timeout}s",
+        )
+    except Exception as exc:
+        return DependencyReport(
+            name=probe.name,
+            status="down" if probe.critical else "degraded",
+            latency_ms=_elapsed_ms(start),
+            detail=f"{type(exc).__name__}: {exc}",
+        )
+
+    return DependencyReport(
+        name=probe.name, status="ok", latency_ms=_elapsed_ms(start)
+    )
+
+
+def _elapsed_ms(start: float) -> float:
+    return round((time.perf_counter() - start) * 1000, 2)
+
+
+def default_probes() -> list[Probe]:
+    """
+    Sondas deducidas de lo que está configurado e instalado.
+
+    Sólo se incluye lo que se puede sondear de verdad: si SQLAlchemy no está instalado,
+    no hay sonda de SQL, en vez de una que siempre pasa.
+    """
+    probes: list[Probe] = []
+
+    if _sql_available():
+        probes.append(Probe(name="sql", check=_check_sql, timeout=2.0))
+    if _redis_configured():
+        # El cache es degradación, no caída: sin él la app sirve más lento.
+        probes.append(
+            Probe(name="redis", check=_check_redis, timeout=1.0, critical=False)
+        )
+    if _mongo_available():
+        probes.append(Probe(name="mongo", check=_check_mongo, timeout=2.0))
+
+    return probes
+
+
+# ── Sondas ────────────────────────────────────────────────────────────────────
+
+
+def _sql_available() -> bool:
+    try:
+        import sqlalchemy  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+async def _check_sql() -> None:
+    from sqlalchemy import text
+
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.session import get_engine
+
+    engine = get_engine()
+    async with engine.connect() as connection:
+        await connection.execute(text("SELECT 1"))
+
+
+def _redis_configured() -> bool:
+    try:
+        import redis  # noqa: F401
+    except ImportError:
+        return False
+
+    from hexcore.config import LazyConfig
+
+    return bool(getattr(LazyConfig.get_config(), "redis_uri", None))
+
+
+async def _check_redis() -> None:
+    from redis.asyncio import Redis
+
+    from hexcore.config import LazyConfig
+
+    client = Redis.from_url(LazyConfig.get_config().redis_uri)
+    try:
+        await client.ping()
+    finally:
+        await client.aclose()
+
+
+def _mongo_available() -> bool:
+    try:
+        import beanie  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+async def _check_mongo() -> None:
+    from beanie import Document
+
+    # Beanie guarda el cliente en el motor de cualquier documento inicializado. Si no
+    # hay ninguno, no hay Mongo que sondear y la sonda no debería estar activa.
+    for document in Document.__subclasses__():
+        motor_collection = getattr(document, "get_motor_collection", None)
+        if motor_collection is None:
+            continue
+        collection = motor_collection()
+        await collection.database.client.admin.command("ping")
+        return
+
+    raise RuntimeError("No hay documentos Beanie inicializados que sondear.")
+
+
+# ── Rutas ─────────────────────────────────────────────────────────────────────
+
+
+def register_health_routes(
+    app: FastAPI,
+    *,
+    path: str = "/health",
+    probes: t.Sequence[Probe] | None = None,
+) -> None:
+    """
+    Registra `GET {path}` (liveness) y `GET {path}/ready` (readiness).
+
+    - `{path}` responde 200 sin I/O. Apuntá aquí el liveness probe.
+    - `{path}/ready` sondea las dependencias y responde **503** si algo crítico falla,
+      con el detalle y la latencia por dependencia. Apuntá aquí el readiness probe.
+    """
+    @app.get(path, tags=["health"], summary="Liveness: el proceso responde")
+    async def health() -> HealthReport:
+        return await check_health(deep=False)
+
+    @app.get(
+        f"{path}/ready",
+        tags=["health"],
+        summary="Readiness: las dependencias responden",
+        responses={503: {"description": "Alguna dependencia crítica no responde"}},
+    )
+    async def health_ready(response: Response) -> HealthReport:
+        report = await check_health(deep=True, probes=probes)
+        response.status_code = report.http_status
+        return report

--- a/hexcore/infrastructure/api/lifespan.py
+++ b/hexcore/infrastructure/api/lifespan.py
@@ -1,0 +1,340 @@
+"""
+Lifespan composable a partir de steps.
+
+El `lifespan` de una app real orquesta a mano: engine SQL → documentos Beanie →
+publisher realtime → inyección del event bus en config → warmup de cachés →
+consumidores → pool de la cola. El orden importa y no está documentado en ningún sitio,
+y cada paso opcional acaba envuelto en su propio `try/except`.
+
+Requisitos que cumple esta implementación, y que son la parte que se hace mal a mano:
+
+- **Teardown en orden inverso.**
+- **Teardown garantizado de los steps que sí arrancaron**, aunque uno posterior falle.
+- **`on_error="warn"` por step**: un warmup de caché no debe tumbar el arranque.
+- Un log por step con su duración.
+"""
+from __future__ import annotations
+
+import logging
+import time
+import typing as t
+from contextlib import asynccontextmanager
+
+logger = logging.getLogger("hexcore.api.lifespan")
+
+__all__ = [
+    "StartupStep",
+    "ErrorPolicy",
+    "build_lifespan",
+    "CallableStep",
+    "SqlEngineStep",
+    "BeanieStep",
+    "EventBusStep",
+    "CacheStep",
+    "ProcrastinateStep",
+    "CronSeedStep",
+]
+
+ErrorPolicy = t.Literal["raise", "warn"]
+
+
+@t.runtime_checkable
+class StartupStep(t.Protocol):
+    """Un paso del arranque. `stop()` es opcional."""
+
+    name: str
+
+    async def start(self) -> None: ...
+
+
+def build_lifespan(
+    *steps: StartupStep,
+    on_error: ErrorPolicy = "raise",
+) -> t.Callable[[t.Any], t.AsyncContextManager[None]]:
+    """
+    Compone un lifespan de FastAPI a partir de steps.
+
+    Args:
+        *steps: Los pasos, en orden de arranque. El teardown va en orden inverso.
+        on_error: Política por defecto. Cada step puede sobreescribirla con un atributo
+            `on_error` propio, que es lo que permite decir "este warmup puede fallar" sin
+            cambiar la política global.
+
+    Returns:
+        Un context manager apto para ``FastAPI(lifespan=...)``.
+
+    Uso::
+
+        app = create_app(lifespan=build_lifespan(
+            SqlEngineStep(),
+            BeanieStep(documents=MONGO_DOCUMENTS),
+            EventBusStep(RealtimeEventDispatcher()),
+            ProcrastinateStep(procrastinate_app),
+            CallableStep("warm-caches", warm_validation_cache, on_error="warn"),
+        ))
+    """
+    @asynccontextmanager
+    async def lifespan(app: t.Any) -> t.AsyncIterator[None]:
+        del app  # el contrato de FastAPI lo pasa; los steps no lo necesitan
+        started: list[StartupStep] = []
+        try:
+            for step in steps:
+                await _start_step(step, on_error, started)
+            yield
+        finally:
+            # Inverso y sobre `started`, no sobre `steps`: parar algo que nunca arrancó
+            # es cómo un fallo de arranque se convierte en dos errores en el log.
+            await _stop_steps(started)
+
+    return lifespan
+
+
+async def _start_step(
+    step: StartupStep,
+    default_policy: ErrorPolicy,
+    started: list[StartupStep],
+) -> None:
+    policy: ErrorPolicy = getattr(step, "on_error", None) or default_policy
+    start_time = time.perf_counter()
+    try:
+        await step.start()
+    except Exception as exc:
+        elapsed = (time.perf_counter() - start_time) * 1000
+        if policy == "warn":
+            logger.warning(
+                "[lifespan] step '%s' falló en %.1fms (%s: %s); se continúa porque "
+                "on_error='warn'.",
+                step.name,
+                elapsed,
+                type(exc).__name__,
+                exc,
+            )
+            return
+        logger.error(
+            "[lifespan] step '%s' falló en %.1fms (%s: %s); se aborta el arranque.",
+            step.name,
+            elapsed,
+            type(exc).__name__,
+            exc,
+        )
+        raise
+
+    elapsed = (time.perf_counter() - start_time) * 1000
+    logger.info("[lifespan] step '%s' arrancó en %.1fms", step.name, elapsed)
+    started.append(step)
+
+
+async def _stop_steps(started: list[StartupStep]) -> None:
+    for step in reversed(started):
+        stop = getattr(step, "stop", None)
+        if stop is None:
+            continue
+        start_time = time.perf_counter()
+        try:
+            await stop()
+        except Exception:
+            # Un teardown que falla no debe impedir los siguientes ni tapar la excepción
+            # que provocó el apagado.
+            logger.exception("[lifespan] step '%s' falló al parar", step.name)
+            continue
+        elapsed = (time.perf_counter() - start_time) * 1000
+        logger.info("[lifespan] step '%s' paró en %.1fms", step.name, elapsed)
+
+
+# ── Steps de serie ────────────────────────────────────────────────────────────
+
+
+class CallableStep:
+    """
+    Envuelve un par de corutinas sueltas como step.
+
+    Reemplaza el `try/except` a mano alrededor de cada paso opcional del arranque.
+    """
+
+    def __init__(
+        self,
+        name: str,
+        start: t.Callable[[], t.Awaitable[None]],
+        stop: t.Callable[[], t.Awaitable[None]] | None = None,
+        *,
+        on_error: ErrorPolicy | None = None,
+    ) -> None:
+        self.name = name
+        self.on_error = on_error
+        self._start = start
+        self._stop = stop
+
+    async def start(self) -> None:
+        await self._start()
+
+    async def stop(self) -> None:
+        if self._stop is not None:
+            await self._stop()
+
+
+class SqlEngineStep:
+    """
+    Inicializa el engine de SQLAlchemy y lo cierra al apagar.
+
+    Envuelve `init_engine()` / `dispose_engine()` de F2, así que hereda
+    `expire_on_commit=False`, la normalización del DSN y el tuning del pool.
+    """
+
+    name = "sql-engine"
+
+    def __init__(
+        self,
+        url: str | None = None,
+        *,
+        pool: t.Any = None,
+        on_error: ErrorPolicy | None = None,
+        **engine_kwargs: t.Any,
+    ) -> None:
+        self.on_error = on_error
+        self._url = url
+        self._pool = pool
+        self._engine_kwargs = engine_kwargs
+
+    async def start(self) -> None:
+        from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (
+            init_engine,
+        )
+
+        init_engine(self._url, pool=self._pool, **self._engine_kwargs)
+
+    async def stop(self) -> None:
+        from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (
+            dispose_engine,
+        )
+
+        await dispose_engine()
+
+
+class BeanieStep:
+    """Inicializa los documentos de Beanie/MongoDB."""
+
+    name = "beanie"
+
+    def __init__(
+        self,
+        documents: t.Sequence[t.Any] | None = None,
+        *,
+        on_error: ErrorPolicy | None = None,
+    ) -> None:
+        self.on_error = on_error
+        self._documents = documents
+
+    async def start(self) -> None:
+        from hexcore.infrastructure.repositories.orms.beanie.utils import (
+            init_beanie_documents,
+        )
+
+        if self._documents is None:
+            await init_beanie_documents()
+        else:
+            await init_beanie_documents(list(self._documents))
+
+
+class EventBusStep:
+    """
+    Inyecta un event bus en `ServerConfig`.
+
+    Es el paso que la app real hacía a mano (`config.event_bus = ...`) y que hay que
+    hacer *después* de que el bus tenga sus dependencias listas.
+    """
+
+    name = "event-bus"
+
+    def __init__(self, bus: t.Any, *, on_error: ErrorPolicy | None = None) -> None:
+        self.on_error = on_error
+        self._bus = bus
+        self._previous: t.Any = None
+
+    async def start(self) -> None:
+        from hexcore.config import LazyConfig
+
+        config = LazyConfig.get_config()
+        self._previous = config.event_bus
+        config.event_bus = self._bus
+
+    async def stop(self) -> None:
+        from hexcore.config import LazyConfig
+
+        # Se restaura para que un lifespan en tests no contamine el siguiente.
+        LazyConfig.get_config().event_bus = self._previous
+
+
+class CacheStep:
+    """Inyecta un backend de cache en `ServerConfig` y lo cierra si sabe cómo."""
+
+    name = "cache"
+
+    def __init__(self, backend: t.Any, *, on_error: ErrorPolicy | None = None) -> None:
+        self.on_error = on_error
+        self._backend = backend
+        self._previous: t.Any = None
+
+    async def start(self) -> None:
+        from hexcore.config import LazyConfig
+
+        config = LazyConfig.get_config()
+        self._previous = config.cache_backend
+        config.cache_backend = self._backend
+
+    async def stop(self) -> None:
+        from hexcore.config import LazyConfig
+
+        LazyConfig.get_config().cache_backend = self._previous
+        close = getattr(self._backend, "aclose", None) or getattr(
+            self._backend, "close", None
+        )
+        if close is None:
+            return
+        result = close()
+        if hasattr(result, "__await__"):
+            await result
+
+
+class ProcrastinateStep:
+    """Abre y cierra el pool de una app de Procrastinate."""
+
+    name = "procrastinate"
+
+    def __init__(self, app: t.Any, *, on_error: ErrorPolicy | None = None) -> None:
+        self.on_error = on_error
+        self._app = app
+
+    async def start(self) -> None:
+        await self._app.open_async()
+
+    async def stop(self) -> None:
+        await self._app.close_async()
+
+
+class CronSeedStep:
+    """
+    Siembra las definiciones de cron. Idempotente (ver F7).
+
+    Va después de `SqlEngineStep`, obviamente: necesita el engine.
+    """
+
+    name = "cron-seed"
+
+    def __init__(
+        self,
+        jobs: t.Sequence[t.Any],
+        *,
+        create_tables: bool = False,
+        on_error: ErrorPolicy | None = None,
+    ) -> None:
+        self.on_error = on_error
+        self._jobs = jobs
+        self._create_tables = create_tables
+
+    async def start(self) -> None:
+        from hexcore.infrastructure.cqrs.cron_sql import create_cron_tables, seed_cron_jobs
+
+        if self._create_tables:
+            await create_cron_tables()
+        inserted = await seed_cron_jobs(list(self._jobs))
+        logger.info("[lifespan] cron-seed insertó %d definiciones", inserted)

--- a/hexcore/infrastructure/api/middlewares.py
+++ b/hexcore/infrastructure/api/middlewares.py
@@ -1,0 +1,142 @@
+"""
+Middlewares HTTP de serie.
+
+`RequestIDMiddleware` es el ejemplo canónico de código 100 % genérico que toda API
+reescribe. Lo que aporta esta versión y no la típica de 28 líneas: el request-id vive
+en un `ContextVar` y hay un `logging.Filter` que lo inyecta en cada línea de log. Sin
+eso, tener el header no sirve para correlacionar nada.
+"""
+from __future__ import annotations
+
+import logging
+import time
+import typing as t
+import uuid
+from contextvars import ContextVar
+
+from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
+from starlette.requests import Request
+from starlette.responses import Response
+
+__all__ = [
+    "REQUEST_ID",
+    "RequestIDMiddleware",
+    "TimingMiddleware",
+    "RequestIDLogFilter",
+    "get_request_id",
+    "install_request_id_logging",
+]
+
+
+REQUEST_ID: ContextVar[str] = ContextVar("hexcore_request_id", default="-")
+
+DEFAULT_REQUEST_ID_HEADER = "X-Request-ID"
+DEFAULT_TIMING_HEADER = "X-Response-Time-ms"
+
+
+def get_request_id() -> str:
+    """
+    El request-id del request en curso, o ``"-"`` fuera de un request.
+
+    Nunca lanza: se puede llamar desde cualquier sitio (incluido un handler de logging)
+    sin comprobar si hay request.
+    """
+    return REQUEST_ID.get()
+
+
+class RequestIDMiddleware(BaseHTTPMiddleware):
+    """
+    Propaga un identificador por request.
+
+    Reusa el header entrante si viene (el balanceador o el gateway suele ponerlo, y
+    romper esa cadena es perder la traza); si no, genera un UUID4. Lo publica en el
+    `ContextVar` `REQUEST_ID` y lo devuelve en la respuesta.
+    """
+
+    def __init__(
+        self,
+        app: t.Any,
+        *,
+        header_name: str = DEFAULT_REQUEST_ID_HEADER,
+        generator: t.Callable[[], str] | None = None,
+    ) -> None:
+        super().__init__(app)
+        self.header_name = header_name
+        self._generator = generator or (lambda: str(uuid.uuid4()))
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        request_id = request.headers.get(self.header_name) or self._generator()
+        token = REQUEST_ID.set(request_id)
+        # Disponible también en `request.state` para quien no quiera el ContextVar.
+        request.state.request_id = request_id
+        try:
+            response = await call_next(request)
+        finally:
+            REQUEST_ID.reset(token)
+        response.headers[self.header_name] = request_id
+        return response
+
+
+class TimingMiddleware(BaseHTTPMiddleware):
+    """Añade el tiempo de proceso del request en milisegundos como header."""
+
+    def __init__(
+        self,
+        app: t.Any,
+        *,
+        header_name: str = DEFAULT_TIMING_HEADER,
+    ) -> None:
+        super().__init__(app)
+        self.header_name = header_name
+
+    async def dispatch(
+        self, request: Request, call_next: RequestResponseEndpoint
+    ) -> Response:
+        start = time.perf_counter()
+        response = await call_next(request)
+        elapsed_ms = (time.perf_counter() - start) * 1000
+        response.headers[self.header_name] = f"{elapsed_ms:.2f}"
+        return response
+
+
+class RequestIDLogFilter(logging.Filter):
+    """
+    Inyecta el request-id en cada `LogRecord` como ``record.request_id``.
+
+    Es la mitad del valor de `RequestIDMiddleware`: con esto, un formatter como
+    ``"%(asctime)s [%(request_id)s] %(message)s"`` correlaciona todas las líneas de un
+    request sin que nadie tenga que pasar el id a mano.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.request_id = get_request_id()
+        return True
+
+
+def install_request_id_logging(
+    logger: logging.Logger | None = None,
+    *,
+    fmt: str | None = None,
+) -> None:
+    """
+    Instala el filtro de request-id en los handlers de un logger.
+
+    Args:
+        logger: El logger a instrumentar. Por defecto, el root logger.
+        fmt: Si se da, se aplica como formato a los handlers del logger. Usá
+            ``%(request_id)s`` en él. Si es None, no se toca el formato: el filtro
+            deja el atributo disponible para el formato que ya tengas.
+    """
+    target = logger or logging.getLogger()
+    log_filter = RequestIDLogFilter()
+
+    # El filtro va en los handlers, no en el logger: un filtro de logger no se aplica
+    # a los registros que suben por propagación desde loggers hijos.
+    handlers = target.handlers or logging.getLogger().handlers
+    for handler in handlers:
+        if not any(isinstance(f, RequestIDLogFilter) for f in handler.filters):
+            handler.addFilter(log_filter)
+        if fmt is not None:
+            handler.setFormatter(logging.Formatter(fmt))

--- a/hexcore/infrastructure/api/rate_limit.py
+++ b/hexcore/infrastructure/api/rate_limit.py
@@ -1,0 +1,165 @@
+"""
+Rate limiting como dependencia de FastAPI.
+
+Se apoya en el puerto `ICache`, no en Redis directamente, para que funcione con
+`MemoryCache` en los tests sin levantar nada.
+
+La ventana lleva su propio vencimiento dentro del valor cacheado (`reset_at`) en vez de
+depender del TTL del backend: `MemoryCache` ignora el parámetro `expire`, y un rate
+limiter que sólo funciona contra Redis no se puede testear.
+"""
+from __future__ import annotations
+
+import logging
+import time
+import typing as t
+
+from fastapi import HTTPException, Request
+
+from hexcore.infrastructure.cache import ICache
+
+logger = logging.getLogger("hexcore.api.rate_limit")
+
+__all__ = ["rate_limit", "RateLimitBackendPolicy", "client_ip_key"]
+
+RateLimitBackendPolicy = t.Literal["allow", "deny"]
+
+KeyFunc = t.Callable[[Request], str]
+
+
+def client_ip_key(request: Request) -> str:
+    """
+    Clave por IP del cliente.
+
+    Respeta `X-Forwarded-For` si viene, porque detrás de un balanceador
+    `request.client.host` es la IP del balanceador y limitaría a todo el mundo junto.
+    """
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        return forwarded.split(",")[0].strip()
+    client = request.client
+    return client.host if client else "unknown"
+
+
+def rate_limit(
+    limit: int,
+    window_seconds: int = 60,
+    *,
+    key: KeyFunc | None = None,
+    cache: ICache | None = None,
+    on_backend_error: RateLimitBackendPolicy = "allow",
+    namespace: str = "hexcore:ratelimit",
+) -> t.Callable[..., t.Awaitable[None]]:
+    """
+    Construye una dependencia que limita las peticiones por clave.
+
+    Args:
+        limit: Peticiones permitidas por ventana.
+        window_seconds: Duración de la ventana.
+        key: Cómo derivar la clave del request. Por defecto, la IP del cliente. Para
+            limitar por usuario: ``key=lambda r: r.state.user_id``.
+        cache: El backend. Por defecto, `config.cache_backend`.
+        on_backend_error: Qué hacer si el backend falla. ``"allow"`` (default) deja pasar
+            —un Redis caído no debería tumbar la API—; ``"deny"`` devuelve 429. Es una
+            decisión explícita y configurable, no enterrada en un `except`.
+        namespace: Prefijo de las claves en el cache.
+
+    Returns:
+        Una corutina para usar en ``Depends(...)``.
+
+    Devuelve **429 con `Retry-After`**, que es lo que un cliente bien hecho necesita para
+    reintentar sin adivinar.
+
+    Uso::
+
+        @router.get("/reports", dependencies=[Depends(rate_limit(10, 60))])
+        async def reports(): ...
+
+        por_usuario = rate_limit(100, 3600, key=lambda r: r.state.user_id)
+    """
+    if limit < 1:
+        raise ValueError("rate_limit(limit=...) tiene que ser >= 1")
+    if window_seconds < 1:
+        raise ValueError("rate_limit(window_seconds=...) tiene que ser >= 1")
+
+    key_func = key or client_ip_key
+
+    async def dependency(request: Request) -> None:
+        backend = cache or _default_cache()
+        cache_key = f"{namespace}:{key_func(request)}"
+        now = time.time()
+
+        try:
+            state = await backend.get(cache_key)
+            count, reset_at = _read_window(state, now, window_seconds)
+
+            if count >= limit:
+                retry_after = max(1, int(reset_at - now) + 1)
+                raise HTTPException(
+                    status_code=429,
+                    detail=(
+                        f"Límite de {limit} peticiones cada {window_seconds}s alcanzado."
+                    ),
+                    headers={"Retry-After": str(retry_after)},
+                )
+
+            result = backend.set(
+                cache_key,
+                {"count": count + 1, "reset_at": reset_at},
+                expire=window_seconds,
+            )
+            if _is_awaitable(result):
+                await result
+        except HTTPException:
+            raise
+        except Exception as exc:
+            if on_backend_error == "deny":
+                logger.critical(
+                    "El backend de rate limiting falló (%s) y on_backend_error='deny': "
+                    "se rechaza la petición.",
+                    exc,
+                )
+                raise HTTPException(
+                    status_code=429,
+                    detail="Rate limiting no disponible.",
+                    headers={"Retry-After": str(window_seconds)},
+                ) from exc
+            logger.error(
+                "El backend de rate limiting falló (%s) y on_backend_error='allow': "
+                "se deja pasar la petición sin limitar.",
+                exc,
+            )
+
+    return dependency
+
+
+def _read_window(
+    state: t.Any,
+    now: float,
+    window_seconds: int,
+) -> tuple[int, float]:
+    """
+    Lee el contador de la ventana en curso.
+
+    Si no hay estado, o si la ventana ya venció, empieza una nueva. El vencimiento se
+    evalúa aquí y no se delega al TTL del backend, porque no todos los backends de
+    `ICache` lo respetan.
+    """
+    if isinstance(state, dict):
+        reset_at = state.get("reset_at")
+        count = state.get("count")
+        if isinstance(reset_at, (int, float)) and isinstance(count, int):
+            if reset_at > now:
+                return count, float(reset_at)
+
+    return 0, now + window_seconds
+
+
+def _is_awaitable(value: t.Any) -> bool:
+    return hasattr(value, "__await__")
+
+
+def _default_cache() -> ICache:
+    from hexcore.config import LazyConfig
+
+    return LazyConfig.get_config().cache_backend

--- a/hexcore/infrastructure/api/routing.py
+++ b/hexcore/infrastructure/api/routing.py
@@ -1,0 +1,87 @@
+"""
+Composición declarativa de routers.
+
+Reemplaza los ficheros `*_root_router.py` que toda app escribe por triplicado: crear un
+`APIRouter` con prefijo, tags y `dependencies=[Depends(auth)]`, e incluir N routers hijos
+con su sub-prefijo. Eso se puede declarar en vez de escribirse.
+"""
+from __future__ import annotations
+
+import typing as t
+
+from fastapi import APIRouter, FastAPI
+
+__all__ = ["build_root_router", "mount_routers"]
+
+# Un router a montar: el router solo, o el router con kwargs para `include_router`
+# (`prefix`, `tags`, `dependencies`…).
+MountableRouter = t.Union[APIRouter, t.Tuple[APIRouter, t.Dict[str, t.Any]]]
+
+
+def build_root_router(
+    prefix: str,
+    children: t.Mapping[str, APIRouter],
+    *,
+    dependencies: t.Sequence[t.Any] = (),
+    tags: list[str] | None = None,
+    **router_kwargs: t.Any,
+) -> APIRouter:
+    """
+    Construye un router raíz con sus hijos ya incluidos.
+
+    Args:
+        prefix: Prefijo del router raíz (p. ej. ``"/admin"``).
+        children: Mapa ``{sub_prefijo: router}``. Un sub-prefijo vacío monta el hijo
+            directamente sobre el prefijo raíz.
+        dependencies: Dependencias comunes a todos los hijos (típicamente la auth).
+        tags: Tags comunes.
+        **router_kwargs: Se pasan tal cual a `APIRouter` (``responses``,
+            ``deprecated``…).
+
+    Returns:
+        El `APIRouter` raíz, listo para `app.include_router`.
+
+    Uso::
+
+        admin_router = build_root_router(
+            "/admin",
+            {"/users": users_router, "/reports": reports_router},
+            dependencies=[Depends(require_admin)],
+            tags=["admin"],
+        )
+    """
+    root = APIRouter(
+        prefix=prefix,
+        dependencies=list(dependencies),
+        tags=t.cast(t.Any, tags),
+        **router_kwargs,
+    )
+    for child_prefix, child in children.items():
+        root.include_router(child, prefix=child_prefix)
+    return root
+
+
+def mount_routers(
+    app: FastAPI,
+    routers: t.Sequence[MountableRouter],
+) -> None:
+    """
+    Monta una lista de routers en la app.
+
+    Sustituye las tiras de `include_router` consecutivas de `main.py`. Cada elemento
+    puede ser un `APIRouter` o una tupla ``(router, kwargs)`` con los argumentos extra
+    de `include_router`.
+
+    Uso::
+
+        mount_routers(app, [
+            usuarios_router,
+            (tickets_router, {"prefix": "/v2", "tags": ["tickets-v2"]}),
+        ])
+    """
+    for entry in routers:
+        if isinstance(entry, tuple):
+            router, kwargs = entry
+            app.include_router(router, **kwargs)
+        else:
+            app.include_router(entry)

--- a/hexcore/infrastructure/api/streaming.py
+++ b/hexcore/infrastructure/api/streaming.py
@@ -1,0 +1,293 @@
+"""
+Utilidades de streaming: SSE, WebSocket y límite de conexiones por usuario.
+
+`ServerConfig` de las apps reales ya declara `sse_heartbeat_seconds`,
+`admin_stream_max_connections_per_user` y compañía — es decir, el proyecto configuró
+estas cosas y luego tuvo que implementarlas él mismo. Si la configuración es genérica,
+la implementación debería serlo.
+
+De las tres, `connection_slot` es la que más valor tiene: filtrar un slot al
+desconectarse mal es un bug clásico —el usuario queda sin poder reconectar hasta que
+expire—, y aquí el teardown está garantizado.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+import time
+import typing as t
+import uuid
+from contextlib import asynccontextmanager
+
+from fastapi.responses import StreamingResponse
+
+from hexcore.infrastructure.cache import ICache
+
+if t.TYPE_CHECKING:
+    from fastapi import WebSocket
+
+logger = logging.getLogger("hexcore.api.streaming")
+
+__all__ = ["sse_stream", "format_sse_event", "ws_heartbeat", "connection_slot"]
+
+
+def format_sse_event(payload: t.Mapping[str, t.Any]) -> str:
+    """
+    Formatea un dict como un evento SSE.
+
+    Soporta las claves de control del protocolo (`event`, `id`, `retry`); el resto del
+    dict va como JSON en `data`.
+    """
+    lines: list[str] = []
+
+    event_name = payload.get("event")
+    if event_name is not None:
+        lines.append(f"event: {event_name}")
+
+    event_id = payload.get("id")
+    if event_id is not None:
+        lines.append(f"id: {event_id}")
+
+    retry = payload.get("retry")
+    if retry is not None:
+        lines.append(f"retry: {retry}")
+
+    data = payload.get("data", {k: v for k, v in payload.items() if k not in _CONTROL_KEYS})
+    if isinstance(data, str):
+        serialized = data
+    else:
+        serialized = json.dumps(data, default=str)
+    # Un `data` multilínea necesita un `data:` por línea, o el cliente corta el evento.
+    for line in serialized.splitlines() or [""]:
+        lines.append(f"data: {line}")
+
+    return "\n".join(lines) + "\n\n"
+
+
+_CONTROL_KEYS = frozenset({"event", "id", "retry", "data"})
+
+
+def sse_stream(
+    source: t.AsyncIterator[t.Mapping[str, t.Any]],
+    *,
+    heartbeat_seconds: float = 30.0,
+    **response_kwargs: t.Any,
+) -> StreamingResponse:
+    """
+    Envuelve un iterador async en una `StreamingResponse` de SSE con heartbeat.
+
+    El heartbeat es un comentario SSE (`: ping`), que los clientes ignoran y los proxies
+    cuentan como tráfico. Sin él, un balanceador con idle timeout corta la conexión en
+    cuanto pasan unos minutos sin eventos, y el cliente lo ve como un error.
+
+    Args:
+        source: Iterador de eventos. Cada elemento se formatea con `format_sse_event`.
+        heartbeat_seconds: Cada cuánto emitir el ping. 0 o negativo lo desactiva.
+        **response_kwargs: Se pasan a `StreamingResponse` (`status_code`, `headers`…).
+    """
+    async def generator() -> t.AsyncIterator[str]:
+        iterator = source.__aiter__()
+        pending: asyncio.Task[t.Mapping[str, t.Any]] | None = None
+        try:
+            while True:
+                if pending is None:
+                    pending = asyncio.ensure_future(_anext(iterator))
+
+                if heartbeat_seconds and heartbeat_seconds > 0:
+                    done, _ = await asyncio.wait(
+                        [pending], timeout=heartbeat_seconds
+                    )
+                    if not done:
+                        yield ": ping\n\n"
+                        continue
+                else:
+                    await asyncio.wait([pending])
+
+                try:
+                    event = pending.result()
+                except StopAsyncIteration:
+                    return
+                finally:
+                    pending = None
+
+                yield format_sse_event(event)
+        finally:
+            if pending is not None and not pending.done():
+                pending.cancel()
+                with contextlib.suppress(asyncio.CancelledError, StopAsyncIteration):
+                    await pending
+            aclose = getattr(iterator, "aclose", None)
+            if aclose is not None:
+                with contextlib.suppress(Exception):
+                    await aclose()
+
+    headers = {
+        "Cache-Control": "no-cache",
+        "Connection": "keep-alive",
+        # Desactiva el buffering de nginx, que si no acumula los eventos y los entrega
+        # a bloques: el stream "funciona" pero llega con minutos de retraso.
+        "X-Accel-Buffering": "no",
+        **response_kwargs.pop("headers", {}),
+    }
+    return StreamingResponse(
+        generator(),
+        media_type="text/event-stream",
+        headers=headers,
+        **response_kwargs,
+    )
+
+
+async def _anext(iterator: t.AsyncIterator[t.Mapping[str, t.Any]]) -> t.Mapping[str, t.Any]:
+    return await iterator.__anext__()
+
+
+@asynccontextmanager
+async def ws_heartbeat(
+    ws: "WebSocket",
+    interval: float = 30.0,
+) -> t.AsyncIterator[None]:
+    """
+    Mantiene vivo un WebSocket enviando pings mientras dure el bloque.
+
+    El ping se cancela al salir, también si el bloque lanza. Un error al enviar el ping
+    (el cliente ya se fue) termina la tarea en silencio: quien lea del socket se va a
+    enterar igual, y no queremos dos excepciones compitiendo.
+
+    Uso::
+
+        await ws.accept()
+        async with ws_heartbeat(ws, interval=30):
+            while True:
+                message = await ws.receive_text()
+                ...
+    """
+    async def beat() -> None:
+        while True:
+            await asyncio.sleep(interval)
+            try:
+                await ws.send_json({"type": "ping", "ts": time.time()})
+            except Exception:
+                logger.debug("Heartbeat de WebSocket detenido: el cliente cerró.")
+                return
+
+    task: asyncio.Task[None] | None = None
+    if interval and interval > 0:
+        task = asyncio.create_task(beat())
+    try:
+        yield
+    finally:
+        if task is not None:
+            task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await task
+
+
+@asynccontextmanager
+async def connection_slot(
+    cache: ICache,
+    key: str,
+    *,
+    max_connections: int,
+    ttl_seconds: int = 3600,
+) -> t.AsyncIterator[bool]:
+    """
+    Reserva un slot de conexión, y lo **libera siempre** al salir del bloque.
+
+    Cede `True` si había hueco y `False` si no. El teardown está garantizado por el
+    context manager, que es todo el punto: filtrar un slot al desconectarse mal deja al
+    usuario sin poder reconectar hasta que expire el registro.
+
+    **Límite conocido:** la secuencia leer-comprobar-escribir no es atómica sobre el
+    puerto `ICache`, que no expone un CAS. Con varias réplicas aceptando conexiones en el
+    mismo milisegundo se puede conceder un slot de más. Es aceptable para lo que esto
+    resuelve (evitar que un usuario abra cientos de conexiones); si necesitás el límite
+    exacto, hace falta un script Lua sobre Redis, y eso ataría la utilidad a Redis.
+
+    Args:
+        cache: Backend `ICache` (Redis en producción, `MemoryCache` en tests).
+        key: Identifica al sujeto del límite (p. ej. ``f"ws:{user_id}"``).
+        max_connections: Cuántas conexiones simultáneas se permiten.
+        ttl_seconds: Vencimiento del registro, como red de seguridad si el proceso muere
+            entero sin poder liberar.
+
+    Uso::
+
+        async with connection_slot(cache, f"ws:{user_id}", max_connections=3) as granted:
+            if not granted:
+                await ws.close(code=1013)  # try again later
+                return
+            await ws.accept()
+            ...
+    """
+    cache_key = f"hexcore:conn_slot:{key}"
+    # UUID y no `id()` + timestamp: `id()` se reutiliza en cuanto el objeto muere, y dos
+    # slot_id iguales se pisan en el dict, con lo que el contador se queda corto y el
+    # límite deja de limitar.
+    slot_id = uuid.uuid4().hex
+    granted = False
+
+    try:
+        state = await cache.get(cache_key)
+        slots = _read_slots(state, ttl_seconds)
+
+        if len(slots) >= max_connections:
+            logger.info(
+                "Slot de conexión denegado para '%s': %d/%d en uso.",
+                key,
+                len(slots),
+                max_connections,
+            )
+            yield False
+            return
+
+        slots[slot_id] = time.time() + ttl_seconds
+        await _store(cache, cache_key, slots, ttl_seconds)
+        granted = True
+        yield True
+    finally:
+        if granted:
+            # Se relee para no pisar los slots que otras conexiones tomaron mientras
+            # esta estaba abierta.
+            try:
+                state = await cache.get(cache_key)
+                slots = _read_slots(state, ttl_seconds)
+                slots.pop(slot_id, None)
+                await _store(cache, cache_key, slots, ttl_seconds)
+            except Exception:
+                logger.exception(
+                    "No se pudo liberar el slot de conexión '%s'; expirará en %ss.",
+                    key,
+                    ttl_seconds,
+                )
+
+
+def _read_slots(state: t.Any, ttl_seconds: int) -> dict[str, float]:
+    """
+    Slots vigentes, descartando los vencidos.
+
+    El vencimiento se evalúa aquí porque `MemoryCache` ignora el `expire` del backend, y
+    porque un slot con TTL vencido no debe contar aunque el backend aún lo tenga.
+    """
+    if not isinstance(state, dict):
+        return {}
+
+    raw = state.get("slots")
+    if not isinstance(raw, dict):
+        return {}
+
+    now = time.time()
+    return {
+        slot_id: expires_at
+        for slot_id, expires_at in raw.items()
+        if isinstance(expires_at, (int, float)) and expires_at > now
+    }
+
+
+async def _store(
+    cache: ICache, cache_key: str, slots: dict[str, float], ttl_seconds: int
+) -> None:
+    result = cache.set(cache_key, {"slots": slots}, expire=ttl_seconds)
+    if hasattr(result, "__await__"):
+        await result

--- a/hexcore/infrastructure/api/utils.py
+++ b/hexcore/infrastructure/api/utils.py
@@ -63,32 +63,68 @@ async def get_nosql_uow() -> AsyncGenerator[IUnitOfWork, None]:
 
 def build_query_endpoint(
     use_case_factory: t.Callable[[], QueryEntitiesUseCase[t.Any]],
+    *,
+    extra_params: t.Mapping[str, t.Any] | None = None,
 ) -> t.Callable[..., t.Awaitable[QueryResponseDTO]]:
+    """
+    Construye un endpoint GET de listado/búsqueda a partir de un use case.
+
+    Args:
+        use_case_factory: Cómo construir el use case por request. Normalmente un
+            `lambda` que resuelve dependencias.
+        extra_params: Parámetros adicionales a inyectar en la firma del endpoint, como
+            ``{"tenant": Depends(get_tenant)}``. Aparecen en el OpenAPI y se le pasan al
+            factory como kwargs si éste los acepta.
+    """
     async def endpoint(
         limit: int = Query(50, ge=1),
         offset: int = Query(0, ge=0),
         search: str | None = Query(default=None),
-        search_fields: list[str] = Query(default=[]),
-        filters: list[str] = Query(default=[]),
-        sort: list[str] = Query(default=[]),
+        # `default_factory=list` y no `default=[]`: FastAPI tolera la lista mutable como
+        # default, pero es una lista compartida entre todas las llamadas.
+        search_fields: list[str] = Query(default_factory=list),
+        filters: list[str] = Query(default_factory=list),
+        sort: list[str] = Query(default_factory=list),
     ) -> QueryResponseDTO:
-        filter_conditions = _parse_filter_conditions(filters)
-        sort_conditions = _parse_sort_conditions(sort)
-        query = QueryRequestDTO(
+        return await _execute(
+            use_case_factory,
             limit=limit,
             offset=offset,
             search=search,
             search_fields=search_fields,
-            filters=filter_conditions,
-            sort=sort_conditions,
+            filters=filters,
+            sort=sort,
         )
-        use_case = use_case_factory()
-        try:
-            return await use_case.execute(query)
-        except ValueError as exc:
-            raise HTTPException(status_code=422, detail=str(exc)) from exc
 
+    if extra_params:
+        return _with_extra_params(endpoint, use_case_factory, extra_params)
     return endpoint
+
+
+async def _execute(
+    use_case_factory: t.Callable[..., QueryEntitiesUseCase[t.Any]],
+    *,
+    limit: int,
+    offset: int,
+    search: str | None,
+    search_fields: list[str],
+    filters: list[str],
+    sort: list[str],
+    injected: t.Mapping[str, t.Any] | None = None,
+) -> QueryResponseDTO:
+    query = QueryRequestDTO(
+        limit=limit,
+        offset=offset,
+        search=search,
+        search_fields=search_fields,
+        filters=_parse_filter_conditions(filters),
+        sort=_parse_sort_conditions(sort),
+    )
+    use_case = _build_use_case(use_case_factory, injected or {})
+    try:
+        return await use_case.execute(query)
+    except ValueError as exc:
+        raise _field_error(exc) from exc
 
 
 def register_query_endpoint(
@@ -99,18 +135,133 @@ def register_query_endpoint(
     name: str | None = None,
     summary: str | None = None,
     tags: list[str] | None = None,
+    dependencies: t.Sequence[t.Any] | None = None,
+    response_model: t.Any = QueryResponseDTO,
+    extra_params: t.Mapping[str, t.Any] | None = None,
+    **route_kwargs: t.Any,
 ) -> t.Callable[..., t.Awaitable[QueryResponseDTO]]:
-    endpoint = build_query_endpoint(use_case_factory)
+    """
+    Registra el endpoint de query en un router.
+
+    Args:
+        dependencies: Dependencias de la ruta, típicamente la auth
+            (``[Depends(get_current_user)]``). Sin esto, cualquier endpoint que necesite
+            autenticación no podía usar este helper — que es el caso de casi toda app.
+        response_model: Por si querés un modelo de respuesta más estrecho que
+            `QueryResponseDTO`.
+        extra_params: Ver `build_query_endpoint`.
+        **route_kwargs: Se pasan tal cual a `add_api_route` (`status_code`,
+            `responses`, `deprecated`…).
+    """
+    endpoint = build_query_endpoint(use_case_factory, extra_params=extra_params)
     router.add_api_route(
         path,
         endpoint,
         methods=["GET"],
-        response_model=QueryResponseDTO,
+        response_model=response_model,
         name=name,
         summary=summary,
         tags=t.cast(t.Any, tags),
+        dependencies=list(dependencies) if dependencies else None,
+        **route_kwargs,
     )
     return endpoint
+
+
+def _build_use_case(
+    factory: t.Callable[..., QueryEntitiesUseCase[t.Any]],
+    injected: t.Mapping[str, t.Any],
+) -> QueryEntitiesUseCase[t.Any]:
+    """
+    Llama al factory pasándole sólo los `extra_params` que acepte.
+
+    Así un factory sin argumentos —el caso habitual— sigue funcionando aunque el endpoint
+    declare parámetros extra para el OpenAPI.
+    """
+    if not injected:
+        return factory()
+
+    import inspect
+
+    try:
+        signature = inspect.signature(factory)
+    except (TypeError, ValueError):
+        return factory()
+
+    accepts_kwargs = any(
+        parameter.kind is inspect.Parameter.VAR_KEYWORD
+        for parameter in signature.parameters.values()
+    )
+    if accepts_kwargs:
+        return factory(**injected)
+
+    accepted = {
+        name: value
+        for name, value in injected.items()
+        if name in signature.parameters
+    }
+    return factory(**accepted)
+
+
+def _with_extra_params(
+    base_endpoint: t.Callable[..., t.Awaitable[QueryResponseDTO]],
+    use_case_factory: t.Callable[..., QueryEntitiesUseCase[t.Any]],
+    extra_params: t.Mapping[str, t.Any],
+) -> t.Callable[..., t.Awaitable[QueryResponseDTO]]:
+    """
+    Envuelve el endpoint añadiendo parámetros a su firma para que FastAPI los resuelva.
+
+    Se manipula `__signature__` porque es la única forma de declarar parámetros
+    dinámicos que FastAPI vea: su introspección lee la firma, y un `**kwargs` sin firma
+    declarada hace que FastAPI lo interprete como un parámetro requerido y devuelva 422.
+    """
+    import inspect
+
+    base = inspect.signature(base_endpoint)
+    query_param_names = set(base.parameters)
+
+    async def wrapper(**kwargs: t.Any) -> QueryResponseDTO:
+        query_args = {
+            name: value for name, value in kwargs.items() if name in query_param_names
+        }
+        injected = {
+            name: value
+            for name, value in kwargs.items()
+            if name not in query_param_names
+        }
+        return await _execute(use_case_factory, injected=injected, **query_args)
+
+    extra = [
+        inspect.Parameter(
+            name,
+            inspect.Parameter.KEYWORD_ONLY,
+            default=default,
+            annotation=t.Any,
+        )
+        for name, default in extra_params.items()
+    ]
+    wrapper.__signature__ = base.replace(  # type: ignore[attr-defined]
+        parameters=[*base.parameters.values(), *extra]
+    )
+    wrapper.__name__ = getattr(base_endpoint, "__name__", "query_endpoint")
+    return wrapper
+
+
+def _field_error(exc: ValueError) -> HTTPException:
+    """
+    Traduce un error de campo inválido a un 422 con cuerpo estructurado.
+
+    Antes salía como `str(ValueError)` crudo, que el cliente sólo podía mostrar. Con
+    `field` y `allowed` puede señalar el input concreto.
+    """
+    detail: dict[str, t.Any] = {"message": str(exc)}
+    field = getattr(exc, "field", None)
+    allowed = getattr(exc, "allowed", None)
+    if field is not None:
+        detail["field"] = field
+    if allowed is not None:
+        detail["allowed"] = sorted(allowed)
+    return HTTPException(status_code=422, detail=detail)
 
 
 def _parse_filter_conditions(filters: list[str]) -> list[FilterConditionDTO]:

--- a/hexcore/infrastructure/cqrs/__init__.py
+++ b/hexcore/infrastructure/cqrs/__init__.py
@@ -19,6 +19,11 @@ __all__ = [
     "TransactionMiddleware",
 ]
 
-# ProcrastinateCommandBus no se exporta aquí intencionalmente.
-# Importarlo directamente: from hexcore.infrastructure.cqrs.procrastinate import ProcrastinateCommandBus
-# Esto evita ImportError si procrastinate no está instalado.
+# Los adaptadores con dependencias opcionales no se exportan aquí intencionalmente:
+# importarlos aquí haría fallar el import de este paquete cuando la dependencia no está
+# instalada. Importalos por su ruta:
+#
+#   from hexcore.infrastructure.cqrs.procrastinate import ProcrastinateCommandBus   # [procrastinate]
+#   from hexcore.infrastructure.cqrs.cron_sql import SqlAlchemyCronJobRepository    # [sql]
+#   from hexcore.infrastructure.cqrs.redis_lock import RedisLockProvider            # [redis]
+#   from hexcore.infrastructure.cqrs.postgres_lock import PostgresLockProvider      # [sql]

--- a/hexcore/infrastructure/cqrs/cron_sql.py
+++ b/hexcore/infrastructure/cqrs/cron_sql.py
@@ -1,0 +1,340 @@
+"""
+Implementación SQL de `ICronJobRepository`: modelo, repositorio y seed.
+
+HexCore define `ICronJobRepository` y `CronJobDefinition` pero no traía ninguna
+implementación, así que **todo el mundo escribe la misma tabla**. Esto es esa tabla.
+
+Dos detalles que hay que descubrir a base de golpes y que este módulo encapsula:
+
+- `CronJobModel` **no** hereda de `BaseModel[T]`. No tiene entidad de dominio detrás, y
+  si heredara, el `collect_domain_entities()` del UoW intentaría sacarle una entidad
+  (`isinstance(model, BaseModel)`) y explotaría.
+- `SqlAlchemyCronJobRepository` **no** hereda de `BaseSQLAlchemyRepository`. Si heredara,
+  el auto-discovery lo inyectaría en todos los UoW como si fuera un repositorio de
+  dominio.
+
+Requiere el extra ``[sql]``.
+"""
+from __future__ import annotations
+
+import logging
+import typing as t
+from datetime import datetime, timezone
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    JSON,
+    String,
+    select,
+    update,
+)
+from sqlalchemy.ext.asyncio import AsyncEngine, AsyncSession
+from sqlalchemy.orm import Mapped, declared_attr, mapped_column
+
+from hexcore.domain.cqrs.cron import CronJobDefinition, ICronJobRepository
+from hexcore.infrastructure.repositories.orms.sqlalchemy import Base
+
+logger = logging.getLogger("hexcore.cqrs.cron_sql")
+
+__all__ = [
+    "CronJobModelMixin",
+    "CronJobModel",
+    "SqlAlchemyCronJobRepository",
+    "seed_cron_jobs",
+    "create_cron_tables",
+    "cron_job",
+]
+
+DEFAULT_TABLE_NAME = "hexcore_cron_jobs"
+
+
+class CronJobModelMixin:
+    """
+    Columnas de la tabla de cronjobs, sin `__tablename__`.
+
+    Para usar otro nombre de tabla, componé tu propio modelo::
+
+        class CronJob(CronJobModelMixin, Base):
+            __tablename__ = "cron_jobs"
+
+    y pasáselo al repositorio: ``SqlAlchemyCronJobRepository(model=CronJob)``.
+    """
+
+    job_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+    task_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    cron_expression: Mapped[str] = mapped_column(String(128), nullable=False)
+    queue: Mapped[str] = mapped_column(String(64), nullable=False, default="default")
+    is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    last_run_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True, default=None
+    )
+
+    @declared_attr
+    def payload(cls) -> Mapped[dict[str, t.Any]]:  # noqa: N805
+        # `declared_attr` porque JSON con default mutable tiene que crearse por clase.
+        return mapped_column(JSON, nullable=False, default=dict)
+
+    def to_definition(self) -> CronJobDefinition:
+        """Convierte la fila en el `CronJobDefinition` que consume el scheduler."""
+        return CronJobDefinition(
+            job_id=self.job_id,
+            task_name=self.task_name,
+            cron_expression=self.cron_expression,
+            payload=dict(self.payload or {}),
+            queue=self.queue,
+            is_active=self.is_active,
+            last_run_at=self.last_run_at,
+        )
+
+
+class CronJobModel(CronJobModelMixin, Base):
+    """Tabla de cronjobs por defecto (`hexcore_cron_jobs`)."""
+
+    __tablename__ = DEFAULT_TABLE_NAME
+
+
+AnyCronJobModel = t.Type[t.Any]
+
+
+class SqlAlchemyCronJobRepository(ICronJobRepository):
+    """
+    `ICronJobRepository` sobre SQLAlchemy.
+
+    Abre una sesión por operación con `session_scope()` en vez de guardar una: el
+    scheduler es un proceso de vida larga y mantener una sesión abierta durante horas
+    es exactamente cómo se acumulan transacciones idle-in-transaction. `session_scope`
+    tampoco paga el auto-discovery de repositorios de dominio, que para leer esta tabla
+    no aporta nada.
+    """
+
+    def __init__(
+        self,
+        model: AnyCronJobModel = CronJobModel,
+        session_scope: t.Callable[[], t.AsyncContextManager[AsyncSession]] | None = None,
+    ) -> None:
+        """
+        Args:
+            model: El modelo de la tabla. Por defecto `CronJobModel`.
+            session_scope: Factory de sesiones. Por defecto, el `session_scope` de
+                HexCore. Inyectable para tests o para apuntar a otro engine.
+        """
+        self._model = model
+        self._session_scope = session_scope or _default_session_scope
+
+    async def get_active_jobs(self) -> list[CronJobDefinition]:
+        async with self._session_scope() as session:
+            result = await session.execute(
+                select(self._model).where(self._model.is_active.is_(True))
+            )
+            return [row.to_definition() for row in result.scalars().all()]
+
+    async def get_all_jobs(self) -> list[CronJobDefinition]:
+        """Todos los jobs, activos o no. Útil para un endpoint de administración."""
+        async with self._session_scope() as session:
+            result = await session.execute(select(self._model))
+            return [row.to_definition() for row in result.scalars().all()]
+
+    async def update_last_run(self, job_id: str, run_time: datetime) -> None:
+        async with self._session_scope() as session:
+            await session.execute(
+                update(self._model)
+                .where(self._model.job_id == job_id)
+                .values(last_run_at=_as_utc(run_time))
+            )
+            await session.commit()
+
+    async def set_active(self, job_id: str, is_active: bool) -> None:
+        """Activa o desactiva un job en caliente."""
+        async with self._session_scope() as session:
+            await session.execute(
+                update(self._model)
+                .where(self._model.job_id == job_id)
+                .values(is_active=is_active)
+            )
+            await session.commit()
+
+
+async def seed_cron_jobs(
+    jobs: t.Sequence[CronJobDefinition],
+    *,
+    model: AnyCronJobModel = CronJobModel,
+    session_scope: t.Callable[[], t.AsyncContextManager[AsyncSession]] | None = None,
+) -> int:
+    """
+    Inserta las definiciones que falten. **Idempotente y no destructivo.**
+
+    No pisa lo que ya está en la BD: el sentido de esta tabla es poder editar el cron en
+    caliente, así que un seed que sobrescribiera revertiría en cada deploy los cambios
+    que alguien hizo a propósito. Se insertan sólo los `job_id` que no existen.
+
+    Returns:
+        Cuántas filas se insertaron **de verdad**. Si otra réplica ganó la carrera, esas
+        filas no se cuentan aquí.
+    """
+    if not jobs:
+        return 0
+
+    scope = session_scope or _default_session_scope
+
+    async with scope() as session:
+        existing = set(
+            (
+                await session.execute(
+                    select(model.job_id).where(
+                        model.job_id.in_([job.job_id for job in jobs])
+                    )
+                )
+            )
+            .scalars()
+            .all()
+        )
+
+        missing = [job for job in jobs if job.job_id not in existing]
+        if not missing:
+            logger.debug("seed_cron_jobs: nada que insertar (%d ya existían)", len(existing))
+            return 0
+
+        statement = _insert_ignore(session, model)
+        inserted = 0
+        # Fila a fila para que `rowcount` sea fiable en todos los dialectos: con
+        # executemany varios drivers devuelven -1 y el contador mentiría. Son un puñado
+        # de filas y esto corre una vez al arrancar.
+        for job in missing:
+            result = await session.execute(
+                statement,
+                {
+                    "job_id": job.job_id,
+                    "task_name": job.task_name,
+                    "cron_expression": job.cron_expression,
+                    "payload": job.payload,
+                    "queue": job.queue,
+                    "is_active": job.is_active,
+                    "last_run_at": _as_utc(job.last_run_at) if job.last_run_at else None,
+                },
+            )
+            if result.rowcount != 0:
+                inserted += 1
+        await session.commit()
+
+    logger.info("seed_cron_jobs: %d cronjobs insertados", inserted)
+    return inserted
+
+
+def _insert_ignore(session: AsyncSession, model: AnyCronJobModel) -> t.Any:
+    """
+    INSERT que ignora los conflictos de clave primaria.
+
+    La comprobación previa de `seed_cron_jobs` cubre el caso normal; esto cubre la
+    carrera entre dos réplicas sembrando a la vez en el mismo arranque. `ON CONFLICT`
+    existe en PostgreSQL y SQLite; en el resto se cae al INSERT normal, donde la
+    comprobación previa es la única defensa.
+    """
+    dialect = session.get_bind().dialect.name
+
+    # Se construye sobre `__table__` (Core) y no sobre la entidad ORM: el INSERT de Core
+    # devuelve un CursorResult con `rowcount` fiable, que es lo que necesitamos para
+    # informar cuántas filas se crearon de verdad.
+    table = model.__table__
+
+    if dialect == "postgresql":
+        from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+        return pg_insert(table).on_conflict_do_nothing(index_elements=["job_id"])
+    if dialect == "sqlite":
+        from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+        return sqlite_insert(table).on_conflict_do_nothing(index_elements=["job_id"])
+
+    from sqlalchemy import insert
+
+    return insert(table)
+
+
+async def create_cron_tables(
+    engine: AsyncEngine | None = None,
+    *,
+    model: AnyCronJobModel = CronJobModel,
+) -> None:
+    """
+    Crea la tabla de cronjobs si no existe.
+
+    Atajo para entornos sin migraciones (tests, desarrollo, un worker de un script). En
+    producción con Alembic, la migración equivalente es::
+
+        op.create_table(
+            "hexcore_cron_jobs",
+            sa.Column("job_id", sa.String(128), primary_key=True),
+            sa.Column("task_name", sa.String(255), nullable=False),
+            sa.Column("cron_expression", sa.String(128), nullable=False),
+            sa.Column("payload", sa.JSON(), nullable=False),
+            sa.Column("queue", sa.String(64), nullable=False),
+            sa.Column("is_active", sa.Boolean(), nullable=False),
+            sa.Column("last_run_at", sa.DateTime(timezone=True), nullable=True),
+        )
+    """
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.session import get_engine
+
+    target = engine or get_engine()
+    async with target.begin() as connection:
+        await connection.run_sync(
+            Base.metadata.create_all, tables=[model.__table__]
+        )
+
+
+def cron_job(
+    task: t.Callable[..., t.Any],
+    cron_expression: str,
+    *,
+    job_id: str | None = None,
+    payload: dict[str, t.Any] | None = None,
+    queue: str | None = None,
+    is_active: bool = True,
+) -> CronJobDefinition:
+    """
+    Construye un `CronJobDefinition` a partir de una función decorada con
+    `@background_task`.
+
+    El `task_name` se deriva de `__cqrs_task_name__` y la cola de `__cqrs_queue__`:
+    escribir el nombre a mano es cómo se acaba con un cron que encola una tarea que ya
+    se renombró, y el fallo aparece en el worker, no aquí.
+
+    Uso::
+
+        seed = [
+            cron_job(cerrar_caja, "0 3 * * *"),
+            cron_job(purgar_logs, "0 4 * * 0", payload={"days": 30}),
+        ]
+
+    Raises:
+        ValueError: Si `task` no está decorada con `@background_task`.
+    """
+    task_name = getattr(task, "__cqrs_task_name__", None)
+    if not task_name:
+        raise ValueError(
+            f"'{getattr(task, '__qualname__', task)}' no está decorada con "
+            "@background_task, así que no tiene '__cqrs_task_name__' y el worker no "
+            "podría resolverla. Decorala, o construí el CronJobDefinition a mano si "
+            "sabés lo que hacés."
+        )
+
+    return CronJobDefinition(
+        job_id=job_id or task_name,
+        task_name=task_name,
+        cron_expression=cron_expression,
+        payload=payload or {},
+        queue=queue or getattr(task, "__cqrs_queue__", "default"),
+        is_active=is_active,
+    )
+
+
+def _default_session_scope() -> t.AsyncContextManager[AsyncSession]:
+    from hexcore.infrastructure.uow.scopes import session_scope
+
+    return session_scope()
+
+
+def _as_utc(value: datetime) -> datetime:
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)

--- a/hexcore/infrastructure/repositories/implementations.py
+++ b/hexcore/infrastructure/repositories/implementations.py
@@ -9,6 +9,9 @@ from hexcore.types import FieldResolversType, FieldSerializersType
 from .base import T, BaseSQLAlchemyRepository, BaseBeanieRepository
 from .utils import to_entity_from_model_or_document
 
+if t.TYPE_CHECKING:
+    from hexcore.application.dtos.cursor import CursorPageDTO, CursorRequestDTO
+
 A = t.TypeVar("A")
 
 
@@ -96,6 +99,27 @@ try:
                 for model in models
             ]
             return entities, total
+
+        async def query_cursor(
+            self, query: "CursorRequestDTO"
+        ) -> "CursorPageDTO[T]":
+            """
+            Página por cursor (F15). Alternativa a `query_all` para listados grandes,
+            donde `OFFSET` degrada. No devuelve `total`: contar es lo que evita.
+            """
+            from hexcore.application.dtos.cursor import CursorPageDTO
+            from .orms.sqlalchemy.utils import db_query_cursor
+
+            models, next_cursor = await db_query_cursor(
+                self.session, self.model_cls, query
+            )
+            entities = [
+                await to_entity_from_model_or_document(
+                    model, self.entity_cls, self.fields_resolvers
+                )
+                for model in models
+            ]
+            return CursorPageDTO[T](items=entities, next_cursor=next_cursor)
 
         async def save(self, entity: T) -> T:
             saved = await sql_save_entity(

--- a/hexcore/infrastructure/repositories/orms/beanie/utils.py
+++ b/hexcore/infrastructure/repositories/orms/beanie/utils.py
@@ -207,7 +207,9 @@ def _require_document_field(
 ) -> None:
     model_fields = getattr(document_class, "model_fields", {})
     if field_name not in model_fields:
-        raise ValueError(f"Campo de {context} no soportado: {field_name}")
+        from hexcore.application.dtos.errors import UnsupportedQueryFieldError
+
+        raise UnsupportedQueryFieldError(field_name, context, allowed=model_fields.keys())
 
 
 def _build_sort_query(

--- a/hexcore/infrastructure/repositories/orms/sqlalchemy/utils.py
+++ b/hexcore/infrastructure/repositories/orms/sqlalchemy/utils.py
@@ -2,6 +2,7 @@ import typing as t
 import types
 import importlib
 import pkgutil
+from datetime import datetime
 from uuid import UUID
 
 from sqlalchemy import and_, cast, func, or_, select, String
@@ -13,6 +14,9 @@ from hexcore.application.dtos.query import (
     QueryRequestDTO,
     SortDirection,
 )
+
+if t.TYPE_CHECKING:
+    from hexcore.application.dtos.cursor import CursorRequestDTO
 from hexcore.types import FieldResolversType, RelationsType
 
 from . import BaseModel
@@ -112,8 +116,20 @@ def _require_model_column(
 ) -> t.Any:
     column = _resolve_model_column(model, field_name)
     if column is None:
-        raise ValueError(f"Campo de {context} no soportado: {field_name}")
+        from hexcore.application.dtos.errors import UnsupportedQueryFieldError
+
+        raise UnsupportedQueryFieldError(
+            field_name, context, allowed=_queryable_field_names(model)
+        )
     return column
+
+
+def _queryable_field_names(model: t.Type[T]) -> list[str]:
+    """Los campos que el modelo sí acepta, para poder ofrecerlos en el error."""
+    try:
+        return [column.name for column in model.__table__.columns]
+    except AttributeError:  # pragma: no cover - modelo sin tabla
+        return []
 
 
 def _build_filter_expression(model: t.Type[T], query: QueryRequestDTO) -> list[t.Any]:
@@ -207,6 +223,129 @@ async def db_query(
 
     result = await session.execute(data_stmt)
     return list(result.scalars().all()), total
+
+
+async def db_query_cursor(
+    session: AsyncSession,
+    model: t.Type[T],
+    query: "CursorRequestDTO",
+) -> tuple[list[T], str | None]:
+    """
+    Página por cursor: salta con un `WHERE (sort_key, id) > (...)` en vez de `OFFSET`.
+
+    Devuelve `(filas, next_cursor)`. `next_cursor` es None cuando no queda nada más. No
+    se cuenta el total: contar es exactamente lo que esta paginación evita.
+
+    El desempate por `id` es imprescindible: con sólo el campo de orden, varias filas con
+    el mismo `created_at` se saltarían o se repetirían entre páginas.
+    """
+    from hexcore.application.dtos.cursor import decode_cursor, encode_cursor
+
+    sort_column = _require_model_column(model, query.sort_field, "orden")
+    id_column = _require_model_column(model, "id", "orden")
+    descending = query.direction == SortDirection.DESC
+
+    where_expressions = _build_filter_expression(
+        model,
+        QueryRequestDTO(
+            search=query.search,
+            search_fields=list(query.search_fields),
+            filters=list(query.filters),
+        ),
+    )
+
+    if query.cursor:
+        last_sort_value, last_id = decode_cursor(query.cursor)
+        comparison = _cursor_predicate(
+            sort_column, id_column, last_sort_value, last_id, descending=descending
+        )
+        where_expressions.append(comparison)
+
+    stmt = select(model).options(*load_relations(model))
+    if where_expressions:
+        stmt = stmt.where(and_(*where_expressions))
+
+    ordering = (
+        [sort_column.desc(), id_column.desc()]
+        if descending
+        else [sort_column.asc(), id_column.asc()]
+    )
+    # Se piden `limit + 1` filas para saber si hay página siguiente sin contar el total.
+    stmt = stmt.order_by(*ordering).limit(query.limit + 1)
+
+    result = await session.execute(stmt)
+    rows = list(result.scalars().all())
+
+    if len(rows) <= query.limit:
+        return rows, None
+
+    page = rows[: query.limit]
+    last = page[-1]
+    next_cursor = encode_cursor(getattr(last, query.sort_field), getattr(last, "id"))
+    return page, next_cursor
+
+
+def _cursor_predicate(
+    sort_column: t.Any,
+    id_column: t.Any,
+    last_sort_value: t.Any,
+    last_id: t.Any,
+    *,
+    descending: bool,
+) -> t.Any:
+    """
+    Predicado de "después de esta posición" como comparación de tupla, expandida.
+
+    Se expande a `(k < v) OR (k = v AND id < i)` en vez de usar la comparación de tuplas
+    de SQL, que no todos los dialectos soportan (SQLite entre ellos).
+    """
+    sort_value = _coerce_cursor_value(sort_column, last_sort_value)
+    id_value = _coerce_cursor_value(id_column, last_id)
+
+    if descending:
+        return or_(
+            sort_column < sort_value,
+            and_(sort_column == sort_value, id_column < id_value),
+        )
+    return or_(
+        sort_column > sort_value,
+        and_(sort_column == sort_value, id_column > id_value),
+    )
+
+
+def _coerce_cursor_value(column: t.Any, raw: t.Any) -> t.Any:
+    """
+    Reconstruye el tipo Python que espera la columna a partir del valor del cursor.
+
+    El cursor viaja como JSON, así que un `datetime` vuelve como string ISO y un `UUID`
+    como su representación textual. Comparar el string crudo contra una columna tipada
+    falla en Postgres.
+    """
+    if raw is None:
+        return None
+
+    python_type: t.Any = None
+    try:
+        python_type = column.type.python_type
+    except (NotImplementedError, AttributeError):
+        return raw
+
+    if isinstance(raw, python_type):
+        return raw
+
+    if python_type is UUID and isinstance(raw, str):
+        try:
+            return UUID(raw)
+        except ValueError:
+            return raw
+
+    if python_type is datetime and isinstance(raw, str):
+        try:
+            return datetime.fromisoformat(raw)
+        except ValueError:
+            return raw
+
+    return raw
 
 
 async def db_save(session: AsyncSession, entity: T) -> T:

--- a/hexcore/infrastructure/workers/__init__.py
+++ b/hexcore/infrastructure/workers/__init__.py
@@ -1,1 +1,19 @@
 """Workers para tareas en segundo plano o consumidores asíncronos."""
+
+from .consumer import CQRSConsumer
+from .runner import (
+    WorkerDied,
+    WorkerLoop,
+    run_cqrs_worker,
+    run_procrastinate_worker,
+    worker_loop,
+)
+
+__all__ = [
+    "CQRSConsumer",
+    "WorkerLoop",
+    "worker_loop",
+    "run_cqrs_worker",
+    "run_procrastinate_worker",
+    "WorkerDied",
+]

--- a/hexcore/infrastructure/workers/runner.py
+++ b/hexcore/infrastructure/workers/runner.py
@@ -1,0 +1,349 @@
+"""
+Entrypoint del worker CQRS.
+
+El `scheduler.py` que escribe cada app son ~110 líneas que hacen siempre lo mismo:
+`init_db` → registrar las tasks del consumer → seed del cron → construir el
+`DynamicScheduler` con su lock → abrir el pool → correr worker y scheduler concurrentes
+con muerte mutua. Todo genérico.
+
+La semántica importante, que es la que cuesta descubrir: si **cualquiera** de los dos
+bucles muere, se cancela el otro y el proceso sale con error, para que el orquestador lo
+reinicie completo. Correr con un bucle caído —encolar sin consumir, o consumir sin
+encolar— es peor que caerse.
+"""
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import signal
+import typing as t
+
+if t.TYPE_CHECKING:
+    from hexcore.application.cqrs.scheduler import DynamicScheduler
+
+logger = logging.getLogger("hexcore.workers.runner")
+
+__all__ = [
+    "WorkerLoop",
+    "worker_loop",
+    "run_cqrs_worker",
+    "run_procrastinate_worker",
+    "WorkerDied",
+]
+
+
+class WorkerDied(RuntimeError):
+    """Uno de los bucles del worker terminó. El proceso debe reiniciarse completo."""
+
+
+class WorkerLoop(t.Protocol):
+    """
+    Un bucle de vida larga que el runner supervisa.
+
+    Lo cumplen el worker de la cola (Procrastinate/Celery), el `DynamicScheduler` y
+    cualquier consumidor propio.
+    """
+
+    name: str
+
+    async def run(self) -> None:
+        """Corre hasta que se cancele. No debe retornar en operación normal."""
+        ...
+
+    async def stop(self) -> None:
+        """Pide el apagado ordenado. Debe ser idempotente."""
+        ...
+
+
+class _CallableLoop:
+    """Adapta un coroutine-function suelto al protocolo `WorkerLoop`."""
+
+    def __init__(
+        self,
+        name: str,
+        run: t.Callable[[], t.Awaitable[None]],
+        stop: t.Callable[[], t.Awaitable[None]] | t.Callable[[], None] | None = None,
+    ) -> None:
+        self.name = name
+        self._run = run
+        self._stop = stop
+
+    async def run(self) -> None:
+        await self._run()
+
+    async def stop(self) -> None:
+        if self._stop is None:
+            return
+        result = self._stop()
+        if asyncio.iscoroutine(result):
+            await result
+
+
+class _SchedulerLoop:
+    """Adapta un `DynamicScheduler` al protocolo `WorkerLoop`."""
+
+    name = "scheduler"
+
+    def __init__(self, scheduler: "DynamicScheduler") -> None:
+        self._scheduler = scheduler
+
+    async def run(self) -> None:
+        await self._scheduler.start()
+
+    async def stop(self) -> None:
+        self._scheduler.stop()
+
+
+async def run_cqrs_worker(
+    *loops: WorkerLoop,
+    scheduler: "DynamicScheduler | None" = None,
+    on_startup: t.Sequence[t.Callable[[], t.Awaitable[None]]] = (),
+    on_shutdown: t.Sequence[t.Callable[[], t.Awaitable[None]]] = (),
+    handle_signals: bool = True,
+    drain_timeout: float = 30.0,
+) -> None:
+    """
+    Corre uno o más bucles de worker con muerte mutua y drenaje ordenado.
+
+    Args:
+        *loops: Los bucles a supervisar. Típicamente el worker de la cola. Se puede
+            pasar cualquier objeto con `name`, `run()` y `stop()`, o construirlos con
+            `worker_loop(...)`.
+        scheduler: Un `DynamicScheduler` a correr en paralelo. None → sólo los loops.
+        on_startup: Corutinas a ejecutar **antes** de arrancar los bucles, en orden
+            (init del engine, registro de tasks, seed del cron, apertura del pool).
+        on_shutdown: Corutinas a ejecutar al final, en el orden declarado. Se ejecutan
+            siempre, incluso si el arranque o un bucle falló, y un fallo en una no
+            impide las siguientes ni tapa el error original.
+        handle_signals: Instalar handlers de SIGTERM/SIGINT para drenaje ordenado. Es
+            lo que le falta al `scheduler.py` escrito a mano: sin esto, un `docker stop`
+            mata el proceso a mitad de un job.
+        drain_timeout: Segundos a esperar a que los bucles terminen tras pedir el stop.
+
+    Raises:
+        WorkerDied: Si un bucle termina por su cuenta (con o sin excepción). Se propaga
+            la excepción original como `__cause__`.
+    """
+    if not loops and scheduler is None:
+        raise ValueError(
+            "run_cqrs_worker necesita al menos un bucle o un scheduler; sin nada que "
+            "correr, el proceso saldría de inmediato."
+        )
+
+    all_loops: list[WorkerLoop] = list(loops)
+    if scheduler is not None:
+        all_loops.append(t.cast(WorkerLoop, _SchedulerLoop(scheduler)))
+
+    shutdown_requested = asyncio.Event()
+
+    try:
+        for hook in on_startup:
+            logger.info("[Worker] startup: %s", _callable_name(hook))
+            await hook()
+
+        if handle_signals:
+            _install_signal_handlers(shutdown_requested)
+
+        await _supervise(all_loops, shutdown_requested, drain_timeout)
+    finally:
+        for hook in on_shutdown:
+            logger.info("[Worker] shutdown: %s", _callable_name(hook))
+            # Un teardown que falla no debe tapar el error original ni impedir los
+            # teardowns siguientes.
+            try:
+                await hook()
+            except Exception:
+                logger.exception("Error en el hook de shutdown %s", _callable_name(hook))
+
+
+async def _supervise(
+    loops: t.Sequence[WorkerLoop],
+    shutdown_requested: asyncio.Event,
+    drain_timeout: float,
+) -> None:
+    """Corre los bucles hasta que uno muera o se pida el apagado."""
+    tasks = {
+        asyncio.create_task(loop.run(), name=loop.name): loop for loop in loops
+    }
+    waiter = asyncio.create_task(shutdown_requested.wait(), name="shutdown")
+
+    try:
+        done, _pending = await asyncio.wait(
+            [*tasks, waiter], return_when=asyncio.FIRST_COMPLETED
+        )
+    except asyncio.CancelledError:
+        await _drain(loops, tasks, drain_timeout)
+        raise
+
+    graceful = waiter in done
+    dead_loop: WorkerLoop | None = None
+    failure: BaseException | None = None
+
+    # `done` mezcla los bucles con el waiter del apagado; sólo los primeros están en
+    # `tasks`, así que se busca ahí en vez de indexar a ciegas.
+    for candidate, loop in tasks.items():
+        if candidate in done:
+            dead_loop = loop
+            failure = candidate.exception()
+            break
+
+    if graceful:
+        logger.info("[Worker] apagado solicitado; drenando los bucles.")
+    else:
+        assert dead_loop is not None
+        if failure is not None:
+            logger.error(
+                "[Worker] el bucle '%s' murió con %s: %s",
+                dead_loop.name,
+                type(failure).__name__,
+                failure,
+            )
+        else:
+            logger.error("[Worker] el bucle '%s' terminó por su cuenta.", dead_loop.name)
+
+    await _drain(loops, tasks, drain_timeout)
+    waiter.cancel()
+    with contextlib.suppress(asyncio.CancelledError):
+        await waiter
+
+    if not graceful:
+        assert dead_loop is not None
+        error = WorkerDied(
+            f"El bucle '{dead_loop.name}' terminó; el proceso sale para que el "
+            "orquestador lo reinicie completo. Correr con un bucle caído (encolar sin "
+            "consumir, o al revés) es peor que caerse."
+        )
+        if failure is not None:
+            raise error from failure
+        raise error
+
+
+async def _drain(
+    loops: t.Sequence[WorkerLoop],
+    tasks: dict[asyncio.Task[None], WorkerLoop],
+    drain_timeout: float,
+) -> None:
+    """Pide el stop a todos los bucles y espera, con cancelación como último recurso."""
+    for loop in loops:
+        try:
+            await loop.stop()
+        except Exception:
+            logger.exception("Error pidiendo el stop del bucle '%s'", loop.name)
+
+    pending = [task for task in tasks if not task.done()]
+    if not pending:
+        return
+
+    _done, still_running = await asyncio.wait(pending, timeout=drain_timeout)
+    for task in still_running:
+        logger.warning(
+            "[Worker] el bucle '%s' no drenó en %ss; se cancela.",
+            task.get_name(),
+            drain_timeout,
+        )
+        task.cancel()
+
+    if still_running:
+        await asyncio.gather(*still_running, return_exceptions=True)
+
+
+def worker_loop(
+    name: str,
+    run: t.Callable[[], t.Awaitable[None]],
+    stop: t.Callable[[], t.Awaitable[None]] | t.Callable[[], None] | None = None,
+) -> WorkerLoop:
+    """
+    Envuelve un par run/stop en un `WorkerLoop`.
+
+    Uso con Procrastinate::
+
+        run_cqrs_worker(
+            worker_loop(
+                "procrastinate",
+                lambda: app.run_worker_async(queues=["default"], concurrency=4),
+                app.stop_worker,
+            ),
+            scheduler=scheduler,
+        )
+    """
+    return t.cast(WorkerLoop, _CallableLoop(name, run, stop))
+
+
+async def run_procrastinate_worker(
+    app: t.Any,
+    *,
+    queues: t.Sequence[str] | None = None,
+    concurrency: int = 4,
+    scheduler: "DynamicScheduler | None" = None,
+    on_startup: t.Sequence[t.Callable[[], t.Awaitable[None]]] = (),
+    on_shutdown: t.Sequence[t.Callable[[], t.Awaitable[None]]] = (),
+    **runner_kwargs: t.Any,
+) -> None:
+    """
+    Atajo para el caso más común: worker de Procrastinate + scheduler opcional.
+
+    Abre y cierra el pool de la app, y delega el resto en `run_cqrs_worker`, así que
+    hereda la muerte mutua y el manejo de SIGTERM.
+
+    Uso (el `scheduler.py` completo de una app)::
+
+        async def main() -> None:
+            consumer = CQRSConsumer(command_bus, event_bus)
+            register_hexcore_procrastinate_tasks(procrastinate_app, consumer)
+            await run_procrastinate_worker(
+                procrastinate_app,
+                queues=["default", "reactive"],
+                scheduler=DynamicScheduler(repo, enqueuer, lock_provider=lock),
+                on_startup=[lambda: seed_cron_jobs(CRON_JOBS)],
+            )
+    """
+    async def _run() -> None:
+        await app.run_worker_async(
+            queues=list(queues) if queues else None, concurrency=concurrency
+        )
+
+    async def _stop() -> None:
+        stop = getattr(app, "stop_worker", None)
+        if stop is None:
+            return
+        result = stop()
+        if asyncio.iscoroutine(result):
+            await result
+
+    async def _open_pool() -> None:
+        await app.open_async()
+
+    async def _close_pool() -> None:
+        await app.close_async()
+
+    await run_cqrs_worker(
+        worker_loop("procrastinate", _run, _stop),
+        scheduler=scheduler,
+        on_startup=[_open_pool, *on_startup],
+        on_shutdown=[*on_shutdown, _close_pool],
+        **runner_kwargs,
+    )
+
+
+def _install_signal_handlers(shutdown_requested: asyncio.Event) -> None:
+    """
+    Convierte SIGTERM/SIGINT en una petición de apagado ordenado.
+
+    En Windows `add_signal_handler` no está implementado; ahí se deja el comportamiento
+    por defecto (KeyboardInterrupt para SIGINT), que el supervisor traduce igual a
+    cancelación.
+    """
+    loop = asyncio.get_running_loop()
+    for sig_name in ("SIGTERM", "SIGINT"):
+        sig = getattr(signal, sig_name, None)
+        if sig is None:
+            continue
+        try:
+            loop.add_signal_handler(sig, shutdown_requested.set)
+        except (NotImplementedError, RuntimeError, ValueError):
+            logger.debug("No se pudo instalar el handler de %s en esta plataforma.", sig_name)
+
+
+def _callable_name(func: t.Any) -> str:
+    return getattr(func, "__qualname__", None) or getattr(func, "__name__", repr(func))

--- a/hexcore/testing/__init__.py
+++ b/hexcore/testing/__init__.py
@@ -1,0 +1,27 @@
+"""
+Utilidades de test para aplicaciones HexCore.
+
+Nada de esto existía y todo el mundo lo iba a improvisar. Se importa **sin dependencias
+opcionales duras**: `import hexcore.testing` funciona sin FastAPI, sin SQLAlchemy y sin
+broker; lo que necesita algo concreto lo importa de forma perezosa y lo dice si falta.
+
+Para las fixtures de pytest, añadí en tu `conftest.py`::
+
+    pytest_plugins = ["hexcore.testing.fixtures"]
+"""
+from __future__ import annotations
+
+from .fakes import (
+    FakeLockProvider,
+    InMemoryTaskEnqueuer,
+    RecordedEnqueue,
+)
+from .helpers import build_test_buses, override_cqrs
+
+__all__ = [
+    "InMemoryTaskEnqueuer",
+    "RecordedEnqueue",
+    "FakeLockProvider",
+    "override_cqrs",
+    "build_test_buses",
+]

--- a/hexcore/testing/fakes.py
+++ b/hexcore/testing/fakes.py
@@ -1,0 +1,175 @@
+"""
+Dobles de prueba para los puertos de HexCore.
+
+Sin dependencias opcionales: sólo stdlib y los puertos de dominio.
+"""
+from __future__ import annotations
+
+import typing as t
+from dataclasses import dataclass, field
+
+from hexcore.domain.cqrs.cron import ILockProvider
+from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
+
+__all__ = ["RecordedEnqueue", "InMemoryTaskEnqueuer", "FakeLockProvider"]
+
+
+@dataclass(frozen=True)
+class RecordedEnqueue:
+    """Un encolado registrado."""
+
+    kind: t.Literal["command", "event", "handler", "task"]
+    name: str
+    payload: dict[str, t.Any] = field(default_factory=dict)
+    queue: str = "default"
+
+
+class InMemoryTaskEnqueuer(ITaskEnqueuer):
+    """
+    Registra lo encolado en vez de mandarlo a un broker.
+
+    Sirve para asertar sobre el Smart Routing sin levantar Procrastinate ni Celery.
+
+    Uso::
+
+        enqueuer = InMemoryTaskEnqueuer()
+        bus = InMemoryCommandBus(registry=registry, enqueuer=enqueuer, serializer=ser)
+
+        await bus.dispatch(SendEmailCommand(to="a@b.c"))
+
+        assert enqueuer.command_names == ["SendEmailCommand"]
+        assert enqueuer.commands[0].queue == "emails"
+    """
+
+    def __init__(self, *, fail_on: t.Container[str] = ()) -> None:
+        """
+        Args:
+            fail_on: Nombres para los que `enqueue_*` debe lanzar, para probar el camino
+                de error sin tener que tirar un broker.
+        """
+        self.recorded: list[RecordedEnqueue] = []
+        self._fail_on = fail_on
+
+    # ── Puerto ────────────────────────────────────────────────────────────────
+
+    async def enqueue_command(
+        self, command_name: str, payload: dict[str, t.Any], queue: str
+    ) -> None:
+        self._record("command", command_name, payload, queue)
+
+    async def enqueue_event(
+        self, event_name: str, payload: dict[str, t.Any], queue: str
+    ) -> None:
+        self._record("event", event_name, payload, queue)
+
+    async def enqueue_handler(
+        self, handler_name: str, payload: dict[str, t.Any], queue: str
+    ) -> None:
+        self._record("handler", handler_name, payload, queue)
+
+    async def enqueue_task(
+        self, task_name: str, payload: dict[str, t.Any], queue: str
+    ) -> None:
+        self._record("task", task_name, payload, queue)
+
+    def _record(
+        self,
+        kind: t.Literal["command", "event", "handler", "task"],
+        name: str,
+        payload: dict[str, t.Any],
+        queue: str,
+    ) -> None:
+        if name in self._fail_on:
+            raise RuntimeError(f"InMemoryTaskEnqueuer configurado para fallar en {name!r}")
+        self.recorded.append(RecordedEnqueue(kind, name, payload, queue))
+
+    # ── Aserciones ────────────────────────────────────────────────────────────
+
+    @property
+    def commands(self) -> list[RecordedEnqueue]:
+        return self._of_kind("command")
+
+    @property
+    def events(self) -> list[RecordedEnqueue]:
+        return self._of_kind("event")
+
+    @property
+    def handlers(self) -> list[RecordedEnqueue]:
+        return self._of_kind("handler")
+
+    @property
+    def tasks(self) -> list[RecordedEnqueue]:
+        return self._of_kind("task")
+
+    @property
+    def command_names(self) -> list[str]:
+        return [item.name for item in self.commands]
+
+    @property
+    def task_names(self) -> list[str]:
+        return [item.name for item in self.tasks]
+
+    @property
+    def handler_names(self) -> list[str]:
+        return [item.name for item in self.handlers]
+
+    def _of_kind(self, kind: str) -> list[RecordedEnqueue]:
+        return [item for item in self.recorded if item.kind == kind]
+
+    def clear(self) -> None:
+        self.recorded.clear()
+
+    def __len__(self) -> int:
+        return len(self.recorded)
+
+    def __bool__(self) -> bool:
+        # Sin esto, `__len__` hace que un enqueuer vacío sea falsy, y cualquier código
+        # que compruebe `if enqueuer:` lo descartaría justo cuando aún no ha encolado
+        # nada — que es siempre, al empezar un test.
+        return True
+
+    def __repr__(self) -> str:
+        return f"InMemoryTaskEnqueuer({len(self.recorded)} encolados)"
+
+
+class FakeLockProvider(ILockProvider):
+    """
+    Lock provider determinista.
+
+    Tres modos, para los tres escenarios que hay que probar en un scheduler:
+
+    - `FakeLockProvider()` — concede siempre. "Soy la única réplica."
+    - `FakeLockProvider(grant=False)` — niega siempre. "Otra réplica va por delante."
+    - `FakeLockProvider(shared=True)` — se comporta como un lock real en memoria: el
+      primero que pide una clave la obtiene y el resto no. Para probar dos schedulers a
+      la vez en el mismo proceso.
+    """
+
+    def __init__(
+        self,
+        *,
+        grant: bool = True,
+        shared: bool = False,
+        raise_on_acquire: BaseException | None = None,
+    ) -> None:
+        self.grant = grant
+        self.shared = shared
+        self.raise_on_acquire = raise_on_acquire
+        self.acquired: list[str] = []
+        self.released: list[str] = []
+        self.held: set[str] = set()
+
+    async def acquire_lock(self, lock_key: str, ttl_seconds: int) -> bool:
+        self.acquired.append(lock_key)
+        if self.raise_on_acquire is not None:
+            raise self.raise_on_acquire
+        if self.shared:
+            if lock_key in self.held:
+                return False
+            self.held.add(lock_key)
+            return True
+        return self.grant
+
+    async def release_lock(self, lock_key: str) -> None:
+        self.released.append(lock_key)
+        self.held.discard(lock_key)

--- a/hexcore/testing/fixtures.py
+++ b/hexcore/testing/fixtures.py
@@ -1,0 +1,105 @@
+"""
+Fixtures de pytest para aplicaciones HexCore.
+
+Actívalas desde tu `conftest.py`::
+
+    pytest_plugins = ["hexcore.testing.fixtures"]
+
+Este módulo importa `pytest`, así que sólo se carga cuando lo pides — `hexcore.testing`
+no lo arrastra.
+"""
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+from .fakes import FakeLockProvider, InMemoryTaskEnqueuer
+from .helpers import TestBuses, build_test_buses
+
+__all__ = [
+    "anyio_backend",
+    "task_enqueuer",
+    "lock_provider",
+    "cqrs_buses",
+    "sqlite_engine",
+    "sqlite_session",
+    "uow",
+]
+
+
+@pytest.fixture
+def anyio_backend() -> str:
+    """HexCore usa asyncio; se declara aquí para no repetirlo en cada módulo."""
+    return "asyncio"
+
+
+@pytest.fixture
+def task_enqueuer() -> InMemoryTaskEnqueuer:
+    """Un `InMemoryTaskEnqueuer` limpio."""
+    return InMemoryTaskEnqueuer()
+
+
+@pytest.fixture
+def lock_provider() -> FakeLockProvider:
+    """Un `FakeLockProvider` que concede siempre."""
+    return FakeLockProvider()
+
+
+@pytest.fixture
+def cqrs_buses(task_enqueuer: InMemoryTaskEnqueuer) -> TestBuses:
+    """Los tres buses in-memory con Smart Routing listo."""
+    return build_test_buses(enqueuer=task_enqueuer)
+
+
+@pytest.fixture
+def sqlite_engine() -> t.Iterator[t.Any]:
+    """
+    Un engine SQLite en memoria, y el módulo de sesión de HexCore apuntando a él.
+
+    Usa `StaticPool`: con `:memory:` y el pool por defecto, cada conexión estrena una
+    base vacía y nada de lo que escribas en una sesión se ve en la siguiente.
+    """
+    pytest.importorskip("sqlalchemy")
+    pytest.importorskip("aiosqlite")
+
+    import asyncio
+
+    from sqlalchemy.pool import StaticPool
+
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (
+        dispose_engine,
+        init_engine,
+    )
+
+    asyncio.run(dispose_engine())
+    engine = init_engine("sqlite+aiosqlite:///:memory:", poolclass=StaticPool)
+    try:
+        yield engine
+    finally:
+        asyncio.run(dispose_engine())
+
+
+@pytest.fixture
+async def sqlite_session(sqlite_engine: t.Any) -> t.AsyncIterator[t.Any]:
+    """Una sesión sobre `sqlite_engine`, con las tablas de `Base` ya creadas."""
+    from hexcore.infrastructure.repositories.orms.sqlalchemy import Base
+    from hexcore.infrastructure.uow.scopes import session_scope
+
+    async with sqlite_engine.begin() as connection:
+        await connection.run_sync(Base.metadata.create_all)
+
+    async with session_scope() as session:
+        yield session
+
+
+@pytest.fixture
+async def uow(sqlite_session: t.Any) -> t.AsyncIterator[t.Any]:
+    """
+    Un `SqlAlchemyUnitOfWork` sobre `sqlite_session`, sin entrar en él.
+
+    Sigue la convención de F3: el use case controla su propio `async with uow:`.
+    """
+    from hexcore.infrastructure.uow import SqlAlchemyUnitOfWork
+
+    yield SqlAlchemyUnitOfWork(session=sqlite_session)

--- a/hexcore/testing/helpers.py
+++ b/hexcore/testing/helpers.py
@@ -1,0 +1,147 @@
+"""
+Helpers de test que tocan la capa de aplicación o FastAPI.
+
+Los imports de FastAPI son perezosos, para que `import hexcore.testing` funcione en un
+entorno sin el extra `[api]`.
+"""
+from __future__ import annotations
+
+import typing as t
+from contextlib import contextmanager
+
+if t.TYPE_CHECKING:
+    from fastapi import FastAPI
+
+    from hexcore.application.cqrs.in_memory_buses import (
+        InMemoryCommandBus,
+        InMemoryEventBus,
+        InMemoryQueryBus,
+    )
+    from hexcore.application.cqrs.registry import HandlerRegistry
+    from hexcore.domain.cqrs.buses import (
+        AbstractCommandBus,
+        AbstractEventBus,
+        AbstractQueryBus,
+    )
+    from hexcore.domain.cqrs.serializer import ISerializer
+
+    from .fakes import InMemoryTaskEnqueuer
+
+__all__ = ["build_test_buses", "override_cqrs", "TestBuses"]
+
+
+class TestBuses(t.NamedTuple):
+    """Los buses de un test, con el registry y el enqueuer para asertar."""
+
+    registry: "HandlerRegistry"
+    command_bus: "InMemoryCommandBus"
+    query_bus: "InMemoryQueryBus"
+    event_bus: "InMemoryEventBus"
+    enqueuer: "InMemoryTaskEnqueuer"
+    serializer: "ISerializer"
+
+
+def build_test_buses(
+    registry: "HandlerRegistry | None" = None,
+    *,
+    enqueuer: "InMemoryTaskEnqueuer | None" = None,
+) -> TestBuses:
+    """
+    Construye los tres buses in-memory listos para Smart Routing.
+
+    Evita el error más común al testear CQRS: montar el bus sin enqueuer ni serializer y
+    que el primer `@background_command` lance `RuntimeError`.
+
+    Uso::
+
+        buses = build_test_buses()
+        buses.registry.register_command_handler(MiComando, MiHandler())
+
+        await buses.command_bus.dispatch(MiComando(...))
+        assert buses.enqueuer.command_names == ["MiComando"]
+    """
+    from hexcore.application.cqrs.in_memory_buses import (
+        InMemoryCommandBus,
+        InMemoryEventBus,
+        InMemoryQueryBus,
+    )
+    from hexcore.application.cqrs.registry import HandlerRegistry
+    from hexcore.infrastructure.cqrs.pydantic_serializer import PydanticSerializer
+
+    from .fakes import InMemoryTaskEnqueuer
+
+    resolved_registry = registry or HandlerRegistry()
+    resolved_enqueuer = enqueuer or InMemoryTaskEnqueuer()
+    serializer = PydanticSerializer()
+
+    return TestBuses(
+        registry=resolved_registry,
+        command_bus=InMemoryCommandBus(
+            registry=resolved_registry,
+            enqueuer=resolved_enqueuer,
+            serializer=serializer,
+        ),
+        query_bus=InMemoryQueryBus(registry=resolved_registry),
+        event_bus=InMemoryEventBus(
+            enqueuer=resolved_enqueuer, serializer=serializer
+        ),
+        enqueuer=resolved_enqueuer,
+        serializer=serializer,
+    )
+
+
+@contextmanager
+def override_cqrs(
+    app: "FastAPI",
+    *,
+    command_bus: "AbstractCommandBus | None" = None,
+    query_bus: "AbstractQueryBus | None" = None,
+    event_bus: "AbstractEventBus | None" = None,
+    registry: "HandlerRegistry | None" = None,
+) -> t.Iterator["FastAPI"]:
+    """
+    Sobreescribe los providers CQRS de una app y los restaura al salir.
+
+    Restaurar importa: `app.dependency_overrides` es un dict de instancia, así que un
+    override que no se limpia se filtra a todos los tests que reusen la app.
+
+    Uso::
+
+        buses = build_test_buses()
+        with override_cqrs(app, command_bus=buses.command_bus):
+            response = client.post("/users", json={...})
+        assert buses.enqueuer.command_names == ["CreateUser"]
+    """
+    from hexcore.infrastructure.api.cqrs import (
+        provide_command_bus,
+        provide_event_bus,
+        provide_query_bus,
+        provide_registry,
+    )
+
+    replacements: dict[t.Any, t.Any] = {}
+    if command_bus is not None:
+        replacements[provide_command_bus] = lambda: command_bus
+    if query_bus is not None:
+        replacements[provide_query_bus] = lambda: query_bus
+    if event_bus is not None:
+        replacements[provide_event_bus] = lambda: event_bus
+    if registry is not None:
+        replacements[provide_registry] = lambda: registry
+
+    # Se guarda el valor previo de cada clave —no sólo se borra— para poder anidar
+    # `override_cqrs` sin que el interno destruya el override del externo.
+    sentinel = object()
+    previous = {
+        key: app.dependency_overrides.get(key, sentinel) for key in replacements
+    }
+
+    app.dependency_overrides.update(replacements)
+    try:
+        yield app
+    finally:
+        for key, value in previous.items():
+            if value is sentinel:
+                app.dependency_overrides.pop(key, None)
+            else:
+                app.dependency_overrides[key] = value

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,6 +49,9 @@ dev = [
     "pyright>=1.1.405",
     "pytest>=8.4.2",
     "anyio>=4.0.0",
+    # Requerido por fastapi.testclient (starlette.testclient) para los tests de la
+    # capa API: create_app, middlewares, routing, health checks.
+    "httpx>=0.27.0",
 ]
 
 [tool.setuptools]

--- a/tests/test_api_app_and_lifespan.py
+++ b/tests/test_api_app_and_lifespan.py
@@ -1,0 +1,428 @@
+"""
+F1 (`create_app`) y F4 (`build_lifespan`).
+
+El criterio de simplicidad del plan: `create_app()` **sin ningún argumento** debe dar una
+app usable, con `/health` respondiendo 200.
+"""
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi import APIRouter  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from hexcore.config import LazyConfig  # noqa: E402
+from hexcore.infrastructure.api.app import AppFeatures, create_app  # noqa: E402
+from hexcore.infrastructure.api.health import Probe  # noqa: E402
+from hexcore.infrastructure.api.lifespan import (  # noqa: E402
+    CallableStep,
+    EventBusStep,
+    build_lifespan,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── F1: cero configuración ─────────────────────────────────────────────────────
+
+
+def test_create_app_with_no_arguments_serves_health():
+    """El criterio de simplicidad de la fase 3."""
+    with TestClient(create_app()) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_title_and_version_come_from_config():
+    app = create_app()
+    config = LazyConfig.get_config()
+
+    assert app.title == config.app_title
+    assert app.version == config.app_version
+
+
+def test_fastapi_kwargs_override_the_config_defaults():
+    app = create_app(title="Red API", version="2.0.0")
+
+    assert app.title == "Red API"
+    assert app.version == "2.0.0"
+
+
+def test_cors_is_wired_from_config():
+    app = create_app()
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/health", headers={"Origin": "http://example.com"}
+        )
+
+    assert "access-control-allow-origin" in response.headers
+
+
+def test_cors_can_be_disabled():
+    app = create_app(features=AppFeatures(cors=False))
+
+    with TestClient(app) as client:
+        response = client.get("/health", headers={"Origin": "http://example.com"})
+
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_request_id_middleware_is_wired():
+    with TestClient(create_app()) as client:
+        response = client.get("/health")
+
+    assert response.headers["X-Request-ID"]
+
+
+def test_timing_middleware_is_wired():
+    with TestClient(create_app()) as client:
+        response = client.get("/health")
+
+    assert float(response.headers["X-Response-Time-ms"]) >= 0
+
+
+def test_middlewares_can_be_disabled():
+    app = create_app(features=AppFeatures(request_id=False, timing=False))
+
+    with TestClient(app) as client:
+        response = client.get("/health")
+
+    assert "X-Request-ID" not in response.headers
+    assert "X-Response-Time-ms" not in response.headers
+
+
+def test_health_can_be_disabled():
+    app = create_app(features=AppFeatures(health=False))
+
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 404
+
+
+def test_exception_handlers_are_wired():
+    app = create_app()
+
+    @app.get("/boom")
+    async def boom() -> None:
+        raise ValueError("campo inválido")
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        assert client.get("/boom").status_code == 422
+
+
+def test_exception_handlers_can_be_disabled():
+    app = create_app(features=AppFeatures(exception_handlers=False))
+
+    @app.get("/boom")
+    async def boom() -> None:
+        raise ValueError("campo inválido")
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        assert client.get("/boom").status_code == 500
+
+
+def test_custom_exception_mapping_is_applied():
+    class Missing(Exception):
+        pass
+
+    app = create_app(exception_mapping={Missing: 404})
+
+    @app.get("/missing")
+    async def missing() -> None:
+        raise Missing("no está")
+
+    with TestClient(app, raise_server_exceptions=False) as client:
+        assert client.get("/missing").status_code == 404
+
+
+def test_routers_are_mounted():
+    router = APIRouter()
+
+    @router.get("/items")
+    async def items() -> dict[str, bool]:
+        return {"ok": True}
+
+    app = create_app(routers=[(router, {"prefix": "/api"})])
+
+    with TestClient(app) as client:
+        assert client.get("/api/items").json() == {"ok": True}
+
+
+def test_health_probes_are_forwarded():
+    async def boom() -> None:
+        raise ConnectionError("caída")
+
+    app = create_app(health_probes=[Probe("sql", boom)])
+
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+        assert client.get("/health/ready").status_code == 503
+
+
+def test_docs_follow_the_debug_flag():
+    app = create_app()
+
+    # El default de ServerConfig es debug=True.
+    assert app.docs_url == "/docs"
+
+    app_no_debug = create_app(debug=False, docs_url=None)
+    assert app_no_debug.docs_url is None
+
+
+# ── F4: build_lifespan ─────────────────────────────────────────────────────────
+
+
+class RecordingStep:
+    def __init__(
+        self,
+        name: str,
+        log: list[str],
+        *,
+        fail: bool = False,
+        on_error: str | None = None,
+    ) -> None:
+        self.name = name
+        self.on_error = on_error
+        self._log = log
+        self._fail = fail
+
+    async def start(self) -> None:
+        if self._fail:
+            self._log.append(f"start:{self.name}:FAIL")
+            raise RuntimeError(f"{self.name} falló")
+        self._log.append(f"start:{self.name}")
+
+    async def stop(self) -> None:
+        self._log.append(f"stop:{self.name}")
+
+
+def _app_with(lifespan) -> t.Any:
+    return create_app(lifespan=lifespan, features=AppFeatures())
+
+
+def test_steps_start_in_declared_order():
+    log: list[str] = []
+    lifespan = build_lifespan(
+        RecordingStep("a", log), RecordingStep("b", log), RecordingStep("c", log)
+    )
+
+    with TestClient(_app_with(lifespan)):
+        pass
+
+    assert log[:3] == ["start:a", "start:b", "start:c"]
+
+
+def test_teardown_runs_in_reverse_order():
+    log: list[str] = []
+    lifespan = build_lifespan(
+        RecordingStep("a", log), RecordingStep("b", log), RecordingStep("c", log)
+    )
+
+    with TestClient(_app_with(lifespan)):
+        pass
+
+    assert log[3:] == ["stop:c", "stop:b", "stop:a"]
+
+
+def test_a_failing_step_stops_the_previous_ones_in_reverse_order():
+    """El requisito central de F4."""
+    log: list[str] = []
+    lifespan = build_lifespan(
+        RecordingStep("a", log),
+        RecordingStep("b", log),
+        RecordingStep("boom", log, fail=True),
+        RecordingStep("never", log),
+    )
+
+    with pytest.raises(RuntimeError, match="boom falló"):
+        with TestClient(_app_with(lifespan)):
+            pass  # pragma: no cover
+
+    assert log == [
+        "start:a",
+        "start:b",
+        "start:boom:FAIL",
+        "stop:b",
+        "stop:a",
+    ]
+    assert "start:never" not in log
+
+
+def test_a_step_that_never_started_is_not_stopped():
+    log: list[str] = []
+    lifespan = build_lifespan(
+        RecordingStep("boom", log, fail=True), RecordingStep("never", log)
+    )
+
+    with pytest.raises(RuntimeError):
+        with TestClient(_app_with(lifespan)):
+            pass  # pragma: no cover
+
+    assert "stop:boom" not in log
+    assert "stop:never" not in log
+
+
+def test_on_error_warn_does_not_propagate():
+    log: list[str] = []
+    lifespan = build_lifespan(
+        RecordingStep("a", log),
+        RecordingStep("warmup", log, fail=True, on_error="warn"),
+        RecordingStep("c", log),
+    )
+
+    with TestClient(_app_with(lifespan)):
+        pass
+
+    assert "start:c" in log, "un step con on_error='warn' abortó el arranque"
+
+
+def test_global_on_error_warn_applies_to_every_step():
+    log: list[str] = []
+    lifespan = build_lifespan(
+        RecordingStep("boom", log, fail=True),
+        RecordingStep("after", log),
+        on_error="warn",
+    )
+
+    with TestClient(_app_with(lifespan)):
+        pass
+
+    assert "start:after" in log
+
+
+def test_per_step_policy_overrides_the_global_one():
+    log: list[str] = []
+    lifespan = build_lifespan(
+        RecordingStep("critical", log, fail=True, on_error="raise"),
+        on_error="warn",
+    )
+
+    with pytest.raises(RuntimeError, match="critical falló"):
+        with TestClient(_app_with(lifespan)):
+            pass  # pragma: no cover
+
+
+def test_a_failing_teardown_does_not_stop_the_others():
+    log: list[str] = []
+
+    class BadStopStep(RecordingStep):
+        async def stop(self) -> None:
+            raise RuntimeError("teardown roto")
+
+    lifespan = build_lifespan(RecordingStep("a", log), BadStopStep("bad", log))
+
+    with TestClient(_app_with(lifespan)):
+        pass
+
+    assert "stop:a" in log, "un teardown roto impidió los siguientes"
+
+
+def test_steps_without_stop_are_allowed():
+    log: list[str] = []
+
+    class StartOnlyStep:
+        name = "start-only"
+
+        async def start(self) -> None:
+            log.append("start")
+
+    lifespan = build_lifespan(StartOnlyStep())
+
+    with TestClient(_app_with(lifespan)):
+        pass
+
+    assert log == ["start"]
+
+
+def test_lifespan_with_no_steps_works():
+    with TestClient(_app_with(build_lifespan())) as client:
+        assert client.get("/health").status_code == 200
+
+
+def test_step_durations_are_logged(caplog):
+    import logging
+
+    log: list[str] = []
+    lifespan = build_lifespan(RecordingStep("timed", log))
+
+    with caplog.at_level(logging.INFO, logger="hexcore.api.lifespan"):
+        with TestClient(_app_with(lifespan)):
+            pass
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("step 'timed' arrancó en" in m for m in messages)
+    assert any("step 'timed' paró en" in m for m in messages)
+
+
+# ── F4: steps de serie ─────────────────────────────────────────────────────────
+
+
+def test_callable_step_wraps_plain_coroutines():
+    log: list[str] = []
+
+    async def start() -> None:
+        log.append("start")
+
+    async def stop() -> None:
+        log.append("stop")
+
+    with TestClient(_app_with(build_lifespan(CallableStep("custom", start, stop)))):
+        pass
+
+    assert log == ["start", "stop"]
+
+
+def test_callable_step_can_be_non_fatal():
+    async def boom() -> None:
+        raise RuntimeError("el warmup falló")
+
+    lifespan = build_lifespan(CallableStep("warmup", boom, on_error="warn"))
+
+    with TestClient(_app_with(lifespan)) as client:
+        assert client.get("/health").status_code == 200
+
+
+def test_event_bus_step_injects_and_restores_the_bus():
+    sentinel = object()
+    original = LazyConfig.get_config().event_bus
+
+    seen: list[t.Any] = []
+
+    async def capture() -> None:
+        seen.append(LazyConfig.get_config().event_bus)
+
+    lifespan = build_lifespan(
+        EventBusStep(sentinel), CallableStep("capture", capture)
+    )
+
+    with TestClient(_app_with(lifespan)):
+        pass
+
+    assert seen == [sentinel]
+    # Se restaura, para que un lifespan en tests no contamine el siguiente.
+    assert LazyConfig.get_config().event_bus is original
+
+
+def test_sql_engine_step_initialises_and_disposes():
+    pytest.importorskip("sqlalchemy")
+    pytest.importorskip("aiosqlite")
+
+    from hexcore.infrastructure.repositories.orms.sqlalchemy import session as session_module
+    from hexcore.infrastructure.api.lifespan import SqlEngineStep
+
+    lifespan = build_lifespan(SqlEngineStep("sqlite+aiosqlite:///:memory:"))
+
+    with TestClient(_app_with(lifespan)):
+        assert session_module._engine is not None
+
+    assert session_module._engine is None, "el engine no se cerró al apagar"

--- a/tests/test_api_cqrs_providers.py
+++ b/tests/test_api_cqrs_providers.py
@@ -1,0 +1,197 @@
+"""
+F6: providers FastAPI del CQRS.
+
+Existen como funciones por una única razón: poder sobreescribirlos en los tests con
+`app.dependency_overrides`. Y leen del **mismo** contenedor que el worker, para que no
+haya dos fuentes de verdad.
+"""
+from __future__ import annotations
+
+import typing as t
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi import Depends, FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from hexcore.application.cqrs.config import CQRSConfig  # noqa: E402
+from hexcore.application.cqrs.registry import HandlerRegistry  # noqa: E402
+from hexcore.domain.cqrs.buses import AbstractCommandBus  # noqa: E402
+from hexcore.domain.cqrs.commands import Command  # noqa: E402
+from hexcore.domain.cqrs.decorators import background_command  # noqa: E402
+from hexcore.domain.cqrs.task_queues import ITaskEnqueuer  # noqa: E402
+from hexcore.infrastructure.api.cqrs import (  # noqa: E402
+    configure_cqrs,
+    get_cqrs_container,
+    provide_command_bus,
+    provide_event_bus,
+    provide_query_bus,
+    provide_registry,
+    reset_cqrs,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _clean_container():
+    reset_cqrs()
+    yield
+    reset_cqrs()
+
+
+class Greet(Command):
+    name: str
+
+
+class GreetHandler:
+    async def handle(self, cmd: Greet) -> str:
+        return f"hola {cmd.name}"
+
+
+@background_command(queue="bg")
+class BackgroundGreet(Command):
+    name: str
+
+
+class SpyEnqueuer(ITaskEnqueuer):
+    def __init__(self) -> None:
+        self.commands: list[str] = []
+
+    async def enqueue_command(self, command_name: str, payload: dict, queue: str) -> None:
+        self.commands.append(command_name)
+
+    async def enqueue_event(self, *a, **k) -> None: ...
+    async def enqueue_handler(self, *a, **k) -> None: ...
+    async def enqueue_task(self, *a, **k) -> None: ...
+
+
+def _registry() -> HandlerRegistry:
+    registry = HandlerRegistry()
+    registry.register_command_handler(Greet, GreetHandler())
+    return registry
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/greet/{name}")
+    async def greet(
+        name: str, bus: AbstractCommandBus = Depends(provide_command_bus)
+    ) -> dict[str, t.Any]:
+        return {"result": await bus.dispatch(Greet(name=name))}
+
+    return app
+
+
+# ── Configuración ──────────────────────────────────────────────────────────────
+
+
+def test_providers_fail_with_a_clear_error_before_configuration():
+    with pytest.raises(RuntimeError, match="configure_cqrs"):
+        provide_command_bus()
+
+
+def test_configure_cqrs_returns_a_usable_container():
+    container = configure_cqrs(_registry(), config=CQRSConfig())
+
+    assert container is get_cqrs_container()
+    assert container.command_bus() is not None
+    assert container.query_bus() is not None
+    assert container.event_bus() is not None
+
+
+def test_buses_are_cached():
+    configure_cqrs(_registry(), config=CQRSConfig())
+
+    assert provide_command_bus() is provide_command_bus()
+    assert provide_query_bus() is provide_query_bus()
+    assert provide_event_bus() is provide_event_bus()
+
+
+def test_provide_registry_returns_the_configured_registry():
+    registry = _registry()
+    configure_cqrs(registry, config=CQRSConfig())
+
+    assert provide_registry() is registry
+
+
+def test_reset_cqrs_forces_reconfiguration():
+    configure_cqrs(_registry(), config=CQRSConfig())
+    reset_cqrs()
+
+    with pytest.raises(RuntimeError):
+        provide_command_bus()
+
+
+# ── Uso desde un endpoint ──────────────────────────────────────────────────────
+
+
+def test_endpoint_resolves_the_command_bus():
+    configure_cqrs(_registry(), config=CQRSConfig())
+
+    with TestClient(_app()) as client:
+        assert client.get("/greet/mundo").json() == {"result": "hola mundo"}
+
+
+def test_dependency_override_replaces_the_bus_in_tests():
+    """La razón por la que estos providers son funciones."""
+    configure_cqrs(_registry(), config=CQRSConfig())
+    app = _app()
+
+    class FakeBus(AbstractCommandBus):
+        async def dispatch(self, command: Command) -> t.Any:
+            return "reemplazado"
+
+    app.dependency_overrides[provide_command_bus] = lambda: FakeBus()
+
+    with TestClient(app) as client:
+        assert client.get("/greet/mundo").json() == {"result": "reemplazado"}
+
+
+# ── Una sola fuente de verdad con el worker ────────────────────────────────────
+
+
+def test_consumer_shares_registry_and_serializer_with_the_web_buses():
+    registry = _registry()
+    container = configure_cqrs(registry, config=CQRSConfig())
+
+    consumer = container.build_consumer()
+
+    assert consumer._command_bus is provide_command_bus()
+    assert consumer._event_bus is provide_event_bus()
+    assert consumer._serializer is container.serializer
+
+
+@pytest.mark.anyio
+async def test_container_propagates_the_enqueuer_for_smart_routing():
+    registry = _registry()
+    registry.register_command_handler(BackgroundGreet, GreetHandler())
+    enqueuer = SpyEnqueuer()
+    configure_cqrs(registry, config=CQRSConfig(), enqueuer=enqueuer)
+
+    await provide_command_bus().dispatch(BackgroundGreet(name="x"))
+
+    assert enqueuer.commands == ["BackgroundGreet"]
+
+
+def test_missing_enqueuer_with_background_commands_fails_at_container_build():
+    """Hereda la validación de P0-5."""
+    registry = _registry()
+    registry.register_command_handler(BackgroundGreet, GreetHandler())
+    configure_cqrs(registry, config=CQRSConfig())
+
+    with pytest.raises(RuntimeError, match="BackgroundGreet"):
+        provide_command_bus()
+
+
+def test_serializer_is_the_same_instance_everywhere():
+    container = configure_cqrs(_registry(), config=CQRSConfig())
+
+    assert container.serializer is container.serializer

--- a/tests/test_api_exception_handlers.py
+++ b/tests/test_api_exception_handlers.py
@@ -1,0 +1,151 @@
+"""
+F5: mapeo de excepciones de dominio a HTTP.
+
+El caso que motiva el default de `ValueError` → 422: hasta ahora sólo se capturaba
+**dentro** de `build_query_endpoint`, así que una query construida a mano devolvía 500.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from hexcore.domain.cqrs.exceptions import DeserializationError, HandlerNotFoundError  # noqa: E402
+from hexcore.domain.exceptions import InactiveEntityException  # noqa: E402
+from hexcore.infrastructure.api.exception_handlers import (  # noqa: E402
+    DEFAULT_EXCEPTION_STATUS_MAP,
+    register_exception_handlers,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class NotFoundError(Exception):
+    """Excepción de dominio de una app cualquiera."""
+
+
+def _app(**kwargs) -> FastAPI:
+    app = FastAPI()
+    register_exception_handlers(app, **kwargs)
+
+    @app.get("/inactive")
+    async def inactive() -> None:
+        raise InactiveEntityException()
+
+    @app.get("/bad-payload")
+    async def bad_payload() -> None:
+        raise DeserializationError("payload corrupto")
+
+    @app.get("/no-handler")
+    async def no_handler() -> None:
+        raise HandlerNotFoundError(int)
+
+    @app.get("/bad-field")
+    async def bad_field() -> None:
+        raise ValueError("campo 'nope' no existe")
+
+    @app.get("/not-found")
+    async def not_found() -> None:
+        raise NotFoundError("el ticket 42 no existe")
+
+    return app
+
+
+def _client(app: FastAPI) -> TestClient:
+    # raise_server_exceptions=False para que las excepciones no mapeadas lleguen como
+    # 500 en vez de propagarse al test.
+    return TestClient(app, raise_server_exceptions=False)
+
+
+def test_default_mapping_covers_the_domain_exceptions():
+    assert DEFAULT_EXCEPTION_STATUS_MAP[InactiveEntityException] == 409
+    assert DEFAULT_EXCEPTION_STATUS_MAP[DeserializationError] == 400
+    assert DEFAULT_EXCEPTION_STATUS_MAP[HandlerNotFoundError] == 501
+    assert DEFAULT_EXCEPTION_STATUS_MAP[ValueError] == 422
+
+
+@pytest.mark.parametrize(
+    ("path", "expected"),
+    [
+        ("/inactive", 409),
+        ("/bad-payload", 400),
+        ("/no-handler", 501),
+        ("/bad-field", 422),
+    ],
+)
+def test_default_handlers_map_to_the_documented_status(path, expected):
+    with _client(_app()) as client:
+        assert client.get(path).status_code == expected
+
+
+def test_response_body_carries_detail_and_error_name():
+    with _client(_app()) as client:
+        body = client.get("/bad-field").json()
+
+    assert body["detail"] == "campo 'nope' no existe"
+    assert body["error"] == "ValueError"
+
+
+def test_custom_mapping_is_merged_with_the_default():
+    with _client(_app(mapping={NotFoundError: 404})) as client:
+        assert client.get("/not-found").status_code == 404
+        # Los defaults siguen ahí.
+        assert client.get("/inactive").status_code == 409
+
+
+def test_custom_mapping_can_override_a_default():
+    with _client(_app(mapping={InactiveEntityException: 410})) as client:
+        assert client.get("/inactive").status_code == 410
+
+
+def test_include_detail_false_hides_the_message():
+    with _client(_app(include_detail=False)) as client:
+        body = client.get("/bad-field").json()
+
+    assert "nope" not in body["detail"]
+    assert body["error"] == "ValueError"
+
+
+def test_include_detail_accepts_a_callable():
+    with _client(
+        _app(include_detail=lambda exc: f"[{type(exc).__name__}] redactado")
+    ) as client:
+        body = client.get("/bad-field").json()
+
+    assert body["detail"] == "[ValueError] redactado"
+
+
+def test_unmapped_exception_is_still_a_500():
+    with _client(_app()) as client:
+        assert client.get("/not-found").status_code == 500
+
+
+def test_a_subclass_wins_over_its_parent():
+    """
+    `DeserializationError` hereda de `CQRSError`, no de `ValueError`, pero el orden de
+    registro tiene que respetar la especificidad si alguien mapea una jerarquía.
+    """
+    class SpecificValueError(ValueError):
+        pass
+
+    app = FastAPI()
+    register_exception_handlers(app, mapping={SpecificValueError: 418})
+
+    @app.get("/specific")
+    async def specific() -> None:
+        raise SpecificValueError("soy más específica")
+
+    @app.get("/generic")
+    async def generic() -> None:
+        raise ValueError("soy genérica")
+
+    with _client(app) as client:
+        assert client.get("/specific").status_code == 418
+        assert client.get("/generic").status_code == 422

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -1,0 +1,220 @@
+"""
+F16: health checks que de verdad comprueban algo.
+
+Un `/health/detailed` que devuelve `{"status": "ok"}` hardcodeado es peor que no tenerlo:
+el orquestador lo lee como "sano" con la BD caída y le sigue mandando tráfico.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from hexcore.infrastructure.api.health import (  # noqa: E402
+    HealthReport,
+    Probe,
+    check_health,
+    default_probes,
+    register_health_routes,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _ok() -> None:
+    return None
+
+
+async def _boom() -> None:
+    raise ConnectionError("no responde")
+
+
+async def _hangs() -> None:
+    await asyncio.sleep(10)
+
+
+# ── Liveness: sin I/O, siempre 200 ─────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_liveness_does_not_run_any_probe():
+    called: list[str] = []
+
+    async def spy() -> None:
+        called.append("probed")
+
+    report = await check_health(deep=False, probes=[Probe("spy", spy)])
+
+    assert report.status == "ok"
+    assert report.deep is False
+    assert report.dependencies == []
+    assert called == [], "el liveness sondeó dependencias"
+
+
+@pytest.mark.anyio
+async def test_liveness_http_status_is_200():
+    report = await check_health(deep=False)
+
+    assert report.http_status == 200
+
+
+# ── Readiness: sondea de verdad ────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_readiness_reports_ok_when_everything_answers():
+    report = await check_health(
+        deep=True, probes=[Probe("sql", _ok), Probe("redis", _ok)]
+    )
+
+    assert report.status == "ok"
+    assert report.deep is True
+    assert {d.name for d in report.dependencies} == {"sql", "redis"}
+    assert all(d.status == "ok" for d in report.dependencies)
+
+
+@pytest.mark.anyio
+async def test_readiness_is_down_when_a_critical_probe_fails():
+    report = await check_health(
+        deep=True, probes=[Probe("sql", _boom), Probe("redis", _ok)]
+    )
+
+    assert report.status == "down"
+    assert report.http_status == 503
+
+    sql = next(d for d in report.dependencies if d.name == "sql")
+    assert sql.status == "down"
+    assert sql.detail is not None
+    assert "ConnectionError" in sql.detail
+
+
+@pytest.mark.anyio
+async def test_a_non_critical_failure_only_degrades():
+    """Un cache caído ralentiza, no impide servir."""
+    report = await check_health(
+        deep=True,
+        probes=[Probe("sql", _ok), Probe("redis", _boom, critical=False)],
+    )
+
+    assert report.status == "degraded"
+    assert report.http_status == 200
+
+
+@pytest.mark.anyio
+async def test_a_probe_that_hangs_times_out_instead_of_hanging_the_check():
+    """Un health check que se cuelga es un health check que tumba el deploy."""
+    report = await check_health(
+        deep=True, probes=[Probe("slow", _hangs, timeout=0.05)]
+    )
+
+    assert report.status == "down"
+    assert report.dependencies[0].detail is not None
+    assert "timeout" in report.dependencies[0].detail
+
+
+@pytest.mark.anyio
+async def test_probes_report_their_latency():
+    async def slow_but_ok() -> None:
+        await asyncio.sleep(0.02)
+
+    report = await check_health(deep=True, probes=[Probe("slow", slow_but_ok)])
+
+    assert report.dependencies[0].latency_ms >= 15
+
+
+@pytest.mark.anyio
+async def test_probes_run_concurrently():
+    async def takes_50ms() -> None:
+        await asyncio.sleep(0.05)
+
+    import time
+
+    start = time.perf_counter()
+    await check_health(
+        deep=True,
+        probes=[Probe(f"p{i}", takes_50ms, timeout=1.0) for i in range(4)],
+    )
+    elapsed = time.perf_counter() - start
+
+    assert elapsed < 0.2, "las sondas corrieron en serie"
+
+
+@pytest.mark.anyio
+async def test_readiness_with_no_probes_is_ok():
+    report = await check_health(deep=True, probes=[])
+
+    assert report.status == "ok"
+    assert report.deep is True
+
+
+def test_default_probes_only_includes_what_can_be_probed():
+    """No queremos una sonda que siempre pasa porque la dependencia no está."""
+    names = {probe.name for probe in default_probes()}
+
+    assert names <= {"sql", "redis", "mongo"}
+    for probe in default_probes():
+        assert probe.timeout > 0
+
+
+# ── Rutas ──────────────────────────────────────────────────────────────────────
+
+
+def test_liveness_route_returns_200_without_probing():
+    app = FastAPI()
+    register_health_routes(app, probes=[Probe("sql", _boom)])
+
+    with TestClient(app) as client:
+        response = client.get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+    assert response.json()["deep"] is False
+
+
+def test_readiness_route_returns_503_when_a_dependency_is_down():
+    app = FastAPI()
+    register_health_routes(app, probes=[Probe("sql", _boom)])
+
+    with TestClient(app) as client:
+        response = client.get("/health/ready")
+
+    assert response.status_code == 503
+    body = response.json()
+    assert body["status"] == "down"
+    assert body["dependencies"][0]["name"] == "sql"
+
+
+def test_readiness_route_returns_200_when_everything_is_up():
+    app = FastAPI()
+    register_health_routes(app, probes=[Probe("sql", _ok)])
+
+    with TestClient(app) as client:
+        response = client.get("/health/ready")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "ok"
+
+
+def test_custom_path():
+    app = FastAPI()
+    register_health_routes(app, path="/_status", probes=[Probe("sql", _ok)])
+
+    with TestClient(app) as client:
+        assert client.get("/_status").status_code == 200
+        assert client.get("/_status/ready").status_code == 200
+        assert client.get("/health").status_code == 404
+
+
+def test_health_report_is_serializable():
+    report = HealthReport(status="ok")
+
+    assert report.model_dump()["status"] == "ok"

--- a/tests/test_api_middlewares_and_routing.py
+++ b/tests/test_api_middlewares_and_routing.py
@@ -1,0 +1,308 @@
+"""
+F11 (middlewares de serie) y F13 (composición de routers).
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")  # requerido por starlette.testclient
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException, Request  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from hexcore.infrastructure.api.middlewares import (  # noqa: E402
+    RequestIDLogFilter,
+    RequestIDMiddleware,
+    TimingMiddleware,
+    get_request_id,
+    install_request_id_logging,
+)
+from hexcore.infrastructure.api.routing import build_root_router, mount_routers  # noqa: E402
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── F11: RequestIDMiddleware ───────────────────────────────────────────────────
+
+
+def _app_with_request_id(**middleware_kwargs) -> FastAPI:
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware, **middleware_kwargs)
+
+    @app.get("/echo")
+    async def echo() -> dict[str, str]:
+        return {"request_id": get_request_id()}
+
+    return app
+
+
+def test_request_id_is_generated_when_absent():
+    with TestClient(_app_with_request_id()) as client:
+        response = client.get("/echo")
+
+    assert response.status_code == 200
+    header_id = response.headers["X-Request-ID"]
+    assert header_id
+    assert response.json()["request_id"] == header_id
+
+
+def test_incoming_request_id_is_reused():
+    """Romper la cadena del gateway es perder la traza."""
+    with TestClient(_app_with_request_id()) as client:
+        response = client.get("/echo", headers={"X-Request-ID": "from-gateway"})
+
+    assert response.headers["X-Request-ID"] == "from-gateway"
+    assert response.json()["request_id"] == "from-gateway"
+
+
+def test_request_id_is_available_in_request_state():
+    """Para quien prefiera `request.state` al ContextVar."""
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/state")
+    async def from_state(request: Request) -> dict[str, str]:
+        return {"request_id": request.state.request_id}
+
+    with TestClient(app) as client:
+        response = client.get("/state", headers={"X-Request-ID": "abc"})
+
+    assert response.json()["request_id"] == "abc"
+
+
+def test_custom_header_name_and_generator():
+    app = _app_with_request_id(header_name="X-Trace", generator=lambda: "fixed-id")
+
+    with TestClient(app) as client:
+        response = client.get("/echo")
+
+    assert response.headers["X-Trace"] == "fixed-id"
+
+
+def test_context_var_is_reset_between_requests():
+    app = _app_with_request_id()
+
+    with TestClient(app) as client:
+        first = client.get("/echo", headers={"X-Request-ID": "one"}).json()["request_id"]
+        second = client.get("/echo", headers={"X-Request-ID": "two"}).json()["request_id"]
+
+    assert (first, second) == ("one", "two")
+    # Fuera de todo request el default vuelve a estar.
+    assert get_request_id() == "-"
+
+
+def test_request_id_header_is_set_even_on_error():
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/boom")
+    async def boom() -> None:
+        raise HTTPException(status_code=418, detail="teapot")
+
+    with TestClient(app) as client:
+        response = client.get("/boom", headers={"X-Request-ID": "err-id"})
+
+    assert response.status_code == 418
+    assert response.headers["X-Request-ID"] == "err-id"
+
+
+# ── F11: TimingMiddleware ──────────────────────────────────────────────────────
+
+
+def test_timing_middleware_adds_the_header():
+    app = FastAPI()
+    app.add_middleware(TimingMiddleware)
+
+    @app.get("/ping")
+    async def ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    with TestClient(app) as client:
+        response = client.get("/ping")
+
+    assert float(response.headers["X-Response-Time-ms"]) >= 0
+
+
+def test_timing_middleware_custom_header():
+    app = FastAPI()
+    app.add_middleware(TimingMiddleware, header_name="X-Took")
+
+    @app.get("/ping")
+    async def ping() -> dict[str, bool]:
+        return {"ok": True}
+
+    with TestClient(app) as client:
+        response = client.get("/ping")
+
+    assert "X-Took" in response.headers
+
+
+# ── F11: el filtro de logging (la mitad del valor) ─────────────────────────────
+
+
+def test_log_filter_injects_the_request_id(caplog):
+    logger = logging.getLogger("hexcore.test.reqid")
+    app = FastAPI()
+    app.add_middleware(RequestIDMiddleware)
+
+    @app.get("/log")
+    async def log_something() -> dict[str, bool]:
+        logger.warning("algo pasó")
+        return {"ok": True}
+
+    handler = logging.StreamHandler()
+    handler.addFilter(RequestIDLogFilter())
+    logger.addHandler(handler)
+    try:
+        with caplog.at_level(logging.WARNING, logger="hexcore.test.reqid"):
+            for record_handler in caplog.handler, handler:
+                record_handler.addFilter(RequestIDLogFilter())
+            with TestClient(app) as client:
+                client.get("/log", headers={"X-Request-ID": "traced"})
+    finally:
+        logger.removeHandler(handler)
+
+    records = [r for r in caplog.records if r.name == "hexcore.test.reqid"]
+    assert records
+    assert getattr(records[0], "request_id") == "traced"
+
+
+def test_log_filter_outside_a_request_uses_the_default():
+    record = logging.LogRecord("x", logging.INFO, __file__, 1, "m", None, None)
+    RequestIDLogFilter().filter(record)
+
+    assert getattr(record, "request_id") == "-"
+
+
+def test_install_request_id_logging_is_idempotent():
+    logger = logging.getLogger("hexcore.test.install")
+    handler = logging.StreamHandler()
+    logger.addHandler(handler)
+    try:
+        install_request_id_logging(logger)
+        install_request_id_logging(logger)
+
+        filters = [f for f in handler.filters if isinstance(f, RequestIDLogFilter)]
+        assert len(filters) == 1
+    finally:
+        logger.removeHandler(handler)
+
+
+def test_install_request_id_logging_can_set_the_format():
+    logger = logging.getLogger("hexcore.test.fmt")
+    handler = logging.StreamHandler()
+    logger.addHandler(handler)
+    try:
+        install_request_id_logging(logger, fmt="[%(request_id)s] %(message)s")
+
+        record = logging.LogRecord("x", logging.INFO, __file__, 1, "hola", None, None)
+        RequestIDLogFilter().filter(record)
+        assert handler.formatter is not None
+        assert handler.formatter.format(record) == "[-] hola"
+    finally:
+        logger.removeHandler(handler)
+
+
+# ── F13: build_root_router / mount_routers ─────────────────────────────────────
+
+
+def _child(name: str) -> APIRouter:
+    router = APIRouter()
+
+    @router.get("/items")
+    async def items() -> dict[str, str]:
+        return {"from": name}
+
+    return router
+
+
+def test_build_root_router_mounts_children_under_their_prefixes():
+    root = build_root_router(
+        "/admin", {"/catalog": _child("catalog"), "/reports": _child("reports")}
+    )
+    app = FastAPI()
+    app.include_router(root)
+
+    with TestClient(app) as client:
+        assert client.get("/admin/catalog/items").json() == {"from": "catalog"}
+        assert client.get("/admin/reports/items").json() == {"from": "reports"}
+
+
+def test_build_root_router_applies_shared_dependencies():
+    calls: list[str] = []
+
+    async def guard() -> None:
+        calls.append("checked")
+
+    root = build_root_router(
+        "/secure", {"/a": _child("a")}, dependencies=[Depends(guard)]
+    )
+    app = FastAPI()
+    app.include_router(root)
+
+    with TestClient(app) as client:
+        assert client.get("/secure/a/items").status_code == 200
+
+    assert calls == ["checked"]
+
+
+def test_build_root_router_shared_dependency_can_reject():
+    async def deny() -> None:
+        raise HTTPException(status_code=403, detail="nope")
+
+    root = build_root_router("/secure", {"/a": _child("a")}, dependencies=[Depends(deny)])
+    app = FastAPI()
+    app.include_router(root)
+
+    with TestClient(app) as client:
+        assert client.get("/secure/a/items").status_code == 403
+
+
+def test_build_root_router_applies_tags():
+    root = build_root_router("/tagged", {"/a": _child("a")}, tags=["admin"])
+    app = FastAPI()
+    app.include_router(root)
+
+    schema = app.openapi()
+    assert schema["paths"]["/tagged/a/items"]["get"]["tags"] == ["admin"]
+
+
+def test_build_root_router_supports_empty_child_prefix():
+    root = build_root_router("/root", {"": _child("direct")})
+    app = FastAPI()
+    app.include_router(root)
+
+    with TestClient(app) as client:
+        assert client.get("/root/items").json() == {"from": "direct"}
+
+
+def test_mount_routers_accepts_plain_routers_and_tuples():
+    app = FastAPI()
+    mount_routers(
+        app,
+        [
+            _child("plain"),
+            (_child("with-kwargs"), {"prefix": "/v2", "tags": ["v2"]}),
+        ],
+    )
+
+    with TestClient(app) as client:
+        assert client.get("/items").json() == {"from": "plain"}
+        assert client.get("/v2/items").json() == {"from": "with-kwargs"}
+
+    schema = app.openapi()
+    assert schema["paths"]["/v2/items"]["get"]["tags"] == ["v2"]
+
+
+def test_mount_routers_with_an_empty_list_is_a_noop():
+    app = FastAPI()
+    mount_routers(app, [])
+
+    with TestClient(app) as client:
+        assert client.get("/nope").status_code == 404

--- a/tests/test_api_rate_limit.py
+++ b/tests/test_api_rate_limit.py
@@ -1,0 +1,228 @@
+"""
+F12: rate limiting como dependencia, sobre `ICache`.
+
+Dos cosas que la implementación de la app real no hacía y que aquí son requisito:
+`Retry-After` en el 429, y una política **explícita** para cuando el backend está caído
+en vez de una decisión enterrada en un `except`.
+"""
+from __future__ import annotations
+
+import time
+import typing as t
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi import Depends, FastAPI, Request  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from hexcore.infrastructure.api.rate_limit import client_ip_key, rate_limit  # noqa: E402
+from hexcore.infrastructure.cache import ICache  # noqa: E402
+from hexcore.infrastructure.cache.cache_backends.memory import MemoryCache  # noqa: E402
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class BrokenCache(ICache):
+    async def get(self, key: str) -> t.Any:
+        raise ConnectionError("redis down")
+
+    def set(self, key: str, value: t.Any, expire: int = 3600) -> t.Any:
+        raise ConnectionError("redis down")
+
+    def delete(self, key: str) -> t.Any:
+        raise ConnectionError("redis down")
+
+
+def _app(**kwargs) -> FastAPI:
+    app = FastAPI()
+    limiter = rate_limit(**kwargs)
+
+    @app.get("/limited", dependencies=[Depends(limiter)])
+    async def limited() -> dict[str, bool]:
+        return {"ok": True}
+
+    return app
+
+
+# ── Ventana básica ─────────────────────────────────────────────────────────────
+
+
+def test_requests_within_the_limit_pass():
+    app = _app(limit=3, window_seconds=60, cache=MemoryCache())
+
+    with TestClient(app) as client:
+        statuses = [client.get("/limited").status_code for _ in range(3)]
+
+    assert statuses == [200, 200, 200]
+
+
+def test_request_over_the_limit_gets_429():
+    app = _app(limit=2, window_seconds=60, cache=MemoryCache())
+
+    with TestClient(app) as client:
+        client.get("/limited")
+        client.get("/limited")
+        response = client.get("/limited")
+
+    assert response.status_code == 429
+
+
+def test_429_carries_retry_after():
+    """La implementación de la app real no lo hacía; sin esto el cliente adivina."""
+    app = _app(limit=1, window_seconds=60, cache=MemoryCache())
+
+    with TestClient(app) as client:
+        client.get("/limited")
+        response = client.get("/limited")
+
+    assert response.status_code == 429
+    retry_after = int(response.headers["Retry-After"])
+    assert 1 <= retry_after <= 61
+
+
+def test_window_expiry_resets_the_counter():
+    cache = MemoryCache()
+    app = _app(limit=1, window_seconds=60, cache=cache)
+
+    with TestClient(app) as client:
+        assert client.get("/limited").status_code == 200
+        assert client.get("/limited").status_code == 429
+
+        # Envejecemos la ventana: el vencimiento se evalúa en el limiter, no en el
+        # backend, precisamente porque MemoryCache ignora `expire`.
+        key = next(iter(cache.cache))
+        cache.cache[key]["reset_at"] = time.time() - 1
+
+        assert client.get("/limited").status_code == 200
+
+
+def test_memory_cache_ignores_expire_so_the_limiter_must_not_rely_on_it():
+    """Documenta por qué la ventana lleva su propio `reset_at`."""
+    cache = MemoryCache()
+
+    import asyncio
+
+    asyncio.run(cache.set("k", {"v": 1}, expire=1))
+    assert asyncio.run(cache.get("k")) == {"v": 1}
+
+
+# ── Claves ─────────────────────────────────────────────────────────────────────
+
+
+def test_different_keys_have_independent_budgets():
+    cache = MemoryCache()
+    app = FastAPI()
+    limiter = rate_limit(
+        limit=1,
+        window_seconds=60,
+        cache=cache,
+        key=lambda request: request.headers.get("X-User", "anon"),
+    )
+
+    @app.get("/limited", dependencies=[Depends(limiter)])
+    async def limited() -> dict[str, bool]:
+        return {"ok": True}
+
+    with TestClient(app) as client:
+        assert client.get("/limited", headers={"X-User": "a"}).status_code == 200
+        assert client.get("/limited", headers={"X-User": "b"}).status_code == 200
+        assert client.get("/limited", headers={"X-User": "a"}).status_code == 429
+
+
+def test_client_ip_key_prefers_forwarded_for():
+    app = FastAPI()
+
+    @app.get("/whoami")
+    async def whoami(request: Request) -> dict[str, str]:
+        return {"key": client_ip_key(request)}
+
+    with TestClient(app) as client:
+        body = client.get(
+            "/whoami", headers={"X-Forwarded-For": "203.0.113.5, 10.0.0.1"}
+        ).json()
+
+    assert body["key"] == "203.0.113.5"
+
+
+def test_client_ip_key_falls_back_to_the_socket_address():
+    app = FastAPI()
+
+    @app.get("/whoami")
+    async def whoami(request: Request) -> dict[str, str]:
+        return {"key": client_ip_key(request)}
+
+    with TestClient(app) as client:
+        assert client.get("/whoami").json()["key"] != ""
+
+
+def test_namespace_isolates_two_limiters_on_the_same_key():
+    cache = MemoryCache()
+    app = FastAPI()
+    per_route_a = rate_limit(limit=1, cache=cache, namespace="a")
+    per_route_b = rate_limit(limit=1, cache=cache, namespace="b")
+
+    @app.get("/a", dependencies=[Depends(per_route_a)])
+    async def a() -> dict[str, bool]:
+        return {"ok": True}
+
+    @app.get("/b", dependencies=[Depends(per_route_b)])
+    async def b() -> dict[str, bool]:
+        return {"ok": True}
+
+    with TestClient(app) as client:
+        assert client.get("/a").status_code == 200
+        assert client.get("/b").status_code == 200
+        assert client.get("/a").status_code == 429
+
+
+# ── Backend caído: política explícita ──────────────────────────────────────────
+
+
+def test_backend_error_allows_by_default():
+    app = _app(limit=1, cache=BrokenCache())
+
+    with TestClient(app) as client:
+        assert client.get("/limited").status_code == 200
+        assert client.get("/limited").status_code == 200
+
+
+def test_backend_error_can_deny_instead():
+    app = _app(limit=1, cache=BrokenCache(), on_backend_error="deny")
+
+    with TestClient(app) as client:
+        response = client.get("/limited")
+
+    assert response.status_code == 429
+    assert "Retry-After" in response.headers
+
+
+def test_backend_error_logs_critical_when_denying(caplog):
+    import logging
+
+    app = _app(limit=1, cache=BrokenCache(), on_backend_error="deny")
+
+    with caplog.at_level(logging.CRITICAL):
+        with TestClient(app) as client:
+            client.get("/limited")
+
+    assert any(r.levelno == logging.CRITICAL for r in caplog.records)
+
+
+# ── Validación de argumentos ───────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("kwargs", [{"limit": 0}, {"limit": -1}])
+def test_invalid_limit_is_rejected(kwargs):
+    with pytest.raises(ValueError, match="limit"):
+        rate_limit(**kwargs)
+
+
+def test_invalid_window_is_rejected():
+    with pytest.raises(ValueError, match="window_seconds"):
+        rate_limit(limit=1, window_seconds=0)

--- a/tests/test_api_streaming.py
+++ b/tests/test_api_streaming.py
@@ -1,0 +1,367 @@
+"""
+F14: SSE, heartbeat de WebSocket y límite de conexiones.
+
+El caso con más valor es `connection_slot`: filtrar un slot al desconectarse mal es un
+bug clásico —el usuario queda sin poder reconectar hasta que expire—, así que aquí el
+teardown tiene que estar garantizado incluso si el bloque lanza o se cancela.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+import typing as t
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi import FastAPI  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from hexcore.infrastructure.api.streaming import (  # noqa: E402
+    connection_slot,
+    format_sse_event,
+    sse_stream,
+    ws_heartbeat,
+)
+from hexcore.infrastructure.cache import ICache  # noqa: E402
+from hexcore.infrastructure.cache.cache_backends.memory import MemoryCache  # noqa: E402
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── format_sse_event ───────────────────────────────────────────────────────────
+
+
+def test_format_sse_event_serializes_the_payload_as_data():
+    frame = format_sse_event({"ticket": 42, "state": "open"})
+
+    assert frame.endswith("\n\n")
+    assert json.loads(frame.split("data: ", 1)[1].strip()) == {
+        "ticket": 42,
+        "state": "open",
+    }
+
+
+def test_format_sse_event_supports_the_control_keys():
+    frame = format_sse_event(
+        {"event": "ticket.updated", "id": "7", "retry": 5000, "data": {"x": 1}}
+    )
+
+    assert "event: ticket.updated" in frame
+    assert "id: 7" in frame
+    assert "retry: 5000" in frame
+    assert '"x": 1' in frame
+
+
+def test_format_sse_event_prefixes_every_line_of_multiline_data():
+    """Sin un `data:` por línea, el cliente corta el evento en el primer salto."""
+    frame = format_sse_event({"data": "linea1\nlinea2"})
+
+    assert frame == "data: linea1\ndata: linea2\n\n"
+
+
+def test_format_sse_event_accepts_a_plain_string():
+    assert format_sse_event({"data": "hola"}) == "data: hola\n\n"
+
+
+# ── sse_stream ─────────────────────────────────────────────────────────────────
+
+
+def _sse_app(source_factory, **kwargs) -> FastAPI:
+    app = FastAPI()
+
+    @app.get("/stream")
+    async def stream():
+        return sse_stream(source_factory(), **kwargs)
+
+    return app
+
+
+def test_sse_stream_emits_the_events():
+    async def source() -> t.AsyncIterator[dict]:
+        yield {"n": 1}
+        yield {"n": 2}
+
+    with TestClient(_sse_app(source)) as client:
+        with client.stream("GET", "/stream") as response:
+            body = "".join(response.iter_text())
+
+    assert body.count("data: ") == 2
+    assert '"n": 1' in body and '"n": 2' in body
+
+
+def test_sse_stream_sets_the_content_type_and_anti_buffering_headers():
+    async def source() -> t.AsyncIterator[dict]:
+        yield {"n": 1}
+
+    with TestClient(_sse_app(source)) as client:
+        with client.stream("GET", "/stream") as response:
+            assert response.headers["content-type"].startswith("text/event-stream")
+            assert response.headers["cache-control"] == "no-cache"
+            # Sin esto, nginx acumula los eventos y el stream llega a bloques.
+            assert response.headers["x-accel-buffering"] == "no"
+            list(response.iter_text())
+
+
+def test_sse_stream_emits_a_heartbeat_while_the_source_is_quiet():
+    async def slow_source() -> t.AsyncIterator[dict]:
+        await asyncio.sleep(0.15)
+        yield {"n": 1}
+
+    app = _sse_app(slow_source, heartbeat_seconds=0.03)
+
+    with TestClient(app) as client:
+        with client.stream("GET", "/stream") as response:
+            body = "".join(response.iter_text())
+
+    assert ": ping" in body, "no se emitió heartbeat durante el silencio"
+    assert '"n": 1' in body
+
+
+def test_sse_stream_without_heartbeat_emits_no_pings():
+    async def source() -> t.AsyncIterator[dict]:
+        yield {"n": 1}
+
+    with TestClient(_sse_app(source, heartbeat_seconds=0)) as client:
+        with client.stream("GET", "/stream") as response:
+            body = "".join(response.iter_text())
+
+    assert ": ping" not in body
+
+
+def test_sse_stream_closes_the_source_generator():
+    closed: list[bool] = []
+
+    async def source() -> t.AsyncIterator[dict]:
+        try:
+            yield {"n": 1}
+        finally:
+            closed.append(True)
+
+    with TestClient(_sse_app(source)) as client:
+        with client.stream("GET", "/stream") as response:
+            list(response.iter_text())
+
+    assert closed == [True]
+
+
+def test_sse_stream_with_an_empty_source_completes():
+    async def source() -> t.AsyncIterator[dict]:
+        return
+        yield  # pragma: no cover
+
+    with TestClient(_sse_app(source)) as client:
+        with client.stream("GET", "/stream") as response:
+            assert "".join(response.iter_text()) == ""
+
+
+# ── ws_heartbeat ───────────────────────────────────────────────────────────────
+
+
+class FakeWebSocket:
+    def __init__(self, *, fail: bool = False) -> None:
+        self.sent: list[dict] = []
+        self._fail = fail
+
+    async def send_json(self, payload: dict) -> None:
+        if self._fail:
+            raise RuntimeError("cliente cerró")
+        self.sent.append(payload)
+
+
+@pytest.mark.anyio
+async def test_ws_heartbeat_sends_pings_while_the_block_runs():
+    ws = FakeWebSocket()
+
+    async with ws_heartbeat(t.cast(t.Any, ws), interval=0.02):
+        await asyncio.sleep(0.07)
+
+    assert len(ws.sent) >= 2
+    assert ws.sent[0]["type"] == "ping"
+
+
+@pytest.mark.anyio
+async def test_ws_heartbeat_stops_on_exit():
+    ws = FakeWebSocket()
+
+    async with ws_heartbeat(t.cast(t.Any, ws), interval=0.02):
+        await asyncio.sleep(0.05)
+
+    count_at_exit = len(ws.sent)
+    await asyncio.sleep(0.08)
+
+    assert len(ws.sent) == count_at_exit, "el heartbeat siguió después del bloque"
+
+
+@pytest.mark.anyio
+async def test_ws_heartbeat_stops_even_if_the_block_raises():
+    ws = FakeWebSocket()
+
+    with pytest.raises(RuntimeError, match="fallo del handler"):
+        async with ws_heartbeat(t.cast(t.Any, ws), interval=0.02):
+            await asyncio.sleep(0.03)
+            raise RuntimeError("fallo del handler")
+
+    count = len(ws.sent)
+    await asyncio.sleep(0.06)
+    assert len(ws.sent) == count
+
+
+@pytest.mark.anyio
+async def test_ws_heartbeat_swallows_send_errors():
+    """El cliente ya se fue: quien lea del socket se enterará; no queremos dos errores."""
+    ws = FakeWebSocket(fail=True)
+
+    async with ws_heartbeat(t.cast(t.Any, ws), interval=0.01):
+        await asyncio.sleep(0.05)
+
+
+@pytest.mark.anyio
+async def test_ws_heartbeat_with_zero_interval_is_disabled():
+    ws = FakeWebSocket()
+
+    async with ws_heartbeat(t.cast(t.Any, ws), interval=0):
+        await asyncio.sleep(0.03)
+
+    assert ws.sent == []
+
+
+# ── connection_slot ────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_connection_slot_grants_up_to_the_limit():
+    cache = MemoryCache()
+
+    async with connection_slot(cache, "user:1", max_connections=2) as first:
+        async with connection_slot(cache, "user:1", max_connections=2) as second:
+            async with connection_slot(cache, "user:1", max_connections=2) as third:
+                assert (first, second, third) == (True, True, False)
+
+
+@pytest.mark.anyio
+async def test_connection_slot_is_released_on_exit():
+    cache = MemoryCache()
+
+    async with connection_slot(cache, "user:1", max_connections=1) as granted:
+        assert granted is True
+
+    async with connection_slot(cache, "user:1", max_connections=1) as granted:
+        assert granted is True, "el slot no se liberó"
+
+
+@pytest.mark.anyio
+async def test_connection_slot_is_released_when_the_block_raises():
+    """El bug clásico: el cliente se desconecta mal y el slot queda ocupado."""
+    cache = MemoryCache()
+
+    with pytest.raises(RuntimeError):
+        async with connection_slot(cache, "user:1", max_connections=1):
+            raise RuntimeError("el cliente murió")
+
+    async with connection_slot(cache, "user:1", max_connections=1) as granted:
+        assert granted is True
+
+
+@pytest.mark.anyio
+async def test_connection_slot_is_released_on_cancellation():
+    cache = MemoryCache()
+
+    async def holder() -> None:
+        async with connection_slot(cache, "user:1", max_connections=1):
+            await asyncio.sleep(3600)
+
+    task = asyncio.create_task(holder())
+    await asyncio.sleep(0.02)
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+
+    async with connection_slot(cache, "user:1", max_connections=1) as granted:
+        assert granted is True
+
+
+@pytest.mark.anyio
+async def test_denied_slot_does_not_consume_anything():
+    cache = MemoryCache()
+
+    async with connection_slot(cache, "user:1", max_connections=1):
+        async with connection_slot(cache, "user:1", max_connections=1) as denied:
+            assert denied is False
+
+    # Tras cerrar el que sí tenía slot, vuelve a haber uno libre (el denegado no
+    # reservó nada que hubiera que liberar).
+    async with connection_slot(cache, "user:1", max_connections=1) as granted:
+        assert granted is True
+
+
+@pytest.mark.anyio
+async def test_expired_slots_do_not_count():
+    cache = MemoryCache()
+    await cache.set(
+        "hexcore:conn_slot:user:1",
+        {"slots": {"zombi": time.time() - 10}},
+    )
+
+    async with connection_slot(cache, "user:1", max_connections=1) as granted:
+        assert granted is True
+
+
+@pytest.mark.anyio
+async def test_slots_are_per_key():
+    cache = MemoryCache()
+
+    async with connection_slot(cache, "user:1", max_connections=1) as first:
+        async with connection_slot(cache, "user:2", max_connections=1) as second:
+            assert (first, second) == (True, True)
+
+
+@pytest.mark.anyio
+async def test_release_failure_does_not_propagate():
+    """Si el backend se cae al liberar, el TTL lo arregla; no rompemos al usuario."""
+
+    class HalfBrokenCache(ICache):
+        def __init__(self) -> None:
+            self.inner = MemoryCache()
+            self.fail_get = False
+
+        async def get(self, key: str) -> t.Any:
+            if self.fail_get:
+                raise ConnectionError("redis down")
+            return await self.inner.get(key)
+
+        def set(self, key: str, value: t.Any, expire: int = 3600) -> t.Any:
+            return self.inner.set(key, value, expire)
+
+        def delete(self, key: str) -> t.Any:
+            return self.inner.delete(key)
+
+    cache = HalfBrokenCache()
+
+    async with connection_slot(cache, "user:1", max_connections=1) as granted:
+        assert granted is True
+        cache.fail_get = True
+    # No debe lanzar al salir.
+
+
+@pytest.mark.anyio
+async def test_concurrent_slot_requests_respect_the_limit():
+    cache = MemoryCache()
+    outcomes: list[bool] = []
+
+    async def attempt() -> None:
+        async with connection_slot(cache, "user:1", max_connections=2) as granted:
+            outcomes.append(granted)
+            if granted:
+                await asyncio.sleep(0.05)
+
+    await asyncio.gather(*(attempt() for _ in range(4)))
+
+    assert sum(outcomes) <= 4
+    assert outcomes.count(False) >= 1, "el límite no rechazó a nadie"

--- a/tests/test_cron_sql.py
+++ b/tests/test_cron_sql.py
@@ -1,0 +1,351 @@
+"""
+F7: modelo + repositorio + seed de `cron_jobs` de serie.
+"""
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+pytest.importorskip("aiosqlite")
+
+from hexcore.domain.cqrs.cron import CronJobDefinition, ICronJobRepository  # noqa: E402
+from hexcore.domain.cqrs.decorators import background_task  # noqa: E402
+from hexcore.infrastructure.cqrs.cron_sql import (  # noqa: E402
+    CronJobModel,
+    CronJobModelMixin,
+    SqlAlchemyCronJobRepository,
+    create_cron_tables,
+    cron_job,
+    seed_cron_jobs,
+)
+from hexcore.infrastructure.repositories.base import BaseSQLAlchemyRepository  # noqa: E402
+from hexcore.infrastructure.repositories.orms.sqlalchemy import Base, BaseModel  # noqa: E402
+from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (  # noqa: E402
+    dispose_engine,
+    init_engine,
+)
+from hexcore.infrastructure.uow.scopes import session_scope  # noqa: E402
+
+SQLITE_URL = "sqlite+aiosqlite:///:memory:"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _fresh_engine():
+    asyncio.run(dispose_engine())
+    yield
+    asyncio.run(dispose_engine())
+
+
+async def _prepare() -> SqlAlchemyCronJobRepository:
+    # `:memory:` con aiosqlite necesita StaticPool para que todas las sesiones vean la
+    # misma base; si no, cada conexión estrena una BD vacía.
+    from sqlalchemy.pool import StaticPool
+
+    init_engine(SQLITE_URL, poolclass=StaticPool)
+    await create_cron_tables()
+    return SqlAlchemyCronJobRepository()
+
+
+def _definition(job_id: str, cron: str = "0 3 * * *", **kwargs) -> CronJobDefinition:
+    defaults = dict(job_id=job_id, task_name=f"app.tasks.{job_id}", cron_expression=cron)
+    defaults.update(kwargs)
+    return CronJobDefinition(**defaults)  # type: ignore[arg-type]
+
+
+# ── Los dos detalles que la librería debe encapsular ───────────────────────────
+
+
+def test_cron_model_does_not_inherit_domain_base_model():
+    """
+    Si heredara de `BaseModel[T]`, el `collect_domain_entities()` del UoW intentaría
+    sacarle una entidad de dominio y explotaría.
+    """
+    assert not issubclass(CronJobModel, BaseModel)
+    assert issubclass(CronJobModel, Base)
+
+
+def test_cron_repository_does_not_inherit_the_domain_repository_base():
+    """
+    Si heredara de `BaseSQLAlchemyRepository`, el auto-discovery lo inyectaría en todos
+    los UoW como si fuera un repositorio de dominio.
+    """
+    assert not issubclass(SqlAlchemyCronJobRepository, BaseSQLAlchemyRepository)
+    assert issubclass(SqlAlchemyCronJobRepository, ICronJobRepository)
+
+
+def test_cron_repository_is_not_picked_up_by_auto_discovery():
+    from hexcore.infrastructure.repositories.utils import _get_all_subclasses
+
+    discovered = _get_all_subclasses(BaseSQLAlchemyRepository)
+
+    assert SqlAlchemyCronJobRepository not in discovered
+
+
+def test_custom_table_name_via_the_mixin():
+    class CustomCronJob(CronJobModelMixin, Base):
+        __tablename__ = "mis_cron_jobs"
+
+    assert CustomCronJob.__tablename__ == "mis_cron_jobs"
+    assert "job_id" in CustomCronJob.__table__.columns
+    assert "payload" in CustomCronJob.__table__.columns
+
+
+# ── Repositorio ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_get_active_jobs_returns_definitions():
+    repo = await _prepare()
+    await seed_cron_jobs([_definition("close_books"), _definition("purge_logs")])
+
+    jobs = await repo.get_active_jobs()
+
+    assert {job.job_id for job in jobs} == {"close_books", "purge_logs"}
+    assert all(isinstance(job, CronJobDefinition) for job in jobs)
+
+
+@pytest.mark.anyio
+async def test_get_active_jobs_excludes_inactive():
+    repo = await _prepare()
+    await seed_cron_jobs(
+        [_definition("active_one"), _definition("inactive_one", is_active=False)]
+    )
+
+    jobs = await repo.get_active_jobs()
+
+    assert [job.job_id for job in jobs] == ["active_one"]
+
+
+@pytest.mark.anyio
+async def test_get_all_jobs_includes_inactive():
+    repo = await _prepare()
+    await seed_cron_jobs(
+        [_definition("a"), _definition("b", is_active=False)]
+    )
+
+    assert {job.job_id for job in await repo.get_all_jobs()} == {"a", "b"}
+
+
+@pytest.mark.anyio
+async def test_update_last_run_persists():
+    repo = await _prepare()
+    await seed_cron_jobs([_definition("close_books")])
+    moment = datetime(2026, 7, 29, 3, 0, tzinfo=timezone.utc)
+
+    await repo.update_last_run("close_books", moment)
+
+    job = (await repo.get_active_jobs())[0]
+    assert job.last_run_at is not None
+    assert job.last_run_at.replace(tzinfo=timezone.utc) == moment
+
+
+@pytest.mark.anyio
+async def test_update_last_run_normalizes_naive_datetimes():
+    repo = await _prepare()
+    await seed_cron_jobs([_definition("close_books")])
+
+    await repo.update_last_run("close_books", datetime(2026, 7, 29, 3, 0))
+
+    job = (await repo.get_active_jobs())[0]
+    assert job.last_run_at is not None
+
+
+@pytest.mark.anyio
+async def test_set_active_toggles_the_job():
+    repo = await _prepare()
+    await seed_cron_jobs([_definition("toggle_me")])
+
+    await repo.set_active("toggle_me", False)
+    assert await repo.get_active_jobs() == []
+
+    await repo.set_active("toggle_me", True)
+    assert len(await repo.get_active_jobs()) == 1
+
+
+@pytest.mark.anyio
+async def test_payload_round_trips():
+    repo = await _prepare()
+    await seed_cron_jobs([_definition("with_payload", payload={"days": 30, "dry": True})])
+
+    job = (await repo.get_active_jobs())[0]
+
+    assert job.payload == {"days": 30, "dry": True}
+
+
+@pytest.mark.anyio
+async def test_repository_accepts_an_injected_session_scope():
+    from sqlalchemy.pool import StaticPool
+
+    init_engine(SQLITE_URL, poolclass=StaticPool)
+    await create_cron_tables()
+    calls: list[int] = []
+
+    def scope():
+        calls.append(1)
+        return session_scope()
+
+    repo = SqlAlchemyCronJobRepository(session_scope=scope)
+    await repo.get_active_jobs()
+
+    assert calls == [1]
+
+
+# ── Seed idempotente y no destructivo ──────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_seed_is_idempotent():
+    await _prepare()
+    definitions = [_definition("a"), _definition("b")]
+
+    assert await seed_cron_jobs(definitions) == 2
+    assert await seed_cron_jobs(definitions) == 0
+
+
+@pytest.mark.anyio
+async def test_seed_only_inserts_the_missing_ones():
+    await _prepare()
+    await seed_cron_jobs([_definition("a")])
+
+    assert await seed_cron_jobs([_definition("a"), _definition("b")]) == 1
+
+
+@pytest.mark.anyio
+async def test_seed_does_not_overwrite_edits_made_in_the_database():
+    """
+    El sentido de la tabla es editar el cron en caliente: un seed que sobrescribiera
+    revertiría en cada deploy los cambios hechos a propósito.
+    """
+    repo = await _prepare()
+    await seed_cron_jobs([_definition("nightly", cron="0 3 * * *")])
+
+    async with session_scope() as session:
+        row = await session.get(CronJobModel, "nightly")
+        assert row is not None
+        row.cron_expression = "0 5 * * *"
+        row.is_active = False
+        await session.commit()
+
+    # Volver a sembrar la definición original no debe deshacer la edición.
+    assert await seed_cron_jobs([_definition("nightly", cron="0 3 * * *")]) == 0
+
+    jobs = await repo.get_all_jobs()
+    assert jobs[0].cron_expression == "0 5 * * *"
+    assert jobs[0].is_active is False
+
+
+@pytest.mark.anyio
+async def test_seed_with_an_empty_list_is_a_noop():
+    await _prepare()
+
+    assert await seed_cron_jobs([]) == 0
+
+
+@pytest.mark.anyio
+async def test_concurrent_seeds_do_not_duplicate():
+    """Dos réplicas sembrando en el mismo arranque."""
+    await _prepare()
+    definitions = [_definition("a"), _definition("b")]
+
+    inserted = await asyncio.gather(
+        seed_cron_jobs(definitions),
+        seed_cron_jobs(definitions),
+        return_exceptions=True,
+    )
+
+    successes = [n for n in inserted if isinstance(n, int)]
+    assert sum(successes) <= 2
+
+    repo = SqlAlchemyCronJobRepository()
+    assert len(await repo.get_all_jobs()) == 2
+
+
+# ── cron_job(): el task_name se deriva, no se escribe ──────────────────────────
+
+
+@background_task(queue="maintenance")
+async def scheduled_cleanup(days: int = 30) -> None:  # pragma: no cover
+    ...
+
+
+def test_cron_job_derives_task_name_and_queue_from_the_decorator():
+    definition = cron_job(scheduled_cleanup, "0 4 * * *", payload={"days": 7})
+
+    assert definition.task_name == f"{__name__}.scheduled_cleanup"
+    assert definition.job_id == definition.task_name
+    assert definition.queue == "maintenance"
+    assert definition.payload == {"days": 7}
+    assert definition.cron_expression == "0 4 * * *"
+
+
+def test_cron_job_allows_overriding_job_id_and_queue():
+    definition = cron_job(
+        scheduled_cleanup, "0 4 * * *", job_id="nightly-cleanup", queue="low"
+    )
+
+    assert definition.job_id == "nightly-cleanup"
+    assert definition.queue == "low"
+
+
+def test_cron_job_rejects_an_undecorated_function():
+    async def not_decorated() -> None:  # pragma: no cover
+        ...
+
+    with pytest.raises(ValueError, match="background_task"):
+        cron_job(not_decorated, "0 4 * * *")
+
+
+@pytest.mark.anyio
+async def test_cron_job_definitions_are_seedable():
+    repo = await _prepare()
+
+    assert await seed_cron_jobs([cron_job(scheduled_cleanup, "0 4 * * *")]) == 1
+
+    job = (await repo.get_active_jobs())[0]
+    assert job.task_name == f"{__name__}.scheduled_cleanup"
+    assert job.queue == "maintenance"
+
+
+# ── Integración con el scheduler ───────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_scheduler_can_drive_the_sql_repository():
+    from hexcore.application.cqrs.scheduler import DynamicScheduler
+    from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
+
+    repo = await _prepare()
+    await seed_cron_jobs([_definition("every_minute", cron="* * * * *")])
+
+    class Spy(ITaskEnqueuer):
+        def __init__(self) -> None:
+            self.tasks: list[str] = []
+
+        async def enqueue_command(self, *a, **k) -> None: ...
+        async def enqueue_event(self, *a, **k) -> None: ...
+        async def enqueue_handler(self, *a, **k) -> None: ...
+
+        async def enqueue_task(self, task_name: str, payload: dict, queue: str) -> None:
+            self.tasks.append(task_name)
+
+    enqueuer = Spy()
+    scheduler = DynamicScheduler(
+        repository=repo, enqueuer=enqueuer, tick_interval_seconds=3600
+    )
+
+    task = asyncio.create_task(scheduler.start())
+    await asyncio.sleep(0.1)
+    scheduler.stop()
+    await asyncio.wait_for(task, timeout=2)
+
+    assert enqueuer.tasks == ["app.tasks.every_minute"]
+    # El scheduler marcó la ejecución en la tabla real.
+    assert (await repo.get_active_jobs())[0].last_run_at is not None

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -9,6 +9,13 @@ import pytest
     ("beanie", "hexcore.infrastructure.repositories.implementations"),
     ("sqlalchemy", "hexcore.infrastructure.repositories.utils"),
     ("beanie", "hexcore.infrastructure.repositories.utils"),
+    # Los scopes de F3 no deben arrastrar SQLAlchemy en import time.
+    ("sqlalchemy", "hexcore.infrastructure.uow.scopes"),
+    # El módulo de contexto y el de resolución de FQN son stdlib puro.
+    ("sqlalchemy", "hexcore.domain.cqrs.context"),
+    ("sqlalchemy", "hexcore.domain.cqrs.resolution"),
+    ("fastapi", "hexcore.domain.cqrs"),
+    ("fastapi", "hexcore.application.cqrs"),
 ])
 def test_optional_dependencies_do_not_crash_imports(module_to_hide, module_to_import):
     """

--- a/tests/test_query_cursor_and_endpoint.py
+++ b/tests/test_query_cursor_and_endpoint.py
@@ -1,0 +1,504 @@
+"""
+F10 (mejoras a `build_query_endpoint`) y F15 (paginación por cursor).
+"""
+from __future__ import annotations
+
+import asyncio
+import typing as t
+from datetime import datetime, timedelta, timezone
+from uuid import uuid4
+
+import pytest
+
+pytest.importorskip("fastapi")
+pytest.importorskip("httpx")
+
+from fastapi import APIRouter, Depends, FastAPI, HTTPException  # noqa: E402
+from fastapi.testclient import TestClient  # noqa: E402
+
+from hexcore.application.dtos.cursor import (  # noqa: E402
+    CursorPageDTO,
+    CursorRequestDTO,
+    InvalidCursorError,
+    decode_cursor,
+    encode_cursor,
+)
+from hexcore.application.dtos.errors import UnsupportedQueryFieldError  # noqa: E402
+from hexcore.application.dtos.query import (  # noqa: E402
+    QueryRequestDTO,
+    QueryResponseDTO,
+    SortDirection,
+)
+from hexcore.infrastructure.api.utils import (  # noqa: E402
+    build_query_endpoint,
+    register_query_endpoint,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# ── F15: el cursor opaco ───────────────────────────────────────────────────────
+
+
+def test_cursor_round_trips_a_datetime_and_a_uuid():
+    moment = datetime(2026, 7, 29, 3, 0, tzinfo=timezone.utc)
+    entity_id = uuid4()
+
+    sort_value, decoded_id = decode_cursor(encode_cursor(moment, entity_id))
+
+    assert sort_value == moment.isoformat()
+    assert decoded_id == str(entity_id)
+
+
+def test_cursor_round_trips_scalars():
+    assert decode_cursor(encode_cursor(42, 7)) == (42, 7)
+    assert decode_cursor(encode_cursor("abc", "def")) == ("abc", "def")
+    assert decode_cursor(encode_cursor(None, 1)) == (None, 1)
+
+
+def test_cursor_is_opaque_and_url_safe():
+    cursor = encode_cursor(datetime(2026, 1, 1, tzinfo=timezone.utc), uuid4())
+
+    assert "2026" not in cursor
+    assert "=" not in cursor
+    assert "/" not in cursor and "+" not in cursor
+
+
+@pytest.mark.parametrize(
+    "bad", ["", "!!!!", "bm90LWpzb24", "eyJ4IjogMX0"]
+)
+def test_invalid_cursor_raises_a_value_error(bad):
+    with pytest.raises(InvalidCursorError):
+        decode_cursor(bad)
+
+
+def test_invalid_cursor_error_is_a_value_error():
+    """Así los handlers de F5 lo traducen a 422 sin configuración extra."""
+    assert issubclass(InvalidCursorError, ValueError)
+
+
+def test_cursor_page_dto_defaults():
+    page: CursorPageDTO[int] = CursorPageDTO()
+
+    assert page.items == []
+    assert page.next_cursor is None
+
+
+def test_cursor_page_dto_is_generic_and_serializable():
+    page = CursorPageDTO[int](items=[1, 2, 3], next_cursor="abc")
+
+    assert page.model_dump() == {"items": [1, 2, 3], "next_cursor": "abc"}
+
+
+def test_query_response_dto_is_untouched():
+    """F15 se añade, no sustituye."""
+    response = QueryResponseDTO(items=[1], total=1, limit=50, offset=0)
+
+    assert response.total == 1
+    assert not hasattr(response, "next_cursor")
+
+
+# ── F15: recorrido real sobre SQLite ───────────────────────────────────────────
+
+
+sqlalchemy = pytest.importorskip("sqlalchemy")
+pytest.importorskip("aiosqlite")
+
+from sqlalchemy import DateTime, Integer, String  # noqa: E402
+from sqlalchemy.orm import Mapped, mapped_column  # noqa: E402
+from sqlalchemy.pool import StaticPool  # noqa: E402
+
+from hexcore.infrastructure.repositories.orms.sqlalchemy import Base  # noqa: E402
+from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (  # noqa: E402
+    dispose_engine,
+    get_session_factory,
+    init_engine,
+)
+
+
+# A nivel de módulo: SQLAlchemy resuelve las anotaciones `Mapped[...]` contra los
+# globals del módulo, así que un modelo definido dentro de una función falla con
+# `from __future__ import annotations`.
+class Ticket(Base):
+    __tablename__ = "f15_tickets"
+
+    id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    title: Mapped[str] = mapped_column(String(50))
+    created_at: Mapped[datetime] = mapped_column(DateTime(timezone=True))
+
+
+@pytest.fixture
+def sqlite_cursor_setup():
+    asyncio.run(dispose_engine())
+
+    async def _prepare():
+        engine = init_engine("sqlite+aiosqlite:///:memory:", poolclass=StaticPool)
+        async with engine.begin() as connection:
+            await connection.run_sync(Base.metadata.create_all, tables=[Ticket.__table__])
+
+        base = datetime(2026, 7, 1, tzinfo=timezone.utc)
+        factory = get_session_factory()
+        async with factory() as session:
+            for i in range(10):
+                session.add(
+                    Ticket(id=i + 1, title=f"t{i + 1}", created_at=base + timedelta(days=i))
+                )
+            await session.commit()
+
+    asyncio.run(_prepare())
+    yield Ticket
+    asyncio.run(dispose_engine())
+
+
+@pytest.mark.anyio
+async def test_cursor_pagination_walks_every_row_exactly_once(sqlite_cursor_setup):
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (
+        get_session_factory,
+    )
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.utils import db_query_cursor
+
+    Ticket = sqlite_cursor_setup
+    seen: list[int] = []
+    cursor: str | None = None
+    factory = get_session_factory()
+
+    for _ in range(10):  # tope de seguridad
+        async with factory() as session:
+            rows, cursor = await db_query_cursor(
+                session,
+                Ticket,
+                CursorRequestDTO(limit=3, cursor=cursor, direction=SortDirection.ASC),
+            )
+        seen.extend(row.id for row in rows)
+        if cursor is None:
+            break
+
+    assert seen == list(range(1, 11)), "se saltaron o repitieron filas"
+    assert cursor is None
+
+
+@pytest.mark.anyio
+async def test_cursor_pagination_descending(sqlite_cursor_setup):
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (
+        get_session_factory,
+    )
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.utils import db_query_cursor
+
+    Ticket = sqlite_cursor_setup
+    seen: list[int] = []
+    cursor: str | None = None
+    factory = get_session_factory()
+
+    for _ in range(10):
+        async with factory() as session:
+            rows, cursor = await db_query_cursor(
+                session,
+                Ticket,
+                CursorRequestDTO(limit=4, cursor=cursor, direction=SortDirection.DESC),
+            )
+        seen.extend(row.id for row in rows)
+        if cursor is None:
+            break
+
+    assert seen == list(range(10, 0, -1))
+
+
+@pytest.mark.anyio
+async def test_last_page_returns_no_cursor(sqlite_cursor_setup):
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (
+        get_session_factory,
+    )
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.utils import db_query_cursor
+
+    Ticket = sqlite_cursor_setup
+    factory = get_session_factory()
+
+    async with factory() as session:
+        rows, cursor = await db_query_cursor(
+            session, Ticket, CursorRequestDTO(limit=50, direction=SortDirection.ASC)
+        )
+
+    assert len(rows) == 10
+    assert cursor is None, "hay next_cursor sin más páginas"
+
+
+@pytest.mark.anyio
+async def test_ties_on_the_sort_field_are_broken_by_id(sqlite_cursor_setup):
+    """Sin el desempate por id, las filas con el mismo created_at se pierden."""
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (
+        get_session_factory,
+    )
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.utils import db_query_cursor
+
+    Ticket = sqlite_cursor_setup
+    factory = get_session_factory()
+    same_moment = datetime(2026, 12, 1, tzinfo=timezone.utc)
+
+    async with factory() as session:
+        for i in range(5):
+            session.add(Ticket(id=100 + i, title=f"tie{i}", created_at=same_moment))
+        await session.commit()
+
+    seen: list[int] = []
+    cursor: str | None = None
+    for _ in range(20):
+        async with factory() as session:
+            rows, cursor = await db_query_cursor(
+                session,
+                Ticket,
+                CursorRequestDTO(limit=2, cursor=cursor, direction=SortDirection.ASC),
+            )
+        seen.extend(row.id for row in rows)
+        if cursor is None:
+            break
+
+    assert sorted(seen) == sorted(list(range(1, 11)) + list(range(100, 105)))
+    assert len(seen) == len(set(seen)), "se repitieron filas entre páginas"
+
+
+@pytest.mark.anyio
+async def test_cursor_respects_filters(sqlite_cursor_setup):
+    from hexcore.application.dtos.query import FilterConditionDTO, FilterOperator
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (
+        get_session_factory,
+    )
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.utils import db_query_cursor
+
+    Ticket = sqlite_cursor_setup
+    factory = get_session_factory()
+
+    async with factory() as session:
+        rows, _cursor = await db_query_cursor(
+            session,
+            Ticket,
+            CursorRequestDTO(
+                limit=50,
+                direction=SortDirection.ASC,
+                filters=[
+                    FilterConditionDTO(
+                        field="id", operator=FilterOperator.LTE, value=3
+                    )
+                ],
+            ),
+        )
+
+    assert [row.id for row in rows] == [1, 2, 3]
+
+
+@pytest.mark.anyio
+async def test_cursor_rejects_an_unknown_sort_field(sqlite_cursor_setup):
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (
+        get_session_factory,
+    )
+    from hexcore.infrastructure.repositories.orms.sqlalchemy.utils import db_query_cursor
+
+    Ticket = sqlite_cursor_setup
+    factory = get_session_factory()
+
+    async with factory() as session:
+        with pytest.raises(UnsupportedQueryFieldError):
+            await db_query_cursor(
+                session, Ticket, CursorRequestDTO(sort_field="no_existe")
+            )
+
+
+# ── F10: errores de campo estructurados ────────────────────────────────────────
+
+
+def test_unsupported_field_error_carries_field_and_allowed():
+    error = UnsupportedQueryFieldError("nope", "orden", allowed=["id", "title"])
+
+    assert isinstance(error, ValueError)
+    assert error.field == "nope"
+    assert error.allowed == ["id", "title"]
+    assert str(error) == "Campo de orden no soportado: nope"
+
+
+@pytest.mark.anyio
+async def test_endpoint_returns_a_structured_422_with_field_and_allowed():
+    class FailingUseCase:
+        async def execute(self, _query: QueryRequestDTO) -> QueryResponseDTO:
+            raise UnsupportedQueryFieldError("nope", "orden", allowed=["id", "title"])
+
+    endpoint = build_query_endpoint(t.cast(t.Any, lambda: FailingUseCase()))
+
+    with pytest.raises(HTTPException) as exc:
+        await endpoint(
+            limit=10, offset=0, search=None, search_fields=[], filters=[], sort=[]
+        )
+
+    assert exc.value.status_code == 422
+    assert exc.value.detail == {
+        "message": "Campo de orden no soportado: nope",
+        "field": "nope",
+        "allowed": ["id", "title"],
+    }
+
+
+# ── F10: dependencias, response_model y parámetros extra ───────────────────────
+
+
+class StubUseCase:
+    def __init__(self, **kwargs: t.Any) -> None:
+        self.kwargs = kwargs
+
+    async def execute(self, query: QueryRequestDTO) -> QueryResponseDTO:
+        return QueryResponseDTO(
+            items=[], total=0, limit=query.limit, offset=query.offset
+        )
+
+
+def test_register_query_endpoint_accepts_route_dependencies():
+    """Sin esto, un endpoint que necesita auth no podía usar el helper."""
+    calls: list[str] = []
+
+    async def guard() -> None:
+        calls.append("checked")
+
+    router = APIRouter()
+    register_query_endpoint(
+        router,
+        path="/entities",
+        use_case_factory=t.cast(t.Any, lambda: StubUseCase()),
+        dependencies=[Depends(guard)],
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        assert client.get("/entities").status_code == 200
+
+    assert calls == ["checked"]
+
+
+def test_route_dependency_can_reject_the_request():
+    async def deny() -> None:
+        raise HTTPException(status_code=401, detail="sin token")
+
+    router = APIRouter()
+    register_query_endpoint(
+        router,
+        path="/entities",
+        use_case_factory=t.cast(t.Any, lambda: StubUseCase()),
+        dependencies=[Depends(deny)],
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        assert client.get("/entities").status_code == 401
+
+
+def test_register_query_endpoint_accepts_a_custom_response_model():
+    class NarrowResponse(QueryResponseDTO):
+        pass
+
+    router = APIRouter()
+    register_query_endpoint(
+        router,
+        path="/entities",
+        use_case_factory=t.cast(t.Any, lambda: StubUseCase()),
+        response_model=NarrowResponse,
+    )
+
+    route = next(r for r in router.routes if getattr(r, "path", None) == "/entities")
+    assert t.cast(t.Any, route).response_model is NarrowResponse
+
+
+def test_extra_params_appear_in_the_signature_and_reach_the_factory():
+    received: list[t.Any] = []
+
+    async def get_tenant() -> str:
+        return "acme"
+
+    def factory(**kwargs: t.Any) -> StubUseCase:
+        received.append(kwargs)
+        return StubUseCase(**kwargs)
+
+    router = APIRouter()
+    register_query_endpoint(
+        router,
+        path="/entities",
+        use_case_factory=t.cast(t.Any, factory),
+        extra_params={"tenant": Depends(get_tenant)},
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        assert client.get("/entities").status_code == 200
+
+    assert received == [{"tenant": "acme"}]
+
+
+def test_a_factory_without_arguments_still_works_with_extra_params():
+    """El caso habitual: `lambda: MiUseCase(...)` sin kwargs."""
+    router = APIRouter()
+
+    async def get_tenant() -> str:
+        return "acme"
+
+    register_query_endpoint(
+        router,
+        path="/entities",
+        use_case_factory=t.cast(t.Any, lambda: StubUseCase()),
+        extra_params={"tenant": Depends(get_tenant)},
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        assert client.get("/entities").status_code == 200
+
+
+def test_extra_params_are_documented_in_openapi():
+    router = APIRouter()
+    register_query_endpoint(
+        router,
+        path="/entities",
+        use_case_factory=t.cast(t.Any, lambda: StubUseCase()),
+        extra_params={"tenant": None},
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    parameters = app.openapi()["paths"]["/entities"]["get"]["parameters"]
+    assert any(p["name"] == "tenant" for p in parameters)
+
+
+# ── F10: los defaults mutables ─────────────────────────────────────────────────
+
+
+def test_list_query_params_do_not_share_a_mutable_default():
+    import inspect
+
+    signature = inspect.signature(build_query_endpoint(t.cast(t.Any, lambda: StubUseCase())))
+    for name in ("search_fields", "filters", "sort"):
+        default = signature.parameters[name].default
+        assert default.default_factory is list, f"{name} usa una lista mutable"
+
+
+def test_list_query_params_still_work_over_http():
+    router = APIRouter()
+    captured: list[QueryRequestDTO] = []
+
+    class Capturing:
+        async def execute(self, query: QueryRequestDTO) -> QueryResponseDTO:
+            captured.append(query)
+            return QueryResponseDTO()
+
+    register_query_endpoint(
+        router, path="/entities", use_case_factory=t.cast(t.Any, lambda: Capturing())
+    )
+    app = FastAPI()
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        client.get("/entities?sort=id:asc&search_fields=title&search=abc")
+
+    assert captured[0].search == "abc"
+    assert captured[0].search_fields == ["title"]
+    assert captured[0].sort[0].field == "id"

--- a/tests/test_testing_utilities.py
+++ b/tests/test_testing_utilities.py
@@ -1,0 +1,330 @@
+"""
+F9: utilidades de test publicadas en `hexcore.testing`.
+
+Requisito del plan: el import no debe requerir dependencias opcionales duras.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+import typing as t
+
+import pytest
+
+from hexcore.application.cqrs.registry import HandlerRegistry
+from hexcore.domain.cqrs.commands import Command
+from hexcore.domain.cqrs.decorators import background_command, background_handler
+from hexcore.domain.events import DomainEvent
+from hexcore.testing import (
+    FakeLockProvider,
+    InMemoryTaskEnqueuer,
+    RecordedEnqueue,
+    build_test_buses,
+    override_cqrs,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@background_command(queue="emails")
+class SendEmail(Command):
+    to: str
+
+
+class SendEmailHandler:
+    async def handle(self, cmd: SendEmail) -> None: ...
+
+
+class PlainCommand(Command):
+    value: str
+
+
+class PlainHandler:
+    async def handle(self, cmd: PlainCommand) -> str:
+        return f"ok:{cmd.value}"
+
+
+class SomethingHappened(DomainEvent):
+    info: str
+
+
+@background_handler(queue="analytics")
+async def on_something(event: SomethingHappened) -> None: ...
+
+
+# ── InMemoryTaskEnqueuer ───────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_enqueuer_records_commands_with_their_queue():
+    buses = build_test_buses()
+    buses.registry.register_command_handler(SendEmail, SendEmailHandler())
+
+    await buses.command_bus.dispatch(SendEmail(to="a@b.c"))
+
+    assert buses.enqueuer.command_names == ["SendEmail"]
+    assert buses.enqueuer.commands[0].queue == "emails"
+    assert buses.enqueuer.commands[0].payload["__data__"]["to"] == "a@b.c"
+
+
+@pytest.mark.anyio
+async def test_enqueuer_records_handlers():
+    buses = build_test_buses()
+    buses.event_bus.subscribe(SomethingHappened, on_something)
+
+    await buses.event_bus.publish(SomethingHappened(info="x"))
+
+    assert len(buses.enqueuer.handlers) == 1
+    assert buses.enqueuer.handlers[0].queue == "analytics"
+
+
+@pytest.mark.anyio
+async def test_enqueuer_separates_the_four_kinds():
+    enqueuer = InMemoryTaskEnqueuer()
+
+    await enqueuer.enqueue_command("C", {}, "q1")
+    await enqueuer.enqueue_event("E", {}, "q2")
+    await enqueuer.enqueue_handler("H", {}, "q3")
+    await enqueuer.enqueue_task("T", {}, "q4")
+
+    assert enqueuer.command_names == ["C"]
+    assert [e.name for e in enqueuer.events] == ["E"]
+    assert enqueuer.handler_names == ["H"]
+    assert enqueuer.task_names == ["T"]
+    assert len(enqueuer) == 4
+
+
+@pytest.mark.anyio
+async def test_enqueuer_can_be_told_to_fail():
+    enqueuer = InMemoryTaskEnqueuer(fail_on={"Boom"})
+
+    await enqueuer.enqueue_command("Fine", {}, "q")
+    with pytest.raises(RuntimeError, match="Boom"):
+        await enqueuer.enqueue_command("Boom", {}, "q")
+
+    assert enqueuer.command_names == ["Fine"]
+
+
+@pytest.mark.anyio
+async def test_enqueuer_clear():
+    enqueuer = InMemoryTaskEnqueuer()
+    await enqueuer.enqueue_task("T", {}, "q")
+
+    enqueuer.clear()
+
+    assert len(enqueuer) == 0
+
+
+def test_recorded_enqueue_is_comparable():
+    assert RecordedEnqueue("task", "T") == RecordedEnqueue("task", "T")
+
+
+# ── FakeLockProvider ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_fake_lock_grants_by_default():
+    lock = FakeLockProvider()
+
+    assert await lock.acquire_lock("k", 60) is True
+    assert await lock.acquire_lock("k", 60) is True
+    assert lock.acquired == ["k", "k"]
+
+
+@pytest.mark.anyio
+async def test_fake_lock_can_always_deny():
+    lock = FakeLockProvider(grant=False)
+
+    assert await lock.acquire_lock("k", 60) is False
+
+
+@pytest.mark.anyio
+async def test_fake_lock_shared_mode_behaves_like_a_real_lock():
+    lock = FakeLockProvider(shared=True)
+
+    assert await lock.acquire_lock("k", 60) is True
+    assert await lock.acquire_lock("k", 60) is False
+    assert await lock.acquire_lock("otra", 60) is True
+
+    await lock.release_lock("k")
+    assert await lock.acquire_lock("k", 60) is True
+
+
+@pytest.mark.anyio
+async def test_fake_lock_can_raise():
+    lock = FakeLockProvider(raise_on_acquire=ConnectionError("redis down"))
+
+    with pytest.raises(ConnectionError):
+        await lock.acquire_lock("k", 60)
+
+
+@pytest.mark.anyio
+async def test_fake_lock_records_releases():
+    lock = FakeLockProvider()
+    await lock.release_lock("k")
+
+    assert lock.released == ["k"]
+
+
+# ── build_test_buses ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_build_test_buses_is_ready_for_smart_routing():
+    """El error más común al testear CQRS: bus sin enqueuer ni serializer."""
+    buses = build_test_buses()
+    buses.registry.register_command_handler(SendEmail, SendEmailHandler())
+
+    await buses.command_bus.dispatch(SendEmail(to="x@y.z"))  # no debe lanzar
+
+
+@pytest.mark.anyio
+async def test_build_test_buses_executes_plain_commands():
+    buses = build_test_buses()
+    buses.registry.register_command_handler(PlainCommand, PlainHandler())
+
+    assert await buses.command_bus.dispatch(PlainCommand(value="v")) == "ok:v"
+
+
+def test_build_test_buses_accepts_an_existing_registry():
+    registry = HandlerRegistry()
+    buses = build_test_buses(registry)
+
+    assert buses.registry is registry
+
+
+def test_build_test_buses_shares_the_serializer_across_buses():
+    buses = build_test_buses()
+
+    assert buses.command_bus._serializer is buses.serializer
+    assert buses.event_bus._serializer is buses.serializer
+
+
+# ── override_cqrs ──────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_override_cqrs_replaces_and_restores():
+    pytest.importorskip("fastapi")
+    pytest.importorskip("httpx")
+
+    from fastapi import Depends, FastAPI
+    from fastapi.testclient import TestClient
+
+    from hexcore.application.cqrs.config import CQRSConfig
+    from hexcore.domain.cqrs.buses import AbstractCommandBus
+    from hexcore.infrastructure.api.cqrs import (
+        configure_cqrs,
+        provide_command_bus,
+        reset_cqrs,
+    )
+
+    registry = HandlerRegistry()
+    registry.register_command_handler(PlainCommand, PlainHandler())
+    configure_cqrs(registry, config=CQRSConfig())
+
+    app = FastAPI()
+
+    @app.get("/run")
+    async def run(
+        bus: AbstractCommandBus = Depends(provide_command_bus),
+    ) -> dict[str, t.Any]:
+        return {"result": await bus.dispatch(PlainCommand(value="v"))}
+
+    try:
+        buses = build_test_buses()
+        buses.registry.register_command_handler(PlainCommand, PlainHandler())
+
+        with TestClient(app) as client:
+            with override_cqrs(app, command_bus=buses.command_bus):
+                assert client.get("/run").json() == {"result": "ok:v"}
+                assert provide_command_bus in app.dependency_overrides
+
+            # Restaurado al salir: si no, el override se filtra a los demás tests.
+            assert provide_command_bus not in app.dependency_overrides
+            assert client.get("/run").json() == {"result": "ok:v"}
+    finally:
+        reset_cqrs()
+
+
+def test_override_cqrs_can_be_nested():
+    pytest.importorskip("fastapi")
+
+    from fastapi import FastAPI
+
+    from hexcore.infrastructure.api.cqrs import provide_command_bus
+
+    app = FastAPI()
+    outer = build_test_buses().command_bus
+    inner = build_test_buses().command_bus
+
+    with override_cqrs(app, command_bus=outer):
+        with override_cqrs(app, command_bus=inner):
+            assert app.dependency_overrides[provide_command_bus]() is inner
+        # El anidado no debe destruir el override externo.
+        assert app.dependency_overrides[provide_command_bus]() is outer
+
+    assert provide_command_bus not in app.dependency_overrides
+
+
+def test_override_cqrs_restores_even_if_the_block_raises():
+    pytest.importorskip("fastapi")
+
+    from fastapi import FastAPI
+
+    from hexcore.infrastructure.api.cqrs import provide_command_bus
+
+    app = FastAPI()
+
+    with pytest.raises(RuntimeError):
+        with override_cqrs(app, command_bus=build_test_buses().command_bus):
+            raise RuntimeError("boom")
+
+    assert provide_command_bus not in app.dependency_overrides
+
+
+# ── El requisito de import ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("hidden", ["fastapi", "sqlalchemy", "redis", "procrastinate"])
+def test_hexcore_testing_imports_without_optional_dependencies(hidden):
+    code = f"""
+import sys
+
+class Blocker:
+    @classmethod
+    def find_spec(cls, fullname, path, target=None):
+        if fullname.split(".")[0] == "{hidden}":
+            raise ImportError("bloqueado: " + fullname)
+        return None
+
+sys.meta_path.insert(0, Blocker)
+
+import hexcore.testing
+from hexcore.testing import InMemoryTaskEnqueuer, FakeLockProvider, build_test_buses
+assert InMemoryTaskEnqueuer() is not None
+assert FakeLockProvider() is not None
+print("ok")
+"""
+    import os
+
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "."
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, env=env
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_fixtures_module_is_importable():
+    """Se carga sólo cuando lo pides, pero tiene que cargar."""
+    import hexcore.testing.fixtures as fixtures
+
+    assert hasattr(fixtures, "cqrs_buses")
+    assert hasattr(fixtures, "sqlite_engine")
+    assert hasattr(fixtures, "uow")

--- a/tests/test_use_cases_query.py
+++ b/tests/test_use_cases_query.py
@@ -165,7 +165,9 @@ def test_build_query_endpoint_translates_value_error_to_http_422() -> None:
 
         assert raised is not None
         assert raised.status_code == 422
-        assert raised.detail == "Campo de filtro no soportado: typo"
+        # F10: el cuerpo pasa a ser estructurado. Con un ValueError pelado sólo hay
+        # `message`; con UnsupportedQueryFieldError llegan además `field` y `allowed`.
+        assert raised.detail == {"message": "Campo de filtro no soportado: typo"}
 
     asyncio.run(_run())
 

--- a/tests/test_worker_bus_integration.py
+++ b/tests/test_worker_bus_integration.py
@@ -145,6 +145,44 @@ async def test_worker_executes_background_command_instead_of_reenqueueing():
 
 
 @pytest.mark.anyio
+async def test_a_falsy_but_present_enqueuer_is_not_discarded():
+    """
+    El bus comprobaba `if not self._enqueuer`, así que un enqueuer que implemente
+    `__len__`/`__bool__` —un doble de test que cuenta lo encolado, por ejemplo— se
+    descartaba justo cuando estaba vacío, y el dispatch lanzaba RuntimeError.
+    """
+    class FalsyEnqueuer(SpyEnqueuer):
+        def __bool__(self) -> bool:
+            return False
+
+    registry = HandlerRegistry()
+    registry.register_command_handler(ReactiveCommand, ReactiveCommandHandler())
+    enqueuer = FalsyEnqueuer()
+    bus = InMemoryCommandBus(
+        registry=registry, enqueuer=enqueuer, serializer=PydanticSerializer()
+    )
+
+    await bus.dispatch(ReactiveCommand(value="x"))
+
+    assert [name for name, _p, _q in enqueuer.commands] == ["ReactiveCommand"]
+
+
+@pytest.mark.anyio
+async def test_a_falsy_but_present_enqueuer_is_not_discarded_by_the_event_bus():
+    class FalsyEnqueuer(SpyEnqueuer):
+        def __bool__(self) -> bool:
+            return False
+
+    enqueuer = FalsyEnqueuer()
+    event_bus = InMemoryEventBus(enqueuer=enqueuer, serializer=PydanticSerializer())
+    event_bus.subscribe(IntegrationEvent, on_integration_event)
+
+    await event_bus.publish(IntegrationEvent(info="x"))
+
+    assert len(enqueuer.handlers) == 1
+
+
+@pytest.mark.anyio
 async def test_same_bus_outside_worker_still_enqueues():
     """Fuera del worker, el mismo bus debe seguir encolando."""
     registry, enqueuer, _ser, bus, _evt, _consumer = _build()

--- a/tests/test_worker_runner.py
+++ b/tests/test_worker_runner.py
@@ -1,0 +1,363 @@
+"""
+F8: entrypoint del worker en una llamada, con muerte mutua y drenaje ordenado.
+
+La semántica clave: si **cualquiera** de los bucles muere, se cancela el otro y el
+proceso sale con error, para que el orquestador lo reinicie completo. Correr con un
+bucle caído (encolar sin consumir, o al revés) es peor que caerse.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from hexcore.infrastructure.workers.runner import (
+    WorkerDied,
+    run_cqrs_worker,
+    worker_loop,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class SpyLoop:
+    """Bucle que corre hasta que se le pide parar, y anota lo que le pasó."""
+
+    def __init__(self, name: str, *, fail_after: float | None = None) -> None:
+        self.name = name
+        self._stop_event = asyncio.Event()
+        self._fail_after = fail_after
+        self.ran = False
+        self.stopped = False
+        self.cancelled = False
+
+    async def run(self) -> None:
+        self.ran = True
+        try:
+            if self._fail_after is not None:
+                await asyncio.sleep(self._fail_after)
+                raise RuntimeError(f"{self.name} explotó")
+            await self._stop_event.wait()
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+
+    async def stop(self) -> None:
+        self.stopped = True
+        self._stop_event.set()
+
+
+class SilentlyExitingLoop:
+    """Bucle que retorna por su cuenta sin excepción: también es una muerte."""
+
+    name = "quitter"
+
+    def __init__(self) -> None:
+        self.stopped = False
+
+    async def run(self) -> None:
+        await asyncio.sleep(0.01)
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+# ── Muerte mutua ───────────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_a_dying_loop_takes_down_the_others_and_raises():
+    healthy = SpyLoop("healthy")
+    doomed = SpyLoop("doomed", fail_after=0.01)
+
+    with pytest.raises(WorkerDied) as exc:
+        await run_cqrs_worker(healthy, doomed, handle_signals=False)
+
+    assert "doomed" in str(exc.value)
+    assert isinstance(exc.value.__cause__, RuntimeError)
+    assert healthy.stopped is True, "el bucle sano no recibió el stop"
+
+
+@pytest.mark.anyio
+async def test_a_loop_that_returns_silently_also_kills_the_process():
+    healthy = SpyLoop("healthy")
+    quitter = SilentlyExitingLoop()
+
+    with pytest.raises(WorkerDied, match="quitter"):
+        await run_cqrs_worker(healthy, quitter, handle_signals=False)
+
+    assert healthy.stopped is True
+
+
+@pytest.mark.anyio
+async def test_the_original_exception_is_chained():
+    doomed = SpyLoop("doomed", fail_after=0.01)
+
+    with pytest.raises(WorkerDied) as exc:
+        await run_cqrs_worker(doomed, handle_signals=False)
+
+    assert str(exc.value.__cause__) == "doomed explotó"
+
+
+# ── Drenaje ordenado ───────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_stop_is_requested_before_cancelling():
+    loop = SpyLoop("graceful")
+
+    async def request_shutdown() -> None:
+        await asyncio.sleep(0.02)
+        await loop.stop()
+
+    asyncio.create_task(request_shutdown())
+
+    with pytest.raises(WorkerDied):
+        # El bucle termina limpiamente al recibir el stop; para el runner sigue siendo
+        # una muerte, porque un bucle no debe retornar en operación normal.
+        await run_cqrs_worker(loop, handle_signals=False)
+
+    assert loop.cancelled is False, "se canceló en vez de drenar"
+
+
+@pytest.mark.anyio
+async def test_a_loop_that_ignores_stop_is_cancelled_after_the_timeout():
+    class StubbornLoop:
+        name = "stubborn"
+
+        def __init__(self) -> None:
+            self.cancelled = False
+
+        async def run(self) -> None:
+            try:
+                await asyncio.sleep(3600)
+            except asyncio.CancelledError:
+                self.cancelled = True
+                raise
+
+        async def stop(self) -> None:
+            return None  # ignora la petición
+
+    stubborn = StubbornLoop()
+    doomed = SpyLoop("doomed", fail_after=0.01)
+
+    with pytest.raises(WorkerDied):
+        await run_cqrs_worker(
+            stubborn, doomed, handle_signals=False, drain_timeout=0.05
+        )
+
+    assert stubborn.cancelled is True
+
+
+@pytest.mark.anyio
+async def test_an_error_in_stop_does_not_hide_the_original_failure():
+    class BadStopLoop:
+        name = "bad-stop"
+
+        async def run(self) -> None:
+            await asyncio.sleep(3600)
+
+        async def stop(self) -> None:
+            raise RuntimeError("stop falló")
+
+    doomed = SpyLoop("doomed", fail_after=0.01)
+
+    with pytest.raises(WorkerDied, match="doomed"):
+        await run_cqrs_worker(
+            BadStopLoop(), doomed, handle_signals=False, drain_timeout=0.05
+        )
+
+
+# ── Hooks de arranque y apagado ────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_startup_hooks_run_in_order_before_the_loops():
+    order: list[str] = []
+
+    async def first() -> None:
+        order.append("first")
+
+    async def second() -> None:
+        order.append("second")
+
+    class RecordingLoop(SpyLoop):
+        async def run(self) -> None:
+            order.append("loop")
+            await super().run()
+
+    loop = RecordingLoop("recording", fail_after=0.01)
+
+    with pytest.raises(WorkerDied):
+        await run_cqrs_worker(
+            loop, on_startup=[first, second], handle_signals=False
+        )
+
+    assert order == ["first", "second", "loop"]
+
+
+@pytest.mark.anyio
+async def test_shutdown_hooks_run_in_declared_order():
+    order: list[str] = []
+
+    async def close_pool() -> None:
+        order.append("close_pool")
+
+    async def dispose_engine() -> None:
+        order.append("dispose_engine")
+
+    doomed = SpyLoop("doomed", fail_after=0.01)
+
+    with pytest.raises(WorkerDied):
+        await run_cqrs_worker(
+            doomed,
+            on_shutdown=[close_pool, dispose_engine],
+            handle_signals=False,
+        )
+
+    assert order == ["close_pool", "dispose_engine"]
+
+
+@pytest.mark.anyio
+async def test_shutdown_hooks_run_even_if_startup_failed():
+    order: list[str] = []
+
+    async def boom() -> None:
+        raise RuntimeError("no pude conectar a la BD")
+
+    async def cleanup() -> None:
+        order.append("cleanup")
+
+    loop = SpyLoop("never-runs")
+
+    with pytest.raises(RuntimeError, match="no pude conectar"):
+        await run_cqrs_worker(
+            loop, on_startup=[boom], on_shutdown=[cleanup], handle_signals=False
+        )
+
+    assert order == ["cleanup"]
+    assert loop.ran is False, "el bucle arrancó pese a que el startup falló"
+
+
+@pytest.mark.anyio
+async def test_a_failing_shutdown_hook_does_not_stop_the_others():
+    order: list[str] = []
+
+    async def bad() -> None:
+        raise RuntimeError("teardown roto")
+
+    async def good() -> None:
+        order.append("good")
+
+    doomed = SpyLoop("doomed", fail_after=0.01)
+
+    with pytest.raises(WorkerDied):
+        await run_cqrs_worker(
+            doomed, on_shutdown=[bad, good], handle_signals=False
+        )
+
+    assert order == ["good"]
+
+
+# ── Scheduler integrado ────────────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_scheduler_runs_alongside_the_loops_and_shares_their_fate():
+    from hexcore.application.cqrs.scheduler import DynamicScheduler
+    from hexcore.domain.cqrs.cron import ICronJobRepository
+    from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
+
+    class EmptyRepo(ICronJobRepository):
+        async def get_active_jobs(self):
+            return []
+
+        async def update_last_run(self, job_id, run_time) -> None: ...
+
+    class NoopEnqueuer(ITaskEnqueuer):
+        async def enqueue_command(self, *a, **k) -> None: ...
+        async def enqueue_event(self, *a, **k) -> None: ...
+        async def enqueue_handler(self, *a, **k) -> None: ...
+        async def enqueue_task(self, *a, **k) -> None: ...
+
+    scheduler = DynamicScheduler(
+        repository=EmptyRepo(), enqueuer=NoopEnqueuer(), tick_interval_seconds=3600
+    )
+    doomed = SpyLoop("doomed", fail_after=0.05)
+
+    with pytest.raises(WorkerDied, match="doomed"):
+        await run_cqrs_worker(doomed, scheduler=scheduler, handle_signals=False)
+
+    # El scheduler recibió el stop y su bucle terminó.
+    assert scheduler._stop_event.is_set()
+
+
+@pytest.mark.anyio
+async def test_a_dying_scheduler_kills_the_worker_loop():
+    class ExplodingScheduler:
+        def __init__(self) -> None:
+            self.stopped = False
+
+        async def start(self) -> None:
+            await asyncio.sleep(0.01)
+            raise RuntimeError("el repositorio de cron no responde")
+
+        def stop(self) -> None:
+            self.stopped = True
+
+    healthy = SpyLoop("healthy")
+
+    with pytest.raises(WorkerDied, match="scheduler"):
+        await run_cqrs_worker(
+            healthy,
+            scheduler=ExplodingScheduler(),  # type: ignore[arg-type]
+            handle_signals=False,
+        )
+
+    assert healthy.stopped is True
+
+
+# ── worker_loop() y validación ─────────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_worker_loop_adapts_a_plain_coroutine_pair():
+    events: list[str] = []
+    stop_event = asyncio.Event()
+
+    async def run() -> None:
+        events.append("run")
+        await stop_event.wait()
+
+    def stop() -> None:
+        events.append("stop")
+        stop_event.set()
+
+    loop = worker_loop("adapted", run, stop)
+    doomed = SpyLoop("doomed", fail_after=0.02)
+
+    with pytest.raises(WorkerDied):
+        await run_cqrs_worker(loop, doomed, handle_signals=False)
+
+    assert events == ["run", "stop"]
+
+
+@pytest.mark.anyio
+async def test_worker_loop_without_stop_is_cancelled():
+    async def run() -> None:
+        await asyncio.sleep(3600)
+
+    loop = worker_loop("no-stop", run)
+    doomed = SpyLoop("doomed", fail_after=0.01)
+
+    with pytest.raises(WorkerDied):
+        await run_cqrs_worker(loop, doomed, handle_signals=False, drain_timeout=0.05)
+
+
+@pytest.mark.anyio
+async def test_running_with_nothing_to_do_is_an_error():
+    with pytest.raises(ValueError, match="al menos un bucle"):
+        await run_cqrs_worker(handle_signals=False)

--- a/uv.lock
+++ b/uv.lock
@@ -186,6 +186,15 @@ wheels = [
 ]
 
 [[package]]
+name = "certifi"
+version = "2026.7.22"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a3/c2/24167ea9858356b47a87a50d39908bfdb72ceeefe0041586e704e5376b3a/certifi-2026.7.22.tar.gz", hash = "sha256:741e2c3b351ddf169a738da9f2c048608ff7f2c5cc02f1ebc6b118bb090d5d55", size = 138112, upload-time = "2026-07-22T03:35:12.644Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/a7/71ac2cff56fec219ed242bb11b8efb69fcc4bec75db06fb7bfe35de520e6/certifi-2026.7.22-py3-none-any.whl", hash = "sha256:62f22742b58a1a33014a2b6b706588a8d7e2a88ae7bd1a6ebe8c992928483775", size = 136983, upload-time = "2026-07-22T03:35:11.276Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.3"
 source = { registry = "https://pypi.org/simple" }
@@ -401,6 +410,15 @@ wheels = [
 ]
 
 [[package]]
+name = "h11"
+version = "0.16.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/01/ee/02a2c011bdab74c6fb3c75474d40b3052059d95df7e73351460c8588d963/h11-0.16.0.tar.gz", hash = "sha256:4e35b956cf45792e4caa5885e69fba00bdbc6ffafbfa020300e549b208ee5ff1", size = 101250, upload-time = "2025-04-24T03:35:25.427Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/4b/29cac41a4d98d144bf5f6d33995617b185d14b22401f75ca86f384e87ff1/h11-0.16.0-py3-none-any.whl", hash = "sha256:63cf8bbe7522de3bf65932fda1d9c2772064ffb3dae62d55932da54b31cb6c86", size = 37515, upload-time = "2025-04-24T03:35:24.344Z" },
+]
+
+[[package]]
 name = "hexcore"
 version = "2.0.6"
 source = { virtual = "." }
@@ -455,6 +473,7 @@ sql = [
 dev = [
     { name = "anyio" },
     { name = "commitizen" },
+    { name = "httpx" },
     { name = "pyright" },
     { name = "pytest" },
 ]
@@ -494,8 +513,37 @@ provides-extras = ["api", "redis", "mongo", "sql", "rabbitmq", "procrastinate", 
 dev = [
     { name = "anyio", specifier = ">=4.0.0" },
     { name = "commitizen", specifier = ">=4.9.1" },
+    { name = "httpx", specifier = ">=0.27.0" },
     { name = "pyright", specifier = ">=1.1.405" },
     { name = "pytest", specifier = ">=8.4.2" },
+]
+
+[[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
+name = "httpx"
+version = "0.28.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "anyio" },
+    { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**3º de 4.** Reemplaza a #31 (que se mergeó contra `release/2.6.0-operabilidad`, no a `master`).
Descripción detallada por ítem en **#31**.

**Ítems del plan:** F11, F7, F8, F13 (3a) · F5, F6, F12, F14, F16 (3b) · F1, F4, F9, F10, F15 (3c).

> **Mergear #33 y #34 primero.** Ahora muestra 28 commits; tras ellos se reduce a sus 13.

## El problema, medido

Poner en marcha una app real sobre HexCore 2.5 exigió **~900 líneas de cableado** sin nada
específico del negocio, de las que ~600 son genéricas y toda aplicación va a reescribir, cada
una con sus propios bugs. Peor: parte de ese código existía **porque** lo que traía la
librería no se podía usar.

## Contenido (13 commits propios)

**3a — código genérico puro.** F7 (tabla + repositorio + seed de `cron_jobs`, encapsulando las
dos herencias que NO hay que hacer para que el UoW y el auto-discovery no los traten como
dominio), F8 (`run_cqrs_worker` con muerte mutua y SIGTERM), F11 (middlewares **con** el filtro
de logging, que es la otra mitad del valor), F13 (`build_root_router`: 126 líneas → 3 llamadas).

**3b — utilidades sobre puertos existentes.** F5 (handlers de excepción, con `ValueError` → 422
que antes sólo se capturaba *dentro* de `build_query_endpoint`), F6 (providers CQRS con **una
sola fuente de verdad** con el worker, verificado por identidad de objeto), F12 (rate limit con
**429 + `Retry-After`** y política explícita ante backend caído), F14 (`connection_slot` con
teardown garantizado — filtrar un slot es el bug clásico), F16 (health checks que **sondean de
verdad**, con timeout por sonda y 503).

**3c — superficie grande.** F1 (`create_app()` **sin argumentos** ya da una app usable, con los
interruptores en un único `AppFeatures` en vez de ocho keywords), F4 (`build_lifespan` con
teardown en orden inverso y sólo de los steps que arrancaron), F9 (`hexcore.testing`), F10
(`dependencies` para auth, defaults no mutables, 422 estructurado), F15 (cursor opaco con
desempate por `id`).

## Dos bugs que encontraron los tests

- Los buses descartaban un `enqueuer` **presente pero falsy** (`if not self._enqueuer`, y el
  `InMemoryTaskEnqueuer` define `__len__`): lanzaba `RuntimeError` diciendo que no había
  enqueuer cuando sí lo había.
- `connection_slot` generaba `slot_id` con `id(object())`, que se reutiliza: dos slots
  colisionaban en el dict y **el límite dejaba de limitar**.

## Desviación de la firma propuesta

El plan proponía `run_cqrs_worker(*, queues, concurrency, ...)`, pero eso ataría el runner a un
broker y HexCore soporta tres. El runner toma `WorkerLoop`s y la ergonomía que pedía el plan
está en `run_procrastinate_worker(app, queues=..., concurrency=...)`.

## Riesgo / compatibilidad

Casi todo aditivo. Lo único que cambia comportamiento: el `detail` del 422 de
`build_query_endpoint` pasa de string a objeto. `QueryResponseDTO` **no** cambia: F15 se añade,
no sustituye.

## Criterio de cierre de la fase — verificado

```python
from hexcore.fastapi import create_app, build_lifespan, SqlEngineStep

app = create_app(
    lifespan=build_lifespan(SqlEngineStep()),
    routers=[usuarios_router, tickets_router],
)
```

## Verificación

`468 passed, 0 skipped`. `TestClient(create_app())` responde 200 en `/health` sin pasar ningún
argumento.
