### PR TITLE
release 2.8.0 — simplificación, fachadas y documentación ejecutable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 ## Unreleased
 
+Esta entrada cubre la aplicación completa del plan de mejora del subsistema CQRS: los
+seis P0, los seis P1, los cinco P2, los dieciséis F, los dos P3 y las reglas de
+simplicidad S3–S7.
+
+### BREAKING
+
+- **cqrs**: se elimina `MiddlewareConfig` de `hexcore.application.cqrs`. Era código
+  muerto: `_build_middlewares` instancia con `cls()` y nunca leía
+  `enabled`/`order`/`options`, así que el `options={"max_retries": 3}` del ejemplo iba al
+  **bus**, no al middleware. Quien lo declaraba no pierde comportamiento —no tenía—, sólo
+  tiene que quitar el import (P2-1, S7)
+
+### Feat
+
+- **fachadas**: nuevos módulos `hexcore.cqrs`, `hexcore.sql` y `hexcore.fastapi`, que
+  reexportan lo público **sin mover nada de sitio**: un import obvio por tarea, y las
+  rutas largas siguen funcionando y devolviendo el mismo objeto. La resolución es
+  perezosa, así que `import hexcore.cqrs` funciona sin los extras y sin ejecutar I/O en
+  import time. Sólo exponen los nombres canónicos `Abstract*`; los alias `I*` siguen
+  importables por su ruta de siempre (S3, S4)
+
 ### Fix
 
 - **cqrs**: el worker ya **ejecuta** los `@background_command` que saca de la cola en
@@ -165,8 +186,38 @@
   `NotImplementedError` con instrucciones en vez de ser un `pass` que perdía el
   evento sin traza (P1-3)
 
+- **task_queues**: el adaptador de Celery ejecuta las corutinas en un **event loop
+  persistente por proceso** en vez de `asyncio.run()` por tarea. Con un `AsyncEngine`
+  compartido, cerrar el loop en cada tarea produce `Event loop is closed` y
+  `attached to a different loop`. Se detecta el fork del pool prefork comparando el PID.
+  Se exponen `run_in_worker_loop(coro)` y `shutdown_worker_loop()` (P1-4)
+- **domain**: `BaseDomainService.__init__` ya no resuelve la configuración en un default
+  de argumento, evaluado en import time, que congelaba el event bus de la primera
+  resolución para todas las instancias (S5)
+- **cli**: las rutas del proyecto se resuelven al ejecutar el comando, no al importar el
+  módulo. `hexcore/__init__.py` importa la CLI, así que la constante a nivel de módulo
+  resolvía la configuración antes de que la app pudiera llamar a
+  `LazyConfig.set_config_modules()` (S5). Se borran además siete constantes sin uso (S7)
+
+### Docs
+
+- **cqrs**: `RetryMiddleware` documenta que sus reintentos se **multiplican** con los de
+  la cola (3 x 3 = 12 ejecuciones, no 6) y avisa con un `warning` —una vez por tipo de
+  comando— si el mensaje también va a background (P2-3)
+- se alinean `README.md` y `DOCS.md` con la API real: `register_command_handler` (no
+  `register_command`), `hexcore.process_command` (no `process_cqrs_command`), y
+  `UseCaseCommandHandler` con las dependencias del use case. Los ejemplos usan las
+  fachadas y los nombres canónicos (P2-4, S4)
+- **DOCS.md** abre con el arranque completo de una app en una pantalla, y documenta el
+  contrato de "ejecutar este comando aquí y ahora": el bus decide por contexto, y
+  `is_worker_execution()` lo expone (P2-5)
+
 ### Test
 
+- se añade `tests/test_documentation_examples.py`, que **ejecuta** los ejemplos de
+  arranque, migración de use case, Smart Routing y cron, y verifica contra la API real
+  que los símbolos y atributos que la documentación menciona existen. Un rename ahora
+  rompe el CI, no la app de alguien (P2-4)
 - **cqrs**: los tests del consumer parcheaban `_resolve_callable` sin restaurarlo y
   contaminaban cualquier test posterior del mismo proceso; ahora usan `monkeypatch`
   (P3-2)

--- a/DOCS.md
+++ b/DOCS.md
@@ -33,6 +33,95 @@ HexCore organiza el código siguiendo los principios DDD y arquitectura hexagona
 
 ---
 
+## 0. Arranque: una app HexCore en una pantalla
+
+Este es el arranque completo de una aplicación estándar. Todo lo que aparece aquí tiene un
+default que funciona, así que lo que no necesites lo puedes quitar.
+
+```python
+# main.py
+from hexcore.fastapi import build_lifespan, create_app, SqlEngineStep
+
+app = create_app(
+    lifespan=build_lifespan(SqlEngineStep()),
+    routers=[usuarios_router, tickets_router],
+)
+```
+
+`create_app()` a secas ya da una app usable: título y versión salen de `ServerConfig`, CORS
+de `config.allow_origins`, y `/health` (liveness) y `/health/ready` (readiness, con sondas
+reales a SQL/Redis/Mongo) existen. También trae el middleware `X-Request-ID`, el de timing y
+el mapeo de excepciones de dominio a HTTP.
+
+Para desactivar algo, hay un solo objeto de interruptores:
+
+```python
+from hexcore.fastapi import AppFeatures
+
+app = create_app(features=AppFeatures(cors=False))
+```
+
+### Los tres imports
+
+Hay un módulo fachada por tarea. Las rutas largas siguen funcionando; estas son las que
+usa esta documentación.
+
+```python
+import hexcore.fastapi as hx    # create_app, build_lifespan, providers, middlewares, health
+import hexcore.cqrs as cqrs     # Command, Query, handlers, decoradores, buses, worker, cron
+import hexcore.sql as sql       # init_engine, session_scope, uow_scope, Base, DTOs de query
+```
+
+### El worker, en una llamada
+
+```python
+# worker.py
+import hexcore.cqrs as cqrs
+
+async def main() -> None:
+    consumer = cqrs.CQRSConsumer(command_bus, event_bus)
+    register_hexcore_procrastinate_tasks(procrastinate_app, consumer)
+
+    await cqrs.run_procrastinate_worker(
+        procrastinate_app,
+        queues=["default", "reactive"],
+        scheduler=cqrs.DynamicScheduler(repo, enqueuer, lock_provider=lock),
+        on_startup=[lambda: cqrs.seed_cron_jobs(CRON_JOBS)],
+    )
+```
+
+Si cualquiera de los dos bucles muere, el runner cancela el otro y el proceso sale con
+`WorkerDied`, para que el orquestador lo reinicie completo: correr con un bucle caído
+—encolar sin consumir, o al revés— es peor que caerse. `SIGTERM` se traduce a drenaje
+ordenado.
+
+### Fuera de un request
+
+Los scopes de `hexcore.sql` sirven en workers, tasks, cron, scripts y seeds:
+
+```python
+import hexcore.sql as sql
+
+async with sql.session_scope() as session:       # sesión pelada, sin construir el UoW
+    ...
+
+async with sql.uow_scope() as uow:               # UoW sin abrir: el use case hace su `async with`
+    await CerrarTicketUseCase(uow).execute(request)
+```
+
+`session_scope` no construye el UoW a propósito: construirlo corre el auto-discovery e
+instancia **todos** los repositorios de dominio, un coste absurdo para leer una tabla de
+infraestructura.
+
+### Nombres canónicos
+
+Conviven dos nombres para varios conceptos por retrocompatibilidad
+(`AbstractCommandBus`/`ICommandBus`, `AbstractSerializer`/`ISerializer`, etc.). Los
+canónicos son los `Abstract*`, y son los únicos que exponen las fachadas y usa esta
+documentación. Los alias `I*` siguen importables por su ruta de siempre.
+
+---
+
 ## 1.1 Configuración v2: root-first y discovery explícito
 
 En v2, HexCore no adivina rutas de repositorios. Debes declararlas en configuración.

--- a/README.md
+++ b/README.md
@@ -295,22 +295,35 @@ Si ya tienes una aplicación escrita con la abstracción `UseCase` de HexCore, p
 En lugar de instanciar un UseCase directamente en tu endpoint, envuélvelo en un comando:
 
 ```python
-from hexcore.application.cqrs.adapters import UseCaseCommandHandler
-from hexcore.application.cqrs.registry import HandlerRegistry
+import hexcore.cqrs as cqrs
 
-# 1. Tienes tu UseCase legado
+# 1. Tienes tu UseCase legado, con sus dependencias
 class CreateUserUseCase(UseCase[CreateUserCommand, UserDTO]):
+    def __init__(self, uow: IUnitOfWork) -> None:
+        self.uow = uow
+
     async def execute(self, request: CreateUserCommand) -> UserDTO:
         # logica legacy
-        pass
+        ...
 
 # 2. Lo registras en el registry de CQRS utilizando el adaptador
-registry = HandlerRegistry()
-registry.register_command(
-    CreateUserCommand, 
-    UseCaseCommandHandler(CreateUserUseCase())
+registry = cqrs.HandlerRegistry()
+registry.register_command_handler(
+    CreateUserCommand,
+    cqrs.UseCaseCommandHandler(CreateUserUseCase(uow)),
+)
+
+# O con un factory, si quieres resolver las dependencias en el momento del dispatch:
+registry.register_command_handler(
+    CreateUserCommand,
+    cqrs.HandlerRegistry.factory(
+        lambda: cqrs.UseCaseCommandHandler(CreateUserUseCase(build_uow()))
+    ),
 )
 ```
+
+> El método es `register_command_handler` (y `register_query_handler`), no
+> `register_command`.
 
 #### Paso 2: Consumirlo desde el endpoint usando el CommandBus
 
@@ -479,28 +492,30 @@ async def clean_old_records_task(days_retention: int):
     pass
 ```
 
-#### 2. Crear el Enqueuer (Adaptador)
+#### 2. Usar un Enqueuer (Adaptador)
 
-Implementa la interfaz genérica `ITaskEnqueuer` usando la SDK de tu Task Queue favorito:
+No hace falta escribirlo: HexCore trae `ProcrastinateEnqueuer` y `CeleryEnqueuer` listos, y
+registran las tareas del consumidor con los nombres `hexcore.process_command`,
+`hexcore.process_handler` y `hexcore.process_task`.
 
 ```python
-from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
+from hexcore.infrastructure.task_queues.procrastinate_adapter import ProcrastinateEnqueuer
 
-class ProcrastinateEnqueuer(ITaskEnqueuer):
-    async def enqueue_command(self, command_name: str, payload: dict, queue: str) -> None:
-        await process_cqrs_command.defer_async(payload=payload)
-        
-    async def enqueue_handler(self, handler_name: str, payload: dict, queue: str) -> None:
-        await process_cqrs_handler.defer_async(handler_name=handler_name, payload=payload)
-    
-    async def enqueue_event(self, event_name: str, payload: dict, queue: str) -> None:
-        pass # Usualmente no se usa directamente si utilizas @background_handler
-        
-    async def enqueue_task(self, task_name: str, payload: dict, queue: str) -> None:
-        await process_generic_task.defer_async(task_name=task_name, payload=payload)
+enqueuer = ProcrastinateEnqueuer(procrastinate_app)
 ```
 
-#### 2. Configurar tus Buses con un Adaptador Oficial
+Si necesitas otro broker, implementa `ITaskEnqueuer` (4 métodos). Dos advertencias:
+
+- **`enqueue_event` no es un `pass`.** Una cola de tareas no puede hacer fan-out a "todos
+  los suscriptores", así que los adaptadores oficiales lanzan `NotImplementedError` en vez
+  de perder el evento en silencio. Para ejecutar un suscriptor concreto en background usa
+  `@background_handler` (el EventBus llamará a `enqueue_handler`); para fan-out real usa
+  `RedisEventBus` o `PostgresEventBus`.
+- Si envuelves corutinas en un worker síncrono (Celery), no uses `asyncio.run()` por tarea:
+  cierra el event loop y deja el pool del `AsyncEngine` atado a un loop muerto. HexCore usa
+  un loop persistente por proceso, expuesto como `run_in_worker_loop(coro)`.
+
+#### 3. Configurar tus Buses con un Adaptador Oficial
 
 HexCore provee adaptadores *plug & play* para **Celery** y **Procrastinate**. Simplemente importa el enqueuer, pásale tu app y configúralo en los buses de memoria.
 
@@ -548,21 +563,47 @@ await enqueuer.enqueue_task(
 
 #### 5. Levantar el Worker (Consumidor Universal)
 
-En el entrypoint de tu worker, usa la función utilitaria `register_hexcore_celery_tasks` para autoconfigurar las rutas en una sola línea:
+En el entrypoint de tu worker, `register_hexcore_*_tasks` autoconfigura las rutas
+`hexcore.process_command`, `hexcore.process_handler` y `hexcore.process_task`:
 
 ```python
-from hexcore.infrastructure.workers.consumer import CQRSConsumer
+import hexcore.cqrs as cqrs
 from hexcore.infrastructure.task_queues.celery_adapter import register_hexcore_celery_tasks
 
-consumer = CQRSConsumer(
-    command_bus=command_bus, # Tu CommandBus configurado
-    event_bus=event_bus, 
-    serializer=serializer
-)
+# Le pasas el MISMO bus que usa el proceso web: el consumer marca el mensaje como
+# "viene del worker", así que el bus lo ejecuta en vez de reencolarlo.
+consumer = cqrs.CQRSConsumer(command_bus, event_bus)
 
-# ¡Magia! Registra las tareas 'hexcore.process_command', 'hexcore.process_handler', etc.
-register_hexcore_celery_tasks(app, consumer)
+register_hexcore_celery_tasks(app, consumer)  # idempotente: llamarla dos veces no revienta
 ```
+
+Un worker que sólo procesa comandos puede omitir el event bus: `cqrs.CQRSConsumer(command_bus)`.
+
+Y el entrypoint completo del worker (con scheduler, muerte mutua y SIGTERM) es una llamada:
+
+```python
+await cqrs.run_procrastinate_worker(
+    procrastinate_app,
+    queues=["default", "reactive"],
+    scheduler=cqrs.DynamicScheduler(repo, enqueuer, lock_provider=lock),
+    on_startup=[lambda: cqrs.seed_cron_jobs(CRON_JOBS)],
+)
+```
+
+#### 6. Ejecutar un comando "aquí y ahora"
+
+No hay una API separada para esto, y es a propósito: el contrato es que **el bus decide
+por contexto**.
+
+- Fuera de un worker, un `@background_command` se encola.
+- Dentro de un worker (es decir, cuando el mensaje viene del `CQRSConsumer`) el **mismo**
+  bus lo ejecuta localmente. Por eso puedes —y debes— compartir un único bus entre la app
+  web y el worker.
+- Si un handler despacha a propósito otro `@background_command`, ese sí se encola: el
+  contexto de worker se consume en el primer dispatch.
+
+Si necesitas comprobarlo desde tu código, `cqrs.is_worker_execution()` responde si el
+mensaje en curso viene de una cola.
 
 ---
 
@@ -570,52 +611,85 @@ register_hexcore_celery_tasks(app, consumer)
 
 HexCore incluye un **`DynamicScheduler`** que te permite programar tareas (`@background_task`) para que se ejecuten periódicamente. La ventaja clave es que lee la configuración desde un repositorio (como tu Base de Datos), permitiendo activar, desactivar o cambiar los horarios **sin necesidad de reiniciar tus servidores**.
 
-### 1. Implementa tu Repositorio
-Implementa `ICronJobRepository` para decirle al Scheduler de dónde leer la configuración (ej. usando SQLAlchemy, MongoDB o Redis):
+### 1. Usa el repositorio SQL de serie (o implementa el tuyo)
+
+Si tu cron vive en SQL —el caso normal— no escribas nada: HexCore trae la tabla, el
+repositorio y el seed (extra `[sql]`).
 
 ```python
-from hexcore.domain.cqrs.cron import ICronJobRepository, CronJobDefinition
+import hexcore.cqrs as cqrs
+
+CRON_JOBS = [
+    cqrs.cron_job(clean_old_records_task, "*/5 * * * *", payload={"days_retention": 30}),
+    cqrs.cron_job(cerrar_caja, "0 3 * * *"),
+]
+
+await cqrs.create_cron_tables()        # o una migración de Alembic
+await cqrs.seed_cron_jobs(CRON_JOBS)   # idempotente, y NO pisa lo editado en BD
+
+repo = cqrs.SqlAlchemyCronJobRepository()
+```
+
+`cron_job()` deriva el `task_name` de `__cqrs_task_name__`: escribirlo a mano es cómo se
+acaba con un cron que encola una tarea ya renombrada, y el fallo aparece en el worker.
+
+Si tu configuración vive en otro sitio (Mongo, Redis, un YAML), implementa
+`ICronJobRepository`:
+
+```python
 from datetime import datetime
 
-class MiCronRepository(ICronJobRepository):
-    async def get_active_jobs(self) -> list[CronJobDefinition]:
-        # SELECT * FROM cronjobs WHERE is_active = true
+import hexcore.cqrs as cqrs
+
+
+class MiCronRepository(cqrs.ICronJobRepository):
+    async def get_active_jobs(self) -> list[cqrs.CronJobDefinition]:
         return [
-            CronJobDefinition(
-                job_id="1",
-                task_name="hexcore.process_task", # o cualquier @background_task
-                cron_expression="*/5 * * * *",    # cada 5 minutos
-                payload={"task_name": "clean_db", "payload": {}}
+            cqrs.CronJobDefinition(
+                job_id="clean-db",
+                task_name="mi_app.tasks.clean_old_records_task",  # un @background_task
+                cron_expression="*/5 * * * *",
+                payload={"days_retention": 30},
+                queue="maintenance",
             )
         ]
-        
+
     async def update_last_run(self, job_id: str, run_time: datetime) -> None:
-        # UPDATE cronjobs SET last_run = run_time WHERE id = job_id
-        pass
+        # Importa implementarlo: es lo que deduplica el encolado entre ticks.
+        ...
 ```
 
 ### 2. Levanta el Scheduler
 En un proceso en background de tu API o en un microservicio separado, arranca el Scheduler inyectándole tu Enqueuer favorito (Celery, Procrastinate):
 
 ```python
-from hexcore.application.cqrs.scheduler import DynamicScheduler
-import asyncio
+import hexcore.cqrs as cqrs
 
-async def run_scheduler():
-    repo = MiCronRepository()
-    scheduler = DynamicScheduler(
-        repository=repo, 
-        enqueuer=enqueuer, 
-        tick_interval_seconds=60
-    )
-    
-    await scheduler.start() # Bucle infinito
+scheduler = cqrs.DynamicScheduler(
+    repository=repo,
+    enqueuer=enqueuer,
+    tick_interval_seconds=60,
+)
 
-# En FastAPI puedes usar lifespan para lanzarlo:
-# asyncio.create_task(run_scheduler())
+# Lo normal es dejar que el runner lo supervise junto al worker: si uno de los dos
+# muere, se cancela el otro y el proceso sale para que el orquestador lo reinicie.
+await cqrs.run_procrastinate_worker(procrastinate_app, scheduler=scheduler)
 ```
 
-El Scheduler evaluará las expresiones (gracias a `croniter`) y delegará la carga pesada al enqueuer. ¡Tu Worker no necesita saber de horarios, solo ejecuta las tareas cuando le llegan!
+El Scheduler evalúa las expresiones con `croniter` y delega la carga pesada al enqueuer. Tu
+Worker no necesita saber de horarios, sólo ejecuta las tareas cuando le llegan.
+
+**Cómo decide si toca ejecutar.** No compara contra el minuto actual, sino que busca si hubo
+alguna ocurrencia entre la última ejecución (`last_run_at`) y ahora. Dos consecuencias que
+importan:
+
+- Un minuto saltado por drift del tick **no** pierde la ejecución.
+- `update_last_run` deduplica de verdad, así que un `tick_interval_seconds < 60` no duplica
+  el encolado dentro del mismo proceso. Entre réplicas sí hace falta lock, y el scheduler
+  emite un `RuntimeWarning` si detecta tick sub-minuto sin `lock_provider`.
+
+`catch_up_window_seconds` (1 hora por defecto) acota el catch-up: un scheduler que estuvo
+caído una semana no dispara ocurrencias antiguas.
 
 ### 3. Distributed Locks (Evitar ejecuciones dobles)
 
@@ -645,7 +719,7 @@ Si usas Procrastinate o bases de datos SQL y no quieres levantar Redis:
 from hexcore.infrastructure.cqrs.postgres_lock import PostgresLockProvider
 
 lock_provider = PostgresLockProvider(my_asyncpg_pool)
-await lock_provider.setup() # Crea la tabla de locks si no existe
+await lock_provider.setup() # Crea la tabla y el índice, y purga lo expirado
 
 scheduler = DynamicScheduler(
     repository=repo, 
@@ -653,6 +727,23 @@ scheduler = DynamicScheduler(
     lock_provider=lock_provider
 )
 ```
+
+> El provider purga las filas expiradas solo (en `setup()` y cada 100 adquisiciones), así
+> que la tabla de locks no crece sin límite. `purge_expired()` es pública si prefieres
+> purgar desde un job propio, y `purge_every=0` desactiva la purga automática.
+
+#### Qué pasa si el lock no responde
+
+Si Redis (o Postgres) se cae, `acquire_lock` no puede decidir, y las dos respuestas
+posibles son malas de formas distintas. La decisión es tuya y explícita:
+
+```python
+RedisLockProvider(redis_client, on_error="skip")   # default: no correr. El cron se detiene.
+RedisLockProvider(redis_client, on_error="raise")  # propagar, para que el supervisor lo vea.
+```
+
+En los logs, "no pude decidir" es `critical` y "el lock estaba tomado por otra réplica"
+—el caso normal— es `debug`.
 
 ---
 

--- a/hexcore/application/cqrs/__init__.py
+++ b/hexcore/application/cqrs/__init__.py
@@ -3,8 +3,8 @@ hexcore.application.cqrs — Capa de aplicación CQRS.
 Registry, Pipeline, Buses In-Memory, Adaptadores y Factory.
 """
 
-from .registry import HandlerRegistry
-from .config import CQRSConfig, BusConfig, MiddlewareConfig
+from .registry import HandlerRegistry, HandlerFactory
+from .config import CQRSConfig, BusConfig
 from .pipeline import MiddlewarePipeline
 from .in_memory_buses import InMemoryCommandBus, InMemoryQueryBus, InMemoryEventBus
 from .adapters import UseCaseCommandHandler
@@ -13,9 +13,9 @@ from .scheduler import DynamicScheduler
 
 __all__ = [
     "HandlerRegistry",
+    "HandlerFactory",
     "CQRSConfig",
     "BusConfig",
-    "MiddlewareConfig",
     "MiddlewarePipeline",
     "InMemoryCommandBus",
     "InMemoryQueryBus",

--- a/hexcore/application/cqrs/config.py
+++ b/hexcore/application/cqrs/config.py
@@ -8,18 +8,17 @@ import typing as t
 from pydantic import BaseModel, ConfigDict, Field
 
 
-class MiddlewareConfig(BaseModel):
-    """Configuración de un middleware individual."""
-
-    enabled: bool = True
-    order: int = 0  # Menor = se ejecuta primero
-    options: dict[str, t.Any] = Field(default_factory=dict)
-
-    model_config = ConfigDict(frozen=True)
-
-
 class BusConfig(BaseModel):
-    """Configuración de un bus individual (command, query o event)."""
+    """
+    Configuración de un bus individual (command, query o event).
+
+    `middlewares` sólo admite middlewares construibles sin argumentos: se instancian con
+    `cls()`. Los que necesitan configuración —`TransactionMiddleware` y su `uow_factory`,
+    `RetryMiddleware` y su política— hay que instanciarlos a mano y pasar el
+    `MiddlewarePipeline` al bus.
+
+    `options` se reenvía al **bus**, no a los middlewares.
+    """
 
     # Clase del bus a instanciar (dotted path o referencia directa)
     # Si es None, usa el bus in-memory por defecto
@@ -46,12 +45,14 @@ class CQRSConfig(BaseModel):
                     backend="hexcore.infrastructure.cqrs.procrastinate.ProcrastinateCommandBus",
                     middlewares=[
                         "hexcore.infrastructure.cqrs.middlewares.LoggingMiddleware",
-                        "hexcore.infrastructure.cqrs.middlewares.RetryMiddleware",
                     ],
-                    options={"max_retries": 3},
+                    options={"queue_name": "hexcore_commands"},
                 ),
             ),
         )
+
+    Nota: `options` se le pasa al **bus**, no a los middlewares. Un middleware que
+    necesite configuración se instancia a mano y se le pasa el pipeline al bus.
     """
 
     enabled: bool = True

--- a/hexcore/cqrs.py
+++ b/hexcore/cqrs.py
@@ -1,0 +1,144 @@
+"""
+Fachada del subsistema CQRS: un import obvio por tarea.
+
+Montar CQRS obligaba a importar de `hexcore.domain.cqrs.commands`,
+`hexcore.domain.cqrs.buses`, `hexcore.application.cqrs.registry`,
+`hexcore.application.cqrs.in_memory_buses`, `hexcore.infrastructure.cqrs.pydantic_serializer`,
+`hexcore.infrastructure.workers.consumer`… Esto reexporta lo público::
+
+    import hexcore.cqrs as cqrs
+
+    registry = cqrs.HandlerRegistry()
+    registry.register_command_handler(CrearTicket, CrearTicketHandler())
+    bus = cqrs.InMemoryCommandBus(registry=registry)
+
+Las rutas largas siguen funcionando: esto **no mueve nada de sitio**.
+
+Los nombres canónicos son los `Abstract*`. Los alias `I*` existen por
+retrocompatibilidad y no se exponen aquí, para que haya un solo nombre por concepto en la
+documentación y en los ejemplos.
+
+La resolución es perezosa (`__getattr__` de módulo) para que importar esta fachada no
+arrastre las dependencias opcionales: `hexcore.cqrs.SqlAlchemyCronJobRepository` sólo
+requiere el extra `[sql]` en el momento en que lo pedís.
+"""
+from __future__ import annotations
+
+import typing as t
+
+# name -> (módulo, atributo)
+_EXPORTS: dict[str, tuple[str, str]] = {
+    # ── Mensajes ──────────────────────────────────────────────────────────────
+    "Command": ("hexcore.domain.cqrs.commands", "Command"),
+    "Query": ("hexcore.domain.cqrs.queries", "Query"),
+    "DomainEvent": ("hexcore.domain.events", "DomainEvent"),
+    # ── Contratos (nombres canónicos) ─────────────────────────────────────────
+    "AbstractCommandHandler": ("hexcore.domain.cqrs.handlers", "AbstractCommandHandler"),
+    "AbstractQueryHandler": ("hexcore.domain.cqrs.handlers", "AbstractQueryHandler"),
+    "AbstractCommandBus": ("hexcore.domain.cqrs.buses", "AbstractCommandBus"),
+    "AbstractQueryBus": ("hexcore.domain.cqrs.buses", "AbstractQueryBus"),
+    "AbstractEventBus": ("hexcore.domain.cqrs.buses", "AbstractEventBus"),
+    "AbstractMiddleware": ("hexcore.domain.cqrs.middleware", "AbstractMiddleware"),
+    "AbstractSerializer": ("hexcore.domain.cqrs.serializer", "AbstractSerializer"),
+    "NextHandler": ("hexcore.domain.cqrs.middleware", "NextHandler"),
+    "ITaskEnqueuer": ("hexcore.domain.cqrs.task_queues", "ITaskEnqueuer"),
+    # ── Decoradores (Smart Routing) ───────────────────────────────────────────
+    "background_command": ("hexcore.domain.cqrs.decorators", "background_command"),
+    "background_handler": ("hexcore.domain.cqrs.decorators", "background_handler"),
+    "background_task": ("hexcore.domain.cqrs.decorators", "background_task"),
+    # ── Registry, pipeline y buses ────────────────────────────────────────────
+    "HandlerRegistry": ("hexcore.application.cqrs.registry", "HandlerRegistry"),
+    "HandlerFactory": ("hexcore.application.cqrs.registry", "HandlerFactory"),
+    "MiddlewarePipeline": ("hexcore.application.cqrs.pipeline", "MiddlewarePipeline"),
+    "InMemoryCommandBus": (
+        "hexcore.application.cqrs.in_memory_buses",
+        "InMemoryCommandBus",
+    ),
+    "InMemoryQueryBus": ("hexcore.application.cqrs.in_memory_buses", "InMemoryQueryBus"),
+    "InMemoryEventBus": ("hexcore.application.cqrs.in_memory_buses", "InMemoryEventBus"),
+    # ── Configuración y factory ───────────────────────────────────────────────
+    "CQRSConfig": ("hexcore.application.cqrs.config", "CQRSConfig"),
+    "BusConfig": ("hexcore.application.cqrs.config", "BusConfig"),
+    "CQRSFactory": ("hexcore.application.cqrs.factory", "CQRSFactory"),
+    "UseCaseCommandHandler": (
+        "hexcore.application.cqrs.adapters",
+        "UseCaseCommandHandler",
+    ),
+    # ── Serializer y middlewares ──────────────────────────────────────────────
+    "PydanticSerializer": (
+        "hexcore.infrastructure.cqrs.pydantic_serializer",
+        "PydanticSerializer",
+    ),
+    "LoggingMiddleware": ("hexcore.infrastructure.cqrs.middlewares", "LoggingMiddleware"),
+    "RetryMiddleware": ("hexcore.infrastructure.cqrs.middlewares", "RetryMiddleware"),
+    "ValidationMiddleware": (
+        "hexcore.infrastructure.cqrs.middlewares",
+        "ValidationMiddleware",
+    ),
+    "TransactionMiddleware": (
+        "hexcore.infrastructure.cqrs.middlewares",
+        "TransactionMiddleware",
+    ),
+    # ── Worker ────────────────────────────────────────────────────────────────
+    "CQRSConsumer": ("hexcore.infrastructure.workers.consumer", "CQRSConsumer"),
+    "run_cqrs_worker": ("hexcore.infrastructure.workers.runner", "run_cqrs_worker"),
+    "run_procrastinate_worker": (
+        "hexcore.infrastructure.workers.runner",
+        "run_procrastinate_worker",
+    ),
+    "worker_loop": ("hexcore.infrastructure.workers.runner", "worker_loop"),
+    "WorkerDied": ("hexcore.infrastructure.workers.runner", "WorkerDied"),
+    "is_worker_execution": ("hexcore.domain.cqrs.context", "is_worker_execution"),
+    "worker_execution": ("hexcore.domain.cqrs.context", "worker_execution"),
+    # ── Cron ──────────────────────────────────────────────────────────────────
+    "CronJobDefinition": ("hexcore.domain.cqrs.cron", "CronJobDefinition"),
+    "ICronJobRepository": ("hexcore.domain.cqrs.cron", "ICronJobRepository"),
+    "ILockProvider": ("hexcore.domain.cqrs.cron", "ILockProvider"),
+    "DynamicScheduler": ("hexcore.application.cqrs.scheduler", "DynamicScheduler"),
+    # Requieren extras: se resuelven sólo al pedirlos.
+    "CronJobModel": ("hexcore.infrastructure.cqrs.cron_sql", "CronJobModel"),
+    "CronJobModelMixin": ("hexcore.infrastructure.cqrs.cron_sql", "CronJobModelMixin"),
+    "SqlAlchemyCronJobRepository": (
+        "hexcore.infrastructure.cqrs.cron_sql",
+        "SqlAlchemyCronJobRepository",
+    ),
+    "seed_cron_jobs": ("hexcore.infrastructure.cqrs.cron_sql", "seed_cron_jobs"),
+    "create_cron_tables": ("hexcore.infrastructure.cqrs.cron_sql", "create_cron_tables"),
+    "cron_job": ("hexcore.infrastructure.cqrs.cron_sql", "cron_job"),
+    "RedisLockProvider": ("hexcore.infrastructure.cqrs.redis_lock", "RedisLockProvider"),
+    "PostgresLockProvider": (
+        "hexcore.infrastructure.cqrs.postgres_lock",
+        "PostgresLockProvider",
+    ),
+    # ── Excepciones ───────────────────────────────────────────────────────────
+    "CQRSError": ("hexcore.domain.cqrs.exceptions", "CQRSError"),
+    "HandlerNotFoundError": (
+        "hexcore.domain.cqrs.exceptions",
+        "HandlerNotFoundError",
+    ),
+    "DuplicateHandlerError": (
+        "hexcore.domain.cqrs.exceptions",
+        "DuplicateHandlerError",
+    ),
+    "DeserializationError": ("hexcore.domain.cqrs.exceptions", "DeserializationError"),
+}
+
+__all__ = sorted(_EXPORTS)
+
+
+def __getattr__(name: str) -> t.Any:
+    try:
+        module_path, attribute = _EXPORTS[name]
+    except KeyError:
+        raise AttributeError(f"module 'hexcore.cqrs' has no attribute {name!r}") from None
+
+    import importlib
+
+    value = getattr(importlib.import_module(module_path), attribute)
+    # Se cachea en el módulo para que el segundo acceso no vuelva a importar.
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return __all__

--- a/hexcore/domain/services.py
+++ b/hexcore/domain/services.py
@@ -23,10 +23,20 @@ T = t.TypeVar("T", bound=BaseEntity)
 class BaseDomainService:
     def __init__(
         self,
-        event_bus: EventBus = LazyConfig().get_config().event_bus,
+        event_bus: EventBus | None = None,
     ) -> None:
+        """
+        Args:
+            event_bus: El bus de eventos. Si es None, se toma de la configuración **en
+                este momento**, no en import time.
+
+        El default era `LazyConfig().get_config().event_bus`, evaluado al importar el
+        módulo: eso resolvía la configuración antes de que la aplicación pudiera llamar a
+        `LazyConfig.set_config_modules()`, y congelaba el bus de la primera resolución
+        para todas las instancias posteriores.
+        """
         self.config = LazyConfig.get_config()
-        self.event_bus = event_bus
+        self.event_bus = event_bus if event_bus is not None else self.config.event_bus
 
     async def list_entities(
         self,

--- a/hexcore/fastapi.py
+++ b/hexcore/fastapi.py
@@ -1,0 +1,122 @@
+"""
+Fachada de la capa FastAPI: un import obvio por tarea.
+
+El arranque completo de una app HexCore::
+
+    from hexcore.fastapi import create_app, build_lifespan, SqlEngineStep, BeanieStep
+
+    app = create_app(
+        lifespan=build_lifespan(SqlEngineStep(), BeanieStep(documents=DOCS)),
+        routers=[usuarios_router, tickets_router],
+    )
+
+Requiere el extra ``[api]``. La resolución es perezosa, así que importar este módulo no
+falla sin FastAPI; falla al pedir el primer nombre.
+"""
+from __future__ import annotations
+
+import typing as t
+
+_EXPORTS: dict[str, tuple[str, str]] = {
+    # ── App y lifespan ────────────────────────────────────────────────────────
+    "create_app": ("hexcore.infrastructure.api.app", "create_app"),
+    "AppFeatures": ("hexcore.infrastructure.api.app", "AppFeatures"),
+    "build_lifespan": ("hexcore.infrastructure.api.lifespan", "build_lifespan"),
+    "StartupStep": ("hexcore.infrastructure.api.lifespan", "StartupStep"),
+    "CallableStep": ("hexcore.infrastructure.api.lifespan", "CallableStep"),
+    "SqlEngineStep": ("hexcore.infrastructure.api.lifespan", "SqlEngineStep"),
+    "BeanieStep": ("hexcore.infrastructure.api.lifespan", "BeanieStep"),
+    "EventBusStep": ("hexcore.infrastructure.api.lifespan", "EventBusStep"),
+    "CacheStep": ("hexcore.infrastructure.api.lifespan", "CacheStep"),
+    "ProcrastinateStep": ("hexcore.infrastructure.api.lifespan", "ProcrastinateStep"),
+    "CronSeedStep": ("hexcore.infrastructure.api.lifespan", "CronSeedStep"),
+    # ── Middlewares ───────────────────────────────────────────────────────────
+    "RequestIDMiddleware": (
+        "hexcore.infrastructure.api.middlewares",
+        "RequestIDMiddleware",
+    ),
+    "TimingMiddleware": ("hexcore.infrastructure.api.middlewares", "TimingMiddleware"),
+    "RequestIDLogFilter": (
+        "hexcore.infrastructure.api.middlewares",
+        "RequestIDLogFilter",
+    ),
+    "get_request_id": ("hexcore.infrastructure.api.middlewares", "get_request_id"),
+    "install_request_id_logging": (
+        "hexcore.infrastructure.api.middlewares",
+        "install_request_id_logging",
+    ),
+    # ── Routing ───────────────────────────────────────────────────────────────
+    "build_root_router": ("hexcore.infrastructure.api.routing", "build_root_router"),
+    "mount_routers": ("hexcore.infrastructure.api.routing", "mount_routers"),
+    # ── Providers CQRS ────────────────────────────────────────────────────────
+    "configure_cqrs": ("hexcore.infrastructure.api.cqrs", "configure_cqrs"),
+    "get_cqrs_container": ("hexcore.infrastructure.api.cqrs", "get_cqrs_container"),
+    "reset_cqrs": ("hexcore.infrastructure.api.cqrs", "reset_cqrs"),
+    "CQRSContainer": ("hexcore.infrastructure.api.cqrs", "CQRSContainer"),
+    "provide_command_bus": ("hexcore.infrastructure.api.cqrs", "provide_command_bus"),
+    "provide_query_bus": ("hexcore.infrastructure.api.cqrs", "provide_query_bus"),
+    "provide_event_bus": ("hexcore.infrastructure.api.cqrs", "provide_event_bus"),
+    "provide_registry": ("hexcore.infrastructure.api.cqrs", "provide_registry"),
+    # ── Sesiones y UoW como dependencias ──────────────────────────────────────
+    "get_session": ("hexcore.infrastructure.api.utils", "get_session"),
+    "get_sql_uow": ("hexcore.infrastructure.api.utils", "get_sql_uow"),
+    "get_sql_uow_open": ("hexcore.infrastructure.api.utils", "get_sql_uow_open"),
+    "get_nosql_uow": ("hexcore.infrastructure.api.utils", "get_nosql_uow"),
+    # ── Endpoints de query ────────────────────────────────────────────────────
+    "build_query_endpoint": (
+        "hexcore.infrastructure.api.utils",
+        "build_query_endpoint",
+    ),
+    "register_query_endpoint": (
+        "hexcore.infrastructure.api.utils",
+        "register_query_endpoint",
+    ),
+    # ── Handlers de excepción ─────────────────────────────────────────────────
+    "register_exception_handlers": (
+        "hexcore.infrastructure.api.exception_handlers",
+        "register_exception_handlers",
+    ),
+    "DEFAULT_EXCEPTION_STATUS_MAP": (
+        "hexcore.infrastructure.api.exception_handlers",
+        "DEFAULT_EXCEPTION_STATUS_MAP",
+    ),
+    # ── Rate limiting ─────────────────────────────────────────────────────────
+    "rate_limit": ("hexcore.infrastructure.api.rate_limit", "rate_limit"),
+    "client_ip_key": ("hexcore.infrastructure.api.rate_limit", "client_ip_key"),
+    # ── Streaming ─────────────────────────────────────────────────────────────
+    "sse_stream": ("hexcore.infrastructure.api.streaming", "sse_stream"),
+    "format_sse_event": ("hexcore.infrastructure.api.streaming", "format_sse_event"),
+    "ws_heartbeat": ("hexcore.infrastructure.api.streaming", "ws_heartbeat"),
+    "connection_slot": ("hexcore.infrastructure.api.streaming", "connection_slot"),
+    # ── Health checks ─────────────────────────────────────────────────────────
+    "check_health": ("hexcore.infrastructure.api.health", "check_health"),
+    "register_health_routes": (
+        "hexcore.infrastructure.api.health",
+        "register_health_routes",
+    ),
+    "default_probes": ("hexcore.infrastructure.api.health", "default_probes"),
+    "HealthReport": ("hexcore.infrastructure.api.health", "HealthReport"),
+    "DependencyReport": ("hexcore.infrastructure.api.health", "DependencyReport"),
+    "Probe": ("hexcore.infrastructure.api.health", "Probe"),
+}
+
+__all__ = sorted(_EXPORTS)
+
+
+def __getattr__(name: str) -> t.Any:
+    try:
+        module_path, attribute = _EXPORTS[name]
+    except KeyError:
+        raise AttributeError(
+            f"module 'hexcore.fastapi' has no attribute {name!r}"
+        ) from None
+
+    import importlib
+
+    value = getattr(importlib.import_module(module_path), attribute)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return __all__

--- a/hexcore/infrastructure/api/lifespan.py
+++ b/hexcore/infrastructure/api/lifespan.py
@@ -200,7 +200,7 @@ class SqlEngineStep:
             init_engine,
         )
 
-        init_engine(self._url, pool=self._pool, **self._engine_kwargs)
+        init_engine(url=self._url, pool=self._pool, **self._engine_kwargs)
 
     async def stop(self) -> None:
         from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (

--- a/hexcore/infrastructure/cli.py
+++ b/hexcore/infrastructure/cli.py
@@ -8,21 +8,21 @@ app = typer.Typer(
     help="CLI para ayudar con tareas de desarrollo en el proyecto Euphoria."
 )
 
-# Asumiendo que el script se ejecuta desde la raíz del proyecto.
-PROJECT_ROOT = LazyConfig.get_config().base_dir
-DOMAIN_PATH = PROJECT_ROOT / "src" / "domain"
-APPLICATION_PATH = PROJECT_ROOT / "src" / "application"
-INFRAESTRUCTURE_PATH = PROJECT_ROOT / "src" / "infrastructure"
-DB_PATH = INFRAESTRUCTURE_PATH / "database"
+# Las rutas se resuelven al ejecutar el comando, no al importar el módulo: `hexcore/__init__.py`
+# importa este módulo, así que una constante a nivel de módulo resolvía la configuración
+# en import time — antes de que la aplicación pudiera llamar a
+# `LazyConfig.set_config_modules()`, y por tanto contra la config equivocada.
+def _project_root() -> Path:
+    """La raíz del proyecto, según la configuración vigente."""
+    return LazyConfig.get_config().base_dir
 
-MODELS_PATH = DB_PATH / "models"
-DOCUMENTS_PATH = DB_PATH / "documents"
 
-TESTS_DOMAIN_PATH = PROJECT_ROOT / "tests" / "domain"
+def _domain_path() -> Path:
+    return _project_root() / "src" / "domain"
 
-README = PROJECT_ROOT / "README.md"
-GITIGNORE = PROJECT_ROOT / ".gitignore"
-MANAGE = PROJECT_ROOT / "manage.py"
+
+def _tests_domain_path() -> Path:
+    return _project_root() / "tests" / "domain"
 
 
 @app.command(name="init")
@@ -126,7 +126,7 @@ def create_domain_module(
         )
         raise typer.Exit(code=1)
 
-    module_path = DOMAIN_PATH / module_name
+    module_path = _domain_path() / module_name
 
     if module_path.exists():
         typer.secho(
@@ -162,7 +162,7 @@ def create_domain_module(
             typer.secho(f"  -> Archivo creado: {file_path}", fg=typer.colors.GREEN)
 
         # 3. Crear directorio y archivos de test
-        test_module_path = TESTS_DOMAIN_PATH / module_name
+        test_module_path = _tests_domain_path() / module_name
         typer.echo(f"Creando el módulo de tests '{module_name}' en: {test_module_path}")
         test_module_path.mkdir(parents=True, exist_ok=True)
         typer.secho(
@@ -194,7 +194,7 @@ def create_domain_module(
             f"2. Define las interfaces de repositorio en 'src/domain/{module_name}/repositories.py'."
         )
         typer.echo(
-            f"3. Escribe pruebas para tus entidades en '{test_entities_path.relative_to(PROJECT_ROOT)}'."
+            f"3. Escribe pruebas para tus entidades en '{test_entities_path.relative_to(_project_root())}'."
         )
 
     except OSError as e:

--- a/hexcore/infrastructure/cqrs/middlewares.py
+++ b/hexcore/infrastructure/cqrs/middlewares.py
@@ -54,8 +54,24 @@ class LoggingMiddleware(IMiddleware):
 
 class RetryMiddleware(IMiddleware):
     """
-    Middleware de reintentos con backoff exponencial.
+    Middleware de reintentos con backoff exponencial, **in-process**.
     Solo reintenta excepciones en ``retryable_exceptions``.
+
+    **Cuidado al combinarlo con Smart Routing.** Los reintentos se multiplican: si la cola
+    reintenta el job 3 veces y este middleware reintenta 3 veces dentro de cada intento,
+    el handler corre hasta 12 veces, no 6. Con un handler no idempotente eso son 12
+    cobros, no 12 logs.
+
+    Elegí uno de los dos:
+
+    - **El de la cola** (recomendado para `@background_command`): la cola persiste el
+      intento, sobrevive a un reinicio del worker y su backoff se ve en el panel.
+      Instanciá el bus sin este middleware.
+    - **Éste** para comandos síncronos, donde no hay cola que reintente y el usuario está
+      esperando la respuesta.
+
+    Si lo declarás y el mensaje además va a background, el middleware avisa una vez por
+    tipo de comando con un `warning`.
     """
 
     def __init__(
@@ -68,8 +84,12 @@ class RetryMiddleware(IMiddleware):
         self._max_retries = max_retries
         self._base_delay = base_delay
         self._retryable_exceptions = retryable_exceptions
+        self._warned: set[str] = set()
+        self._logger = logging.getLogger("hexcore.cqrs.retry")
 
     async def handle(self, message: t.Any, next_handler: NextHandler) -> t.Any:
+        self._warn_if_also_retried_by_the_queue(message)
+
         last_exception: Exception | None = None
         for attempt in range(self._max_retries + 1):
             try:
@@ -80,6 +100,29 @@ class RetryMiddleware(IMiddleware):
                     delay = self._base_delay * (2**attempt)
                     await asyncio.sleep(delay)
         raise last_exception  # type: ignore[misc]
+
+    def _warn_if_also_retried_by_the_queue(self, message: t.Any) -> None:
+        """
+        Avisa una vez por tipo si el mensaje también lo reintenta la cola.
+
+        Una vez por tipo y no por mensaje: en un worker con carga, un warning por job
+        llena el log y deja de leerse.
+        """
+        message_type = type(message)
+        if not getattr(message_type, "__cqrs_background__", False):
+            return
+
+        name = message_type.__qualname__
+        if name in self._warned:
+            return
+        self._warned.add(name)
+        self._logger.warning(
+            "'%s' está decorado con @background_command y además pasa por "
+            "RetryMiddleware: los reintentos se multiplican (%d in-process x los de la "
+            "cola). Si el handler no es idempotente, quitá uno de los dos.",
+            name,
+            self._max_retries,
+        )
 
 
 class ValidationMiddleware(IMiddleware):

--- a/hexcore/infrastructure/task_queues/celery_adapter.py
+++ b/hexcore/infrastructure/task_queues/celery_adapter.py
@@ -7,12 +7,104 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import threading
 import typing as t
 import weakref
 
 from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
 
 logger = logging.getLogger("hexcore.task_queues.celery")
+
+
+class _PersistentLoop:
+    """
+    Un event loop por proceso worker, en un hilo dedicado.
+
+    `asyncio.run()` por tarea crea y **cierra** un loop nuevo cada vez. Con un
+    `AsyncEngine` de SQLAlchemy compartido eso produce `Event loop is closed` y
+    `Future attached to a different loop`: el pool guarda conexiones atadas al loop de la
+    tarea anterior, que ya no existe.
+
+    Detalle imprescindible con el pool *prefork* de Celery: el loop se crea de forma
+    perezosa y se comprueba el PID en cada uso. Un loop y un hilo creados antes del fork
+    no son utilizables en el hijo, así que al detectar un PID distinto se crean de nuevo.
+    """
+
+    def __init__(self) -> None:
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._pid: int | None = None
+        self._lock = threading.RLock()
+
+    def run(self, coro: t.Coroutine[t.Any, t.Any, t.Any]) -> t.Any:
+        """Ejecuta la corutina en el loop del proceso y espera su resultado."""
+        loop = self._ensure_loop()
+        return asyncio.run_coroutine_threadsafe(coro, loop).result()
+
+    def _ensure_loop(self) -> asyncio.AbstractEventLoop:
+        with self._lock:
+            current_pid = os.getpid()
+            if (
+                self._loop is not None
+                and self._pid == current_pid
+                and self._thread is not None
+                and self._thread.is_alive()
+            ):
+                return self._loop
+
+            if self._loop is not None and self._pid != current_pid:
+                logger.debug(
+                    "Fork detectado (pid %s → %s): se crea un event loop nuevo.",
+                    self._pid,
+                    current_pid,
+                )
+
+            loop = asyncio.new_event_loop()
+            thread = threading.Thread(
+                target=loop.run_forever,
+                name="hexcore-celery-loop",
+                daemon=True,
+            )
+            thread.start()
+            self._loop, self._thread, self._pid = loop, thread, current_pid
+            return loop
+
+    def shutdown(self, timeout: float = 5.0) -> None:
+        """Para el loop y su hilo. Idempotente."""
+        with self._lock:
+            loop, thread = self._loop, self._thread
+            self._loop = self._thread = self._pid = None
+
+        if loop is None:
+            return
+        loop.call_soon_threadsafe(loop.stop)
+        if thread is not None:
+            thread.join(timeout=timeout)
+        loop.close()
+
+
+_LOOP = _PersistentLoop()
+
+
+def run_in_worker_loop(coro: t.Coroutine[t.Any, t.Any, t.Any]) -> t.Any:
+    """
+    Ejecuta una corutina en el event loop persistente del proceso worker.
+
+    Útil para tareas de Celery propias que también toquen el `AsyncEngine`: si usás
+    `asyncio.run()` en ellas, vuelve el problema que este módulo resuelve.
+    """
+    return _LOOP.run(coro)
+
+
+def shutdown_worker_loop(timeout: float = 5.0) -> None:
+    """
+    Para el event loop persistente.
+
+    Llamalo desde la señal `worker_shutdown` de Celery si querés un apagado limpio; no es
+    obligatorio, porque el hilo es daemon.
+    """
+    _LOOP.shutdown(timeout)
 
 if t.TYPE_CHECKING:
     try:
@@ -96,8 +188,14 @@ def register_hexcore_celery_tasks(
     Es **idempotente**: llamarla dos veces sobre la misma app no vuelve a registrar.
     Antes cada aplicación tenía que protegerla con un flag de módulo.
 
-    Dado que las tareas de Celery son síncronas y el Consumer de HexCore es
-    asíncrono, se envuelven en `asyncio.run()`.
+    Las tareas de Celery son síncronas y el Consumer de HexCore es asíncrono, así que se
+    ejecutan en un **event loop persistente por proceso** (ver `_PersistentLoop`), no con
+    `asyncio.run()` por tarea. Con `asyncio.run()` y un `AsyncEngine` compartido aparecen
+    `Event loop is closed` y `attached to a different loop`.
+
+    Limitación conocida: las tareas se ejecutan en un hilo distinto al que Celery usa para
+    la tarea. Si tu código depende de estado thread-local puesto por Celery (algunos
+    plugins de tracing lo hacen), pásalo explícitamente al handler.
 
     Returns:
         True si se registraron las tareas, False si ya estaban registradas.
@@ -111,15 +209,15 @@ def register_hexcore_celery_tasks(
 
     @app.task(name="hexcore.process_command", bind=True)
     def process_command(self: t.Any, payload: dict[str, t.Any]) -> None:
-        asyncio.run(consumer.process_command(payload))
+        _LOOP.run(consumer.process_command(payload))
 
     @app.task(name="hexcore.process_handler", bind=True)
     def process_handler(self: t.Any, handler_name: str, payload: dict[str, t.Any]) -> None:
-        asyncio.run(consumer.process_handler(handler_name, payload))
+        _LOOP.run(consumer.process_handler(handler_name, payload))
 
     @app.task(name="hexcore.process_task", bind=True)
     def process_task(self: t.Any, task_name: str, payload: dict[str, t.Any]) -> None:
-        asyncio.run(consumer.process_task(task_name, payload))
+        _LOOP.run(consumer.process_task(task_name, payload))
 
     try:
         _registered_apps[id(app)] = app

--- a/hexcore/sql.py
+++ b/hexcore/sql.py
@@ -1,0 +1,95 @@
+"""
+Fachada de la capa SQL: un import obvio por tarea.
+
+::
+
+    import hexcore.sql as sql
+
+    sql.init_engine()                       # arranque
+    async with sql.session_scope() as s:    # fuera de un request
+        ...
+    await sql.dispose_engine()              # apagado
+
+Requiere el extra ``[sql]``. La resolución es perezosa, así que importar este módulo no
+falla sin SQLAlchemy; falla —con el error de SQLAlchemy— al pedir el primer nombre.
+"""
+from __future__ import annotations
+
+import typing as t
+
+_EXPORTS: dict[str, tuple[str, str]] = {
+    # ── Engine y sesiones ─────────────────────────────────────────────────────
+    "init_engine": (
+        "hexcore.infrastructure.repositories.orms.sqlalchemy.session",
+        "init_engine",
+    ),
+    "dispose_engine": (
+        "hexcore.infrastructure.repositories.orms.sqlalchemy.session",
+        "dispose_engine",
+    ),
+    "get_engine": (
+        "hexcore.infrastructure.repositories.orms.sqlalchemy.session",
+        "get_engine",
+    ),
+    "get_session_factory": (
+        "hexcore.infrastructure.repositories.orms.sqlalchemy.session",
+        "get_session_factory",
+    ),
+    "PoolSettings": (
+        "hexcore.infrastructure.repositories.orms.sqlalchemy.session",
+        "PoolSettings",
+    ),
+    "normalize_async_dsn": (
+        "hexcore.infrastructure.repositories.orms.sqlalchemy.session",
+        "normalize_async_dsn",
+    ),
+    # ── Scopes (fuera de FastAPI) ─────────────────────────────────────────────
+    "session_scope": ("hexcore.infrastructure.uow.scopes", "session_scope"),
+    "uow_scope": ("hexcore.infrastructure.uow.scopes", "uow_scope"),
+    "open_uow_scope": ("hexcore.infrastructure.uow.scopes", "open_uow_scope"),
+    "nosql_uow_scope": ("hexcore.infrastructure.uow.scopes", "nosql_uow_scope"),
+    # ── Modelos y UoW ─────────────────────────────────────────────────────────
+    "Base": ("hexcore.infrastructure.repositories.orms.sqlalchemy", "Base"),
+    "BaseModel": ("hexcore.infrastructure.repositories.orms.sqlalchemy", "BaseModel"),
+    "SqlAlchemyUnitOfWork": ("hexcore.infrastructure.uow", "SqlAlchemyUnitOfWork"),
+    "SqlAlchemyRepository": (
+        "hexcore.infrastructure.repositories.implementations",
+        "SqlAlchemyRepository",
+    ),
+    "BaseSQLAlchemyRepository": (
+        "hexcore.infrastructure.repositories.base",
+        "BaseSQLAlchemyRepository",
+    ),
+    # ── Consultas ─────────────────────────────────────────────────────────────
+    "QueryRequestDTO": ("hexcore.application.dtos.query", "QueryRequestDTO"),
+    "QueryResponseDTO": ("hexcore.application.dtos.query", "QueryResponseDTO"),
+    "FilterConditionDTO": ("hexcore.application.dtos.query", "FilterConditionDTO"),
+    "FilterOperator": ("hexcore.application.dtos.query", "FilterOperator"),
+    "SortConditionDTO": ("hexcore.application.dtos.query", "SortConditionDTO"),
+    "SortDirection": ("hexcore.application.dtos.query", "SortDirection"),
+    "CursorPageDTO": ("hexcore.application.dtos.cursor", "CursorPageDTO"),
+    "CursorRequestDTO": ("hexcore.application.dtos.cursor", "CursorRequestDTO"),
+    "UnsupportedQueryFieldError": (
+        "hexcore.application.dtos.errors",
+        "UnsupportedQueryFieldError",
+    ),
+}
+
+__all__ = sorted(_EXPORTS)
+
+
+def __getattr__(name: str) -> t.Any:
+    try:
+        module_path, attribute = _EXPORTS[name]
+    except KeyError:
+        raise AttributeError(f"module 'hexcore.sql' has no attribute {name!r}") from None
+
+    import importlib
+
+    value = getattr(importlib.import_module(module_path), attribute)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return __all__

--- a/tests/test_celery_event_loop.py
+++ b/tests/test_celery_event_loop.py
@@ -1,0 +1,215 @@
+"""
+P1-4: el adaptador de Celery ya no crea (y cierra) un event loop por tarea.
+
+`asyncio.run()` por tarea, con un `AsyncEngine` de SQLAlchemy compartido, produce
+`Event loop is closed` y `Future attached to a different loop`: el pool guarda conexiones
+atadas al loop de la tarea anterior, que ya no existe. Es el problema que llevó a la app
+real a abandonar Celery.
+"""
+from __future__ import annotations
+
+import asyncio
+import sys
+import threading
+import typing as t
+from unittest.mock import MagicMock
+
+import pytest
+
+sys.modules.setdefault("celery", MagicMock())
+
+from hexcore.infrastructure.task_queues import celery_adapter  # noqa: E402
+from hexcore.infrastructure.task_queues.celery_adapter import (  # noqa: E402
+    register_hexcore_celery_tasks,
+    run_in_worker_loop,
+    shutdown_worker_loop,
+)
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+@pytest.fixture(autouse=True)
+def _fresh_loop():
+    shutdown_worker_loop()
+    yield
+    shutdown_worker_loop()
+
+
+class CollectingApp:
+    """App de Celery mínima que guarda las funciones registradas."""
+
+    def __init__(self) -> None:
+        self.tasks: dict[str, t.Callable[..., t.Any]] = {}
+
+    def task(self, *args: t.Any, **kwargs: t.Any):
+        name = kwargs["name"]
+
+        def decorator(func):
+            self.tasks[name] = func
+            return func
+
+        return decorator
+
+
+def test_the_same_loop_is_reused_across_calls():
+    loops: list[int] = []
+
+    async def record() -> None:
+        loops.append(id(asyncio.get_running_loop()))
+
+    for _ in range(5):
+        run_in_worker_loop(record())
+
+    assert len(set(loops)) == 1, "se creó un event loop distinto por llamada"
+
+
+def test_the_loop_stays_open_between_calls():
+    """El síntoma exacto: la segunda llamada veía el loop de la primera ya cerrado."""
+    captured: list[asyncio.AbstractEventLoop] = []
+
+    async def capture() -> None:
+        captured.append(asyncio.get_running_loop())
+
+    run_in_worker_loop(capture())
+    first = captured[0]
+
+    assert first.is_closed() is False
+
+    run_in_worker_loop(capture())
+
+    assert captured[1] is first
+
+
+def test_an_asyncio_primitive_survives_between_tasks():
+    """
+    Lo que rompía de verdad: un objeto atado al loop (aquí un Event; en producción el
+    pool del AsyncEngine) creado en una tarea y usado en la siguiente.
+    """
+    holder: dict[str, asyncio.Event] = {}
+
+    async def create() -> None:
+        holder["event"] = asyncio.Event()
+
+    async def use() -> None:
+        holder["event"].set()
+        await holder["event"].wait()
+
+    run_in_worker_loop(create())
+    run_in_worker_loop(use())  # con asyncio.run() esto lanza
+
+    assert holder["event"].is_set()
+
+
+def test_results_are_returned():
+    async def compute() -> int:
+        return 42
+
+    assert run_in_worker_loop(compute()) == 42
+
+
+def test_exceptions_propagate_to_the_caller():
+    async def boom() -> None:
+        raise ValueError("falló el handler")
+
+    with pytest.raises(ValueError, match="falló el handler"):
+        run_in_worker_loop(boom())
+
+
+def test_the_loop_runs_in_a_dedicated_named_thread():
+    names: list[str] = []
+
+    async def record() -> None:
+        names.append(threading.current_thread().name)
+
+    run_in_worker_loop(record())
+
+    assert names == ["hexcore-celery-loop"]
+    assert threading.current_thread().name != "hexcore-celery-loop"
+
+
+def test_shutdown_closes_the_loop_and_a_new_one_is_created():
+    captured: list[asyncio.AbstractEventLoop] = []
+
+    async def capture() -> None:
+        captured.append(asyncio.get_running_loop())
+
+    run_in_worker_loop(capture())
+    first = captured[0]
+
+    shutdown_worker_loop()
+    assert first.is_closed() is True
+
+    run_in_worker_loop(capture())
+    assert captured[1] is not first
+
+
+def test_shutdown_is_idempotent():
+    shutdown_worker_loop()
+    shutdown_worker_loop()
+
+
+def test_a_fork_gets_a_fresh_loop():
+    """
+    Con el pool prefork de Celery, un loop creado antes del fork no sirve en el hijo. El
+    adaptador lo detecta comparando el PID.
+    """
+    async def noop() -> None:
+        return None
+
+    run_in_worker_loop(noop())
+    loop_before = celery_adapter._LOOP._loop
+    pid_before = celery_adapter._LOOP._pid
+
+    # Se simula el fork falseando el PID registrado.
+    celery_adapter._LOOP._pid = (pid_before or 0) + 1
+    run_in_worker_loop(noop())
+
+    assert celery_adapter._LOOP._loop is not loop_before
+
+
+def test_registered_tasks_use_the_persistent_loop():
+    app = CollectingApp()
+    seen: list[int] = []
+
+    class Consumer:
+        async def process_command(self, payload: dict) -> None:
+            seen.append(id(asyncio.get_running_loop()))
+
+        async def process_handler(self, handler_name: str, payload: dict) -> None:
+            seen.append(id(asyncio.get_running_loop()))
+
+        async def process_task(self, task_name: str, payload: dict) -> None:
+            seen.append(id(asyncio.get_running_loop()))
+
+    register_hexcore_celery_tasks(t.cast(t.Any, app), t.cast(t.Any, Consumer()))
+
+    app.tasks["hexcore.process_command"](None, {"a": 1})
+    app.tasks["hexcore.process_handler"](None, "h", {"a": 1})
+    app.tasks["hexcore.process_task"](None, "t", {"a": 1})
+
+    assert len(seen) == 3
+    assert len(set(seen)) == 1, "las tareas no comparten el event loop"
+
+
+def test_concurrent_task_submissions_share_the_loop():
+    loops: list[int] = []
+    lock = threading.Lock()
+
+    async def record() -> None:
+        with lock:
+            loops.append(id(asyncio.get_running_loop()))
+
+    def submit() -> None:
+        run_in_worker_loop(record())
+
+    threads = [threading.Thread(target=submit) for _ in range(6)]
+    for thread in threads:
+        thread.start()
+    for thread in threads:
+        thread.join()
+
+    assert len(loops) == 6
+    assert len(set(loops)) == 1

--- a/tests/test_cqrs_middlewares.py
+++ b/tests/test_cqrs_middlewares.py
@@ -9,7 +9,9 @@ import typing as t
 import pytest
 
 from hexcore.application.cqrs.config import CQRSConfig
-from hexcore.infrastructure.cqrs.middlewares import TransactionMiddleware
+from hexcore.domain.cqrs.commands import Command
+from hexcore.domain.cqrs.decorators import background_command
+from hexcore.infrastructure.cqrs.middlewares import RetryMiddleware, TransactionMiddleware
 
 
 @pytest.fixture
@@ -59,3 +61,89 @@ async def test_transaction_middleware_uses_the_injected_factory():
     assert result == "handled:msg"
     assert uow.entered is True
     assert uow.commits == 1
+
+
+# ── P2-3: RetryMiddleware vs el retry de la cola ───────────────────────────────
+
+
+@background_command(queue="bg")
+class RetriedBackgroundCommand(Command):
+    value: str
+
+
+class PlainRetriedCommand(Command):
+    value: str
+
+
+@pytest.mark.anyio
+async def test_retry_middleware_warns_when_the_queue_also_retries(caplog):
+    import logging
+
+    middleware = RetryMiddleware(max_retries=2, base_delay=0)
+
+    async def ok(message: t.Any) -> str:
+        return "ok"
+
+    with caplog.at_level(logging.WARNING, logger="hexcore.cqrs.retry"):
+        await middleware.handle(RetriedBackgroundCommand(value="x"), ok)
+
+    warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+    assert len(warnings) == 1
+    assert "reintentos se multiplican" in warnings[0].getMessage()
+
+
+@pytest.mark.anyio
+async def test_the_warning_is_emitted_once_per_type_not_per_message(caplog):
+    import logging
+
+    middleware = RetryMiddleware(max_retries=1, base_delay=0)
+
+    async def ok(message: t.Any) -> str:
+        return "ok"
+
+    with caplog.at_level(logging.WARNING, logger="hexcore.cqrs.retry"):
+        for i in range(5):
+            await middleware.handle(RetriedBackgroundCommand(value=str(i)), ok)
+
+    assert len([r for r in caplog.records if r.levelno == logging.WARNING]) == 1
+
+
+@pytest.mark.anyio
+async def test_no_warning_for_synchronous_commands(caplog):
+    import logging
+
+    middleware = RetryMiddleware(max_retries=1, base_delay=0)
+
+    async def ok(message: t.Any) -> str:
+        return "ok"
+
+    with caplog.at_level(logging.WARNING, logger="hexcore.cqrs.retry"):
+        await middleware.handle(PlainRetriedCommand(value="x"), ok)
+
+    assert [r for r in caplog.records if r.levelno == logging.WARNING] == []
+
+
+@pytest.mark.anyio
+async def test_retry_middleware_still_retries():
+    attempts: list[int] = []
+    middleware = RetryMiddleware(max_retries=2, base_delay=0)
+
+    async def flaky(message: t.Any) -> str:
+        attempts.append(1)
+        if len(attempts) < 3:
+            raise RuntimeError("aún no")
+        return "ok"
+
+    assert await middleware.handle(PlainRetriedCommand(value="x"), flaky) == "ok"
+    assert len(attempts) == 3
+
+
+@pytest.mark.anyio
+async def test_retry_middleware_reraises_after_exhausting_retries():
+    middleware = RetryMiddleware(max_retries=1, base_delay=0)
+
+    async def always_fails(message: t.Any) -> str:
+        raise RuntimeError("siempre falla")
+
+    with pytest.raises(RuntimeError, match="siempre falla"):
+        await middleware.handle(PlainRetriedCommand(value="x"), always_fails)

--- a/tests/test_documentation_examples.py
+++ b/tests/test_documentation_examples.py
@@ -1,0 +1,398 @@
+"""
+P2-4: los ejemplos de la documentación se ejecutan.
+
+Un ejemplo que nadie ejecuta se desalinea de la API en el primer refactor, y eso es
+exactamente lo que había pasado: `registry.register_command(...)` cuando el método es
+`register_command_handler`, `process_cqrs_command` cuando la tarea es
+`hexcore.process_command`, y `UseCaseCommandHandler(CreateUserUseCase())` sin las
+dependencias del use case.
+
+Este módulo hace dos cosas:
+
+1. Ejecuta versiones vivas de los ejemplos clave (los que enseñan el arranque y el
+   Smart Routing).
+2. Comprueba, contra la API real, que los símbolos y los nombres de método que los
+   documentos mencionan existen — para que un rename rompa el CI y no la app de alguien.
+"""
+from __future__ import annotations
+
+import re
+import typing as t
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+def _read(name: str) -> str:
+    return (REPO_ROOT / name).read_text(encoding="utf-8")
+
+
+# Los mensajes y tareas de los ejemplos van a nivel de módulo, que es exactamente lo que
+# los decoradores exigen desde P0-3: definidos dentro de una función no serían resolubles
+# desde el worker, y el decorador lo rechaza al aplicarse.
+from hexcore.domain.cqrs.commands import Command  # noqa: E402
+from hexcore.domain.cqrs.decorators import (  # noqa: E402
+    background_command,
+    background_task,
+)
+
+
+@background_command(queue="high_priority")
+class _SendEmailCommand(Command):
+    user_id: str
+    template: str
+
+
+@background_task(queue="maintenance")
+async def _clean_old_records_task(days_retention: int) -> None:  # pragma: no cover
+    ...
+
+
+# ── Los ejemplos de arranque, ejecutados ───────────────────────────────────────
+
+
+def test_docs_startup_example_runs():
+    """El ejemplo de "una app HexCore en una pantalla" de DOCS.md."""
+    pytest.importorskip("fastapi")
+    pytest.importorskip("httpx")
+    from fastapi.testclient import TestClient
+
+    from hexcore.fastapi import build_lifespan, create_app
+
+    app = create_app(lifespan=build_lifespan(), routers=[])
+
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+
+
+def test_docs_startup_example_with_sql_engine_step_runs():
+    pytest.importorskip("fastapi")
+    pytest.importorskip("httpx")
+    pytest.importorskip("sqlalchemy")
+    pytest.importorskip("aiosqlite")
+    from fastapi.testclient import TestClient
+
+    from hexcore.fastapi import SqlEngineStep, build_lifespan, create_app
+
+    app = create_app(
+        lifespan=build_lifespan(SqlEngineStep("sqlite+aiosqlite:///:memory:"))
+    )
+
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+
+
+def test_docs_app_features_example_runs():
+    pytest.importorskip("fastapi")
+    pytest.importorskip("httpx")
+    from fastapi.testclient import TestClient
+
+    from hexcore.fastapi import AppFeatures, create_app
+
+    app = create_app(features=AppFeatures(cors=False))
+
+    with TestClient(app) as client:
+        response = client.get("/health", headers={"Origin": "http://x.com"})
+
+    assert "access-control-allow-origin" not in response.headers
+
+
+def test_docs_three_facade_imports_work():
+    import hexcore.cqrs as cqrs
+    import hexcore.sql as sql
+
+    assert cqrs.Command is not None
+    assert sql.session_scope is not None
+
+    pytest.importorskip("fastapi")
+    import hexcore.fastapi as hx
+
+    assert hx.create_app is not None
+
+
+@pytest.mark.anyio
+async def test_docs_scopes_example_runs():
+    pytest.importorskip("sqlalchemy")
+    pytest.importorskip("aiosqlite")
+
+    from sqlalchemy.pool import StaticPool
+
+    import hexcore.sql as sql
+
+    await sql.dispose_engine()
+    sql.init_engine("sqlite+aiosqlite:///:memory:", poolclass=StaticPool)
+    try:
+        async with sql.session_scope() as session:
+            assert session is not None
+    finally:
+        await sql.dispose_engine()
+
+
+# ── El ejemplo de migración de UseCase (P2-4) ──────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_readme_use_case_migration_example_runs():
+    """
+    El ejemplo del README usaba `registry.register_command(...)` —método que no existe— y
+    `UseCaseCommandHandler(CreateUserUseCase())` sin las dependencias del use case.
+    """
+    import hexcore.cqrs as cqrs
+    from hexcore.application.use_cases.base import UseCase
+
+    class CreateUserCommand(cqrs.Command):
+        email: str
+
+    class FakeUoW:
+        created: list[str] = []
+
+    class CreateUserUseCase(UseCase[CreateUserCommand, str]):
+        def __init__(self, uow: t.Any) -> None:
+            self.uow = uow
+
+        async def execute(self, request: CreateUserCommand) -> str:
+            self.uow.created.append(request.email)
+            return request.email
+
+    uow = FakeUoW()
+    registry = cqrs.HandlerRegistry()
+    registry.register_command_handler(
+        CreateUserCommand, cqrs.UseCaseCommandHandler(CreateUserUseCase(uow))
+    )
+
+    bus = cqrs.InMemoryCommandBus(registry=registry)
+    assert await bus.dispatch(CreateUserCommand(email="a@b.c")) == "a@b.c"
+    assert uow.created == ["a@b.c"]
+
+
+@pytest.mark.anyio
+async def test_readme_factory_registration_example_runs():
+    """La variante con `HandlerRegistry.factory(...)` del mismo ejemplo."""
+    import hexcore.cqrs as cqrs
+    from hexcore.application.use_cases.base import UseCase
+
+    class CreateUserCommand(cqrs.Command):
+        email: str
+
+    class CreateUserUseCase(UseCase[CreateUserCommand, str]):
+        def __init__(self, uow: t.Any) -> None:
+            self.uow = uow
+
+        async def execute(self, request: CreateUserCommand) -> str:
+            return request.email
+
+    registry = cqrs.HandlerRegistry()
+    registry.register_command_handler(
+        CreateUserCommand,
+        cqrs.HandlerRegistry.factory(
+            lambda: cqrs.UseCaseCommandHandler(CreateUserUseCase(object()))
+        ),
+    )
+
+    bus = cqrs.InMemoryCommandBus(registry=registry)
+    assert await bus.dispatch(CreateUserCommand(email="x@y.z")) == "x@y.z"
+
+
+# ── El ejemplo de Smart Routing y del worker ────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_readme_smart_routing_and_worker_example_runs():
+    """
+    El contrato que documenta P2-5: el mismo bus encola fuera del worker y ejecuta
+    dentro de él.
+    """
+    import hexcore.cqrs as cqrs
+    from hexcore.testing import InMemoryTaskEnqueuer
+
+    handled: list[str] = []
+
+    class SendEmailHandler:
+        async def handle(self, cmd: t.Any) -> None:
+            handled.append(cmd.user_id)
+
+    registry = cqrs.HandlerRegistry()
+    registry.register_command_handler(_SendEmailCommand, SendEmailHandler())
+    enqueuer = InMemoryTaskEnqueuer()
+    serializer = cqrs.PydanticSerializer()
+
+    command_bus = cqrs.InMemoryCommandBus(
+        registry=registry, enqueuer=enqueuer, serializer=serializer
+    )
+    event_bus = cqrs.InMemoryEventBus(enqueuer=enqueuer, serializer=serializer)
+    consumer = cqrs.CQRSConsumer(command_bus, event_bus)
+
+    # Fuera del worker: encola.
+    await command_bus.dispatch(_SendEmailCommand(user_id="1", template="welcome"))
+    assert enqueuer.command_names == ["_SendEmailCommand"]
+    assert handled == []
+
+    # Dentro del worker, el MISMO bus: ejecuta.
+    await consumer.process_command(enqueuer.commands[0].payload)
+    assert handled == ["1"]
+
+
+@pytest.mark.anyio
+async def test_readme_generic_task_enqueue_example_runs():
+    """El ejemplo que encola una `@background_task` derivando su nombre y su cola."""
+    from hexcore.testing import InMemoryTaskEnqueuer
+
+    enqueuer = InMemoryTaskEnqueuer()
+
+    await enqueuer.enqueue_task(
+        task_name=getattr(_clean_old_records_task, "__cqrs_task_name__"),
+        payload={"days_retention": 30},
+        queue=getattr(_clean_old_records_task, "__cqrs_queue__"),
+    )
+
+    assert enqueuer.tasks[0].name.endswith("_clean_old_records_task")
+    assert enqueuer.tasks[0].queue == "maintenance"
+
+
+@pytest.mark.anyio
+async def test_readme_cron_job_example_runs():
+    """`cron_job()` deriva el task_name del decorador, como dice el README."""
+    pytest.importorskip("sqlalchemy")
+
+    import hexcore.cqrs as cqrs
+
+    definition = cqrs.cron_job(
+        _clean_old_records_task, "*/5 * * * *", payload={"days_retention": 30}
+    )
+
+    assert definition.task_name == getattr(
+        _clean_old_records_task, "__cqrs_task_name__"
+    )
+    assert definition.queue == "maintenance"
+    assert definition.cron_expression == "*/5 * * * *"
+
+
+def test_readme_lock_provider_on_error_example_is_valid():
+    """Las dos formas que el README documenta para `on_error`."""
+    pytest.importorskip("redis")
+
+    from unittest.mock import AsyncMock
+
+    from hexcore.infrastructure.cqrs.redis_lock import RedisLockProvider
+
+    assert RedisLockProvider(AsyncMock(), on_error="skip").on_error == "skip"
+    assert RedisLockProvider(AsyncMock(), on_error="raise").on_error == "raise"
+
+
+def test_readme_command_only_consumer_example_runs():
+    """`cqrs.CQRSConsumer(command_bus)` sin event bus, como dice el README."""
+    import hexcore.cqrs as cqrs
+
+    bus = cqrs.InMemoryCommandBus(registry=cqrs.HandlerRegistry())
+
+    assert cqrs.CQRSConsumer(bus) is not None
+
+
+# ── La documentación no debe mencionar API que no existe ───────────────────────
+
+DOC_FILES = ["README.md", "DOCS.md"]
+
+
+@pytest.mark.parametrize("doc", DOC_FILES)
+def test_docs_do_not_mention_the_wrong_registry_method(doc):
+    """`register_command(` no existe; el método es `register_command_handler`."""
+    content = _read(doc)
+
+    assert not re.search(r"register_command\(", content), (
+        f"{doc} menciona register_command(, que no existe"
+    )
+    assert not re.search(r"register_query\(", content), (
+        f"{doc} menciona register_query(, que no existe"
+    )
+
+
+@pytest.mark.parametrize("doc", DOC_FILES)
+def test_docs_do_not_mention_the_wrong_task_names(doc):
+    """Las tareas del consumidor se llaman `hexcore.process_*`."""
+    content = _read(doc)
+
+    for wrong in ("process_cqrs_command", "process_cqrs_handler", "process_cqrs_task"):
+        assert wrong not in content, f"{doc} menciona {wrong}, que no existe"
+
+
+@pytest.mark.parametrize("doc", DOC_FILES)
+def test_docs_do_not_mention_deleted_api(doc):
+    content = _read(doc)
+
+    assert "MiddlewareConfig" not in content, f"{doc} menciona MiddlewareConfig, borrado"
+
+
+def _code_blocks(content: str) -> list[str]:
+    """Los bloques de código de un markdown. La prosa puede *mencionar* lo que quiera."""
+    return re.findall(r"```[a-zA-Z]*\n(.*?)```", content, re.DOTALL)
+
+
+@pytest.mark.parametrize("doc", DOC_FILES)
+def test_docs_examples_do_not_teach_the_legacy_aliases(doc):
+    """
+    S4: los **ejemplos** enseñan un solo nombre por concepto — los canónicos `Abstract*`.
+    Los alias siguen existiendo en el código, y la prosa puede nombrarlos para explicar
+    que existen; lo que no debe pasar es que un ejemplo los use.
+    """
+    code = "\n".join(_code_blocks(_read(doc)))
+
+    for legacy in ("ICommandBus", "IQueryBus", "ISerializer", "IMiddleware"):
+        assert legacy not in code, (
+            f"un ejemplo de {doc} usa el alias legacy {legacy}; usá su nombre canónico Abstract*"
+        )
+
+
+def test_every_hexcore_symbol_referenced_in_the_docs_exists():
+    """
+    Los símbolos de HexCore que aparecen en un `from hexcore... import ...` de la
+    documentación tienen que existir. Es lo que convierte un rename en un CI rojo.
+    """
+    import importlib
+
+    missing: list[str] = []
+    pattern = re.compile(r"^from (hexcore[\w.]*) import ([^\n(]+)$", re.MULTILINE)
+
+    for doc in DOC_FILES:
+        for module_path, names in pattern.findall(_read(doc)):
+            try:
+                module = importlib.import_module(module_path)
+            except ImportError:
+                continue  # necesita un extra no instalado
+            for raw_name in names.split(","):
+                name = raw_name.strip().split(" as ")[0].strip()
+                if not name or not name.isidentifier():
+                    continue
+                if not hasattr(module, name):
+                    missing.append(f"{doc}: {module_path}.{name}")
+
+    assert not missing, "la documentación referencia símbolos inexistentes: " + ", ".join(
+        missing
+    )
+
+
+def test_docs_facade_attributes_exist():
+    """Los `hx.x` / `cqrs.x` / `sql.x` que menciona la documentación existen."""
+    import importlib
+
+    aliases = {"hx": "hexcore.fastapi", "cqrs": "hexcore.cqrs", "sql": "hexcore.sql"}
+    # `(?<![\w.])` evita capturar el fragmento `cqrs.` de una ruta larga como
+    # `hexcore.application.cqrs.commands`, que no es un uso de la fachada.
+    pattern = re.compile(r"(?<![\w.])(hx|cqrs|sql)\.([A-Za-z_][A-Za-z0-9_]*)\b")
+    missing: list[str] = []
+
+    for doc in DOC_FILES:
+        for alias, attribute in pattern.findall(_read(doc)):
+            facade = importlib.import_module(aliases[alias])
+            if attribute not in facade.__all__:
+                missing.append(f"{doc}: {alias}.{attribute}")
+
+    assert not missing, "la documentación usa atributos que la fachada no exporta: " + ", ".join(
+        sorted(set(missing))
+    )

--- a/tests/test_facades.py
+++ b/tests/test_facades.py
@@ -1,0 +1,180 @@
+"""
+S3: módulos fachada `hexcore.cqrs`, `hexcore.sql` y `hexcore.fastapi`.
+
+Requisitos:
+- Reexportan lo público **sin mover nada de sitio**: la ruta larga sigue valiendo y
+  devuelve exactamente el mismo objeto.
+- Nada de I/O ni side effects en import time (S5), y por tanto el import de la fachada no
+  arrastra las dependencias opcionales.
+"""
+from __future__ import annotations
+
+import importlib
+import os
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+FACADES = ["hexcore.cqrs", "hexcore.sql", "hexcore.fastapi"]
+
+
+@pytest.mark.parametrize("facade_name", FACADES)
+def test_facade_exports_resolve_to_the_canonical_object(facade_name):
+    """La fachada no crea objetos nuevos: apunta a los de siempre."""
+    facade = importlib.import_module(facade_name)
+
+    for name, (module_path, attribute) in facade._EXPORTS.items():
+        try:
+            module = importlib.import_module(module_path)
+        except ImportError:
+            pytest.skip(f"{module_path} necesita un extra no instalado")
+        expected = getattr(module, attribute)
+        assert getattr(facade, name) is expected, f"{facade_name}.{name}"
+
+
+@pytest.mark.parametrize("facade_name", FACADES)
+def test_facade_all_matches_its_exports(facade_name):
+    facade = importlib.import_module(facade_name)
+
+    assert facade.__all__ == sorted(facade._EXPORTS)
+    assert dir(facade) == facade.__all__
+
+
+@pytest.mark.parametrize("facade_name", FACADES)
+def test_unknown_attribute_raises_attribute_error(facade_name):
+    facade = importlib.import_module(facade_name)
+
+    with pytest.raises(AttributeError, match="no attribute"):
+        facade.DefinitelyNotExported
+
+
+@pytest.mark.parametrize("facade_name", FACADES)
+def test_resolution_is_cached_in_module_globals(facade_name):
+    facade = importlib.import_module(facade_name)
+    name = facade.__all__[0]
+
+    first = getattr(facade, name)
+    assert name in vars(facade)
+    assert getattr(facade, name) is first
+
+
+def test_cqrs_facade_exposes_only_the_canonical_names():
+    """
+    S4: un solo nombre por concepto en la superficie que enseña la documentación. Los
+    alias `I*` siguen existiendo en su módulo, pero no aquí.
+    """
+    import hexcore.cqrs as cqrs
+
+    assert "AbstractCommandBus" in cqrs.__all__
+    for legacy in ("ICommandBus", "IQueryBus", "IEventBus", "ISerializer", "IMiddleware"):
+        assert legacy not in cqrs.__all__, f"{legacy} no debería estar en la fachada"
+
+    # Pero el alias sigue importable por su ruta de siempre.
+    from hexcore.domain.cqrs.buses import ICommandBus
+
+    assert ICommandBus is cqrs.AbstractCommandBus
+
+
+def test_cqrs_facade_covers_the_smart_routing_workflow():
+    """El caso de uso que motivó la fachada: montar CQRS con un solo import."""
+    import hexcore.cqrs as cqrs
+
+    registry = cqrs.HandlerRegistry()
+    bus = cqrs.InMemoryCommandBus(
+        registry=registry,
+        enqueuer=None,
+        serializer=cqrs.PydanticSerializer(),
+    )
+
+    assert bus is not None
+    assert callable(cqrs.background_command)
+    assert cqrs.CQRSConsumer is not None
+
+
+@pytest.mark.parametrize(
+    ("facade_name", "hidden"),
+    [
+        ("hexcore.cqrs", "fastapi"),
+        ("hexcore.cqrs", "sqlalchemy"),
+        ("hexcore.cqrs", "redis"),
+        ("hexcore.cqrs", "procrastinate"),
+        ("hexcore.sql", "fastapi"),
+        ("hexcore.sql", "sqlalchemy"),
+        ("hexcore.fastapi", "sqlalchemy"),
+        ("hexcore.fastapi", "redis"),
+    ],
+)
+def test_importing_a_facade_does_not_require_optional_dependencies(facade_name, hidden):
+    """
+    S5: nada de I/O ni imports pesados en import time. La resolución perezosa es lo que
+    permite que `import hexcore.cqrs` funcione sin el extra `[sql]`.
+    """
+    code = f"""
+import sys
+
+class Blocker:
+    @classmethod
+    def find_spec(cls, fullname, path, target=None):
+        if fullname.split(".")[0] == "{hidden}":
+            raise ImportError("bloqueado: " + fullname)
+        return None
+
+sys.meta_path.insert(0, Blocker)
+
+import {facade_name}
+assert {facade_name}.__all__
+print("ok")
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "."
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, env=env
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout
+
+
+def test_hexcore_fastapi_does_not_shadow_the_real_fastapi():
+    """
+    El módulo se llama `hexcore.fastapi`; con imports absolutos (el default en Python 3)
+    los módulos internos siguen viendo el paquete `fastapi` real. Vale comprobarlo.
+    """
+    pytest.importorskip("fastapi")
+
+    import fastapi
+
+    import hexcore.fastapi as hx
+
+    assert fastapi.__name__ == "fastapi"
+    assert hx.__name__ == "hexcore.fastapi"
+    assert hx.create_app.__module__ == "hexcore.infrastructure.api.app"
+
+
+def test_facades_do_not_execute_io_on_import():
+    """
+    Importar las tres fachadas no debe crear engines, conexiones ni leer configuración.
+    """
+    code = """
+import hexcore.cqrs, hexcore.sql, hexcore.fastapi
+from hexcore.infrastructure.repositories.orms.sqlalchemy import session
+assert session._engine is None, "importar las fachadas creó un engine"
+from hexcore.config import LazyConfig
+assert LazyConfig._imported_config is None, "importar las fachadas resolvió la config"
+print("ok")
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "."
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, env=env
+    )
+
+    assert result.returncode == 0, result.stderr
+    assert "ok" in result.stdout


### PR DESCRIPTION
**4º de 4.** Reemplaza a #32 (que se mergeó contra `release/2.7.0-factories`, no a `master`).
Descripción detallada por ítem en **#32**.

**Ítems del plan:** P1-4, P2-1, P2-3, S3, S4, S5, S7, P2-4, P2-5 (Fase 4).

> **Mergear #33, #34 y #35 primero.** Ahora muestra 33 commits; tras ellos se reduce a sus 5.
> Este PR contiene el estado completo y verificado del plan, así que también sirve como red:
> si algo se torciera en la secuencia, mergear sólo este deja `master` correcto (con un único
> bump en vez de cuatro).

## Contenido (5 commits propios)

| Ítem | Qué arregla |
| :-- | :-- |
| **P1-4** | El adaptador de Celery envolvía cada task en `asyncio.run()`, que **cierra** el loop: con un `AsyncEngine` compartido produce `Event loop is closed` y `attached to a different loop`. Es el problema que llevó a la app real a abandonar Celery. Ahora un loop persistente por proceso, con detección del fork del pool *prefork* comparando el PID. |
| **P2-1 / S7** | `MiddlewareConfig` era código muerto: `_build_middlewares` instancia con `cls()` y nunca lo leía, así que el `options={"max_retries": 3}` del propio ejemplo iba al **bus**. Se borra, junto a siete constantes sin uso de la CLI. |
| **P2-3** | `RetryMiddleware` compite con el retry de la cola y los reintentos se **multiplican** (3 × 3 = 12 ejecuciones, no 6). Con un handler no idempotente, 12 cobros. Se documenta y se avisa. |
| **S3 / S4** | Fachadas `hexcore.cqrs` / `hexcore.sql` / `hexcore.fastapi`, que reexportan lo público **sin mover nada de sitio** (verificado por identidad para cada nombre). Resolución perezosa: `import hexcore.cqrs` funciona sin los extras. Sólo exponen los nombres canónicos `Abstract*`. |
| **P2-4 / P2-5** | Documentación alineada con la API real y **ejecutada en CI**. |

## Dos violaciones de S5 que el plan daba por respetada

El test de las fachadas ("nada de I/O en import time") las destapó:

- `cli.py` calculaba `PROJECT_ROOT = LazyConfig.get_config().base_dir` a nivel de módulo, y
  `hexcore/__init__.py` importa `cli` — así que **importar `hexcore` resolvía la
  configuración** antes de que la app pudiera llamar a `LazyConfig.set_config_modules()`.
- `BaseDomainService.__init__` tenía `event_bus = LazyConfig().get_config().event_bus` como
  **default de argumento**, evaluado al importar, congelando el bus de la primera resolución.

## Lo que impide que la documentación se vuelva a desalinear

`tests/test_documentation_examples.py` **ejecuta** los ejemplos (arranque, migración de use
case, Smart Routing web vs worker, cron, locks) y además verifica contra la API real que todo
símbolo de un `from hexcore... import ...` existe y que todo `hx.x`/`cqrs.x`/`sql.x` está en la
fachada. Más guardas negativos para los errores concretos del plan: nada de
`register_command(`, nada de `process_cqrs_*`, nada de `MiddlewareConfig`, ningún alias legacy
en un bloque de código.

Un rename ahora rompe el CI en vez de la app de alguien.

## Riesgo / compatibilidad

⚠️ **BREAKING (menor).** `MiddlewareConfig` deja de ser importable desde
`hexcore.application.cqrs`. No tenía comportamiento, así que quien lo declaraba no pierde
funcionalidad — sólo tiene que quitar el import. **Si preferís un shim deprecado en su lugar,
se revierte en un commit.**

El resto aditivo. La firma de `register_hexcore_celery_tasks` no cambia.

Limitación de P1-4 documentada en el docstring: las corutinas corren en un hilo distinto al de
la tarea de Celery, así que el estado thread-local de algunos plugins de tracing hay que
pasarlo explícitamente.

## Criterio de cierre de la fase

- [x] Los ejemplos de la documentación se ejecutan en CI
- [x] El "hello world" de la guía cabe en una pantalla (`DOCS.md` abre con él)

## Verificación

`530 passed, 0 skipped` con los comandos exactos del workflow.
