### PR TITLE
docs+feat!: README de v5, política de soporte y DeprecationWarning en la API anterior a 5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,5 @@
 __pycache__
 .mypy_cache
 *.egg-info
+# Índice local de CodeGraph (no es artefacto del proyecto)
+.codegraph/

--- a/README.md
+++ b/README.md
@@ -1,22 +1,55 @@
 # HexCore [![PyPI Downloads](https://static.pepy.tech/personalized-badge/hexcore?period=total&units=INTERNATIONAL_SYSTEM&left_color=BLACK&right_color=GREEN&left_text=downloads)](https://pepy.tech/projects/hexcore)
-HexCore es un módulo base reutilizable para proyectos Python que implementan arquitectura hexagonal y event handling.
+
+Núcleo reutilizable para aplicaciones Python con **arquitectura hexagonal**, **DDD**, **CQRS**
+y **tareas en background**. HexCore trae las abstracciones (entidades, repositorios, UoW,
+buses) *y* la infraestructura que normalmente reescribe cada proyecto: la capa de sesión SQL,
+las factories de FastAPI, el runner del worker, el cron dinámico y las utilidades de test.
+
+El objetivo de diseño es que el camino feliz sea **cero configuración**: `create_app()` sin
+argumentos da una app usable, `init_engine()` sin argumentos da un engine de producción
+correcto.
+
+```python
+# main.py — el arranque completo de una app HexCore
+from hexcore.fastapi import build_lifespan, create_app, SqlEngineStep
+
+app = create_app(
+    lifespan=build_lifespan(SqlEngineStep()),
+    routers=[usuarios_router, tickets_router],
+)
+```
+
+```python
+# worker.py — el worker completo, con cron, muerte mutua y SIGTERM
+import hexcore.cqrs as cqrs
+
+await cqrs.run_procrastinate_worker(
+    procrastinate_app,
+    queues=["default", "reactive"],
+    scheduler=cqrs.DynamicScheduler(repo, enqueuer, lock_provider=lock),
+    on_startup=[lambda: cqrs.seed_cron_jobs(CRON_JOBS)],
+)
+```
 
 ---
 
-## Skills del Proyecto
+## Índice
 
-Este repositorio cuenta con un conjunto de skills adicionales para extender y personalizar funcionalidades en VS Code y otros entornos compatibles. Puedes encontrarlas en:
-
-- [Repositorio de Skills de HexCore](https://github.com/Indroic/hexcore-skill)
-
----
-
-## ¿Qué provee HexCore?
-
-- **Clases base y abstracciones** para entidades, repositorios, servicios y unidad de trabajo (UoW), siguiendo los principios de DDD y arquitectura hexagonal.
-- **Interfaces y contratos** para caché, eventos y manejo de dependencias, desacoplando la lógica de negocio de la infraestructura.
-- **Utilidades para event sourcing y event dispatching** listas para usar en cualquier proyecto.
-- **Estructura flexible** para que puedas construir microservicios o aplicaciones monolíticas desacopladas y testeables.
+- [Instalación](#instalación)
+- [Los tres imports](#los-tres-imports)
+- [Qué trae, de un vistazo](#qué-trae-de-un-vistazo)
+- [Capa SQL: engine, sesiones y scopes](#capa-sql-engine-sesiones-y-scopes)
+- [Utilidades FastAPI](#utilidades-fastapi)
+- [Arquitectura CQRS](#arquitectura-cqrs)
+- [Task Queues (Smart Routing)](#task-queues-smart-routing)
+- [Tareas periódicas dinámicas (cron en caliente)](#tareas-periódicas-dinámicas-cron-en-caliente)
+- [Utilidades de test](#utilidades-de-test)
+- [Repositorios y entidades](#repositorios-y-entidades)
+- [Configuración](#configuración)
+- [Templates de proyecto (CLI)](#templates-de-proyecto-cli)
+- [Versiones y soporte](#versiones-y-soporte) ← **todo lo anterior a 5.0 está deprecado**
+- [Guía de migración a 5.x](#guía-de-migración-a-5x)
+- [Contribuir](#contribuir)
 
 ---
 
@@ -26,477 +59,489 @@ Este repositorio cuenta con un conjunto de skills adicionales para extender y pe
 pip install hexcore
 ```
 
-## Templates de Proyecto (CLI)
+HexCore no arrastra dependencias pesadas: todo lo que no es el núcleo va en **extras**, y los
+módulos que las necesitan sólo las importan cuando los usás.
 
-HexCore incluye templates base para bootstrap de proyectos:
+| Extra | Trae | Habilita |
+| :-- | :-- | :-- |
+| `[api]` | FastAPI, Uvicorn | `hexcore.fastapi`: `create_app`, lifespan, middlewares, health, rate limit, streaming |
+| `[sql]` | SQLAlchemy, asyncpg, Alembic | `hexcore.sql`, repositorios SQL, cron en SQL, `PostgresLockProvider` |
+| `[mongo]` | Beanie, PyMongo | Repositorios y UoW de MongoDB |
+| `[redis]` | redis | `RedisEventBus`, `RedisLockProvider`, `RedisCache` |
+| `[procrastinate]` | Procrastinate | `ProcrastinateEnqueuer`, `run_procrastinate_worker` |
+| `[rabbitmq]` | aio-pika | `RabbitMQEventBus` y su worker |
+| `[all]` | todo lo anterior | — |
 
 ```sh
-hexcore init mi_proyecto --template hexagonal
-hexcore init mi_proyecto --template vertical-slice
+pip install "hexcore[api,sql,procrastinate]"
+pip install "hexcore[all]"
 ```
 
-- `hexagonal`: crea `src/domain`, `src/application`, `src/infrastructure`.
-- `vertical-slice`: crea `src/features`, `src/shared/domain`, `src/shared/application`, `src/shared/infrastructure`.
-
-En ambos templates se generan:
-- `config.py` en raíz con `repository_discovery_paths` de ejemplo.
-- estructura de migraciones con Alembic.
+> `import hexcore.cqrs` funciona sin ningún extra: la resolución de nombres es perezosa, así
+> que `hexcore.cqrs.SqlAlchemyCronJobRepository` sólo exige `[sql]` en el momento en que lo
+> pedís.
 
 ---
 
-## Configuración v2 (Folder-Agnostic)
+## Los tres imports
 
-Desde v2, HexCore usa configuración explícita y no aplica fallback implícito para descubrir repositorios.
-
-### 1. Configuración visible en raíz
-
-Define un archivo `config.py` en la raíz del proyecto:
+Hay un módulo fachada por tarea. Reexportan lo público **sin mover nada de sitio**: las rutas
+largas siguen funcionando y devuelven el mismo objeto.
 
 ```python
-from hexcore.config import ServerConfig
+import hexcore.fastapi as hx    # create_app, build_lifespan, providers, middlewares, health
+import hexcore.cqrs as cqrs     # Command, Query, handlers, decoradores, buses, worker, cron
+import hexcore.sql as sql       # init_engine, session_scope, uow_scope, Base, DTOs de query
+```
 
-config = ServerConfig(
-    repository_discovery_paths={
-        "myapp.features.users.infrastructure.repositories",
-        "myapp.features.billing.infrastructure.repositories",
-    }
+Las fachadas exponen **sólo los nombres canónicos** (`AbstractCommandBus`,
+`AbstractSerializer`, …). Los alias históricos `I*` siguen importables por su ruta de siempre,
+pero están deprecados — ver [Versiones y soporte](#versiones-y-soporte).
+
+---
+
+## Qué trae, de un vistazo
+
+| Necesitás | API | Extra |
+| :-- | :-- | :-- |
+| Una app FastAPI cableada | `hx.create_app()`, `hx.AppFeatures` | `api` |
+| Orquestar el arranque y el apagado | `hx.build_lifespan()` + steps | `api` |
+| Engine y sesiones SQL | `sql.init_engine()`, `sql.dispose_engine()`, `sql.PoolSettings` | `sql` |
+| Sesión o UoW fuera de un request | `sql.session_scope()`, `sql.uow_scope()` | `sql` |
+| Request-id correlacionado en los logs | `hx.RequestIDMiddleware`, `hx.install_request_id_logging()` | `api` |
+| Excepciones de dominio → HTTP | `hx.register_exception_handlers()` | `api` |
+| Health checks que sondean de verdad | `hx.register_health_routes()`, `hx.check_health()` | `api` |
+| Rate limiting | `hx.rate_limit()` | `api` |
+| SSE / WebSocket / límite de conexiones | `hx.sse_stream()`, `hx.ws_heartbeat()`, `hx.connection_slot()` | `api` |
+| Composición de routers | `hx.build_root_router()`, `hx.mount_routers()` | `api` |
+| Endpoints de listado y búsqueda | `hx.register_query_endpoint()` | `api` |
+| Paginación por cursor | `sql.CursorPageDTO`, `sql.CursorRequestDTO` | `sql` |
+| Commands, Queries y eventos | `cqrs.Command`, `cqrs.Query`, `cqrs.HandlerRegistry` | — |
+| Ejecutar en background | `cqrs.background_command`, `cqrs.background_handler`, `cqrs.background_task` | — |
+| Entrypoint del worker | `cqrs.run_cqrs_worker()`, `cqrs.run_procrastinate_worker()` | — |
+| Cron editable en caliente | `cqrs.DynamicScheduler`, `cqrs.SqlAlchemyCronJobRepository` | `sql` |
+| Locks distribuidos | `cqrs.RedisLockProvider`, `cqrs.PostgresLockProvider` | `redis` / `sql` |
+| Testear todo lo anterior | `hexcore.testing` | — |
+
+---
+
+## Capa SQL: engine, sesiones y scopes
+
+```python
+import hexcore.sql as sql
+
+sql.init_engine()          # en el arranque; sin argumentos usa config.async_sql_database_url
+await sql.dispose_engine() # en el apagado
+```
+
+`init_engine()` sin argumentos ya produce un engine correcto para producción. Lo que **no** es
+configurable porque es la única respuesta correcta:
+
+- **`expire_on_commit=False`.** Con el default de SQLAlchemy (`True`) los atributos de las
+  entidades expiran al comitear, y el siguiente acceso dispara un lazy-load sobre una sesión
+  cerrada → `MissingGreenlet` / `DetachedInstanceError`.
+- **Normalización del DSN.** Un `DATABASE_URL` de PaaS viene como `postgresql://…` y
+  `create_async_engine` no lo acepta. Se traduce a `postgresql+asyncpg://` solo. Si tu DSN ya
+  declara driver, se respeta.
+
+Lo que sí se configura va en un objeto de settings, no en una lista de keywords:
+
+```python
+sql.init_engine(
+    url="postgresql://user:pass@host/db",           # opcional; se normaliza
+    pool=sql.PoolSettings(size=20, max_overflow=10, recycle=1800),
+    echo=True,                                      # cualquier kwarg de create_async_engine
 )
 ```
 
-### 2. Prioridad para cargar configuración
+`pool.pre_ping` va en `True` por defecto a propósito: un pool sin pre-ping contra Postgres
+detrás de un balanceador entrega conexiones muertas al primer failover.
 
-`LazyConfig` resuelve módulos en este orden:
+### Fuera de un request
 
-1. `HEXCORE_CONFIG_MODULE`
-2. `HEXCORE_CONFIG_MODULES` (lista separada por comas)
-3. módulos configurados por `LazyConfig.set_config_modules(...)`
-4. `config` por defecto (raíz del proyecto)
-
-### 3. Regla de discovery en v2
-
-- Si `repository_discovery_paths` está vacío, no se cargan módulos de repositorios.
-- UoW falla con error explícito para evitar comportamiento ambiguo.
-
----
-
-## Pautas de Colaboración
-
-¡Gracias por tu interés en contribuir a HexCore! Para mantener una colaboración organizada y eficiente, sigue estas pautas:
-
-### 1. Código de Conducta
-Mantén siempre una comunicación respetuosa y profesional. Revisa el [Código de Conducta](CODE_OF_CONDUCT.md) antes de interactuar.
-
-### 2. Cómo Contribuir
-- **Forkea** el repositorio y crea una rama para tu contribución (`feature/nombre`, `fix/nombre`, etc.).
-- Realiza tus cambios en la rama y asegúrate de que el código funcione correctamente.
-- Escribe una descripción clara y detallada en tu pull request (PR).
-- Relaciona los issues relevantes en tu PR si aplica.
-
-### 3. Estilo y Formato de Código
-- Sigue la guía de estilos de Python ([PEP8](https://pep8.org/)).
-- Usa comentarios cuando sea necesario para clarificar el propósito del código.
-- Idealmente, incluye pruebas unitarias para nuevas funciones y arreglos.
-
-### 4. Revisión de Pull Requests
-- Todos los PR serán revisados antes de ser aceptados. Se pueden solicitar cambios o aclaraciones.
-- Responde a los comentarios de los revisores para facilitar el proceso.
-
-### 5. Issues
-- Describe claramente los problemas que encuentres.
-- Proporciona información relevante (logs, versiones, pasos para reproducir, etc.).
-
-### 6. Comunicación
-- Usa los issues y las discusiones para preguntas, sugerencias o propuestas.
-- Si tienes dudas sobre cómo empezar, puedes abrir un issue para orientación.
-
-### 7. Licencia
-Al contribuir, aceptas que tu código será distribuido bajo la licencia del repositorio.
-
----
-
-## Documentación Básica
-
-### Estructura principal
-
-HexCore se organiza con los siguientes submódulos y carpetas:
-
-- **src/domain/**: Módulos de dominio, entidades, repositorios, servicios, objetos de valor, eventos, enums y excepciones.
-  ```
-  src/domain/{modulo}/
-    ├─ __init__.py
-    ├─ entities.py
-    ├─ repositories.py
-    ├─ services.py
-    ├─ value_objects.py
-    ├─ events.py
-    ├─ enums.py
-    └─ exceptions.py
-  ```
-- **src/application/**: Casos de uso (UseCase) y DTOs para orquestar la lógica de negocio.
-- **src/infrastructure/**: Implementaciones técnicas (ORM/ODM, CLI, caché, base de datos, repositorios, unit of work).
-- **src/infrastructure/database/models/**: Modelos SQLAlchemy para base de datos relacional.
-- **src/infrastructure/database/documents/**: Documentos Beanie para MongoDB.
-- **tests/**: Pruebas para módulos de dominio e infraestructura.
-
----
-
-### Abstracciones de Entidades y Eventos
-
-#### BaseEntity
-
-Clase base para entidades de dominio. Provee atributos comunes y gestión de eventos.
+`get_session`/`get_sql_uow` son dependencias de FastAPI. Para workers, tasks, cron, scripts y
+seeds hay scopes:
 
 ```python
-from hexcore.domain.base import BaseEntity
+async with sql.session_scope() as session:      # sesión pelada
+    rows = (await session.execute(select(CronJobModel))).scalars().all()
 
-class User(BaseEntity):
-    id: UUID
-    name: str
+async with sql.uow_scope() as uow:              # UoW SIN abrir
+    await CerrarTicketUseCase(uow).execute(request)
+
+async with sql.open_uow_scope() as uow:         # UoW ya abierto
+    await uow.tickets.save(ticket)
+    await uow.commit()
 ```
 
-#### DomainEvent y eventos de entidad
+`session_scope` no construye el UoW a propósito: construirlo corre el auto-discovery e
+instancia **todos** los repositorios de dominio, un coste absurdo para leer una tabla de
+infraestructura.
 
-Abstracciones para eventos de dominio y para ciclo de vida de entidades.
-
-```python
-from hexcore.domain.events import DomainEvent, EntityCreatedEvent
-
-class UserCreatedEvent(EntityCreatedEvent[User]):
-    pass
-
-user = User(...)
-event = UserCreatedEvent(entity_id=user.id, payload={"name": user.name})
-```
+**Convención de transacción.** `uow_scope` y la dependencia `hx.get_sql_uow` ceden el UoW
+**sin entrar** en él, para que el use case controle su propio `async with self.uow:` sin anidar
+contextos. Si querés el UoW ya abierto, usá `open_uow_scope` / `hx.get_sql_uow_open`.
 
 ---
 
-### Implementaciones de Repositorios
+## Utilidades FastAPI
 
-#### SQLAlchemyCommonImplementationsRepo
-
-Repositorio genérico para modelos SQLAlchemy con métodos CRUD reutilizables.
+### `create_app()`
 
 ```python
-class SQLAlchemyCommonImplementationsRepo(BaseSQLAlchemyRepository[T], HasBasicArgs[T, M], t.Generic[T, M]):
-    # Métodos principales: get_by_id, list_all, save, delete
-    ...
+from hexcore.fastapi import create_app
+
+app = create_app()   # ya es una app usable
 ```
 
-**Ejemplo:**
+Sin argumentos cablea: `title`/`version` desde `ServerConfig`, CORS desde
+`config.allow_origins`, middleware `X-Request-ID`, middleware de timing, mapeo de excepciones
+de dominio a HTTP, y las rutas `/health` y `/health/ready`.
+
+Los interruptores van en **un solo objeto**, no en ocho keywords:
 
 ```python
-class UserRepository(SQLAlchemyCommonImplementationsRepo[UserEntity, UserModel]):
-    def __init__(self, uow):
-        super().__init__(
-            entity_cls=UserEntity,
-            model_cls=UserModel,
-            not_found_exception=UserNotFoundException,
-            fields_resolvers=None,
-            fields_serializers=None,
-            uow=uow
-        )
-```
+from hexcore.fastapi import AppFeatures, create_app
 
-#### BeanieODMCommonImplementationsRepo
-
-Repositorio genérico para documentos Beanie ODM (MongoDB) con métodos CRUD reutilizables.
-
-```python
-class BeanieODMCommonImplementationsRepo(IBaseRepository[T], HasBasicArgs[T, D], t.Generic[T, D]):
-    # Métodos principales: get_by_id, list_all, save, delete
-    ...
-```
-
-**Ejemplo:**
-
-```python
-class UserRepository(BeanieODMCommonImplementationsRepo[UserEntity, UserDocument]):
-    def __init__(self, uow):
-        super().__init__(
-            entity_cls=UserEntity,
-            document_cls=UserDocument,
-            not_found_exception=UserNotFoundException,
-            fields_resolvers=None,
-            fields_serializers=None,
-            uow=uow
-        )
-```
-
----
-
-### Inicialización y Descubrimiento de Documentos Beanie
-
-Para inicializar y registrar automáticamente todos los documentos Beanie:
-
-```python
-from hexcore.infrastructure.repositories.orms.beanie.utils import init_beanie_documents
-
-await init_beanie_documents()
-```
-
----
-
-### Conversión entre modelos/documentos y entidades
-
-Ambos repositorios utilizan `to_entity_from_model_or_document` para convertir modelos ORM/ODM en entidades del dominio, aplicando resolvers para atributos complejos.
-
----
-
----
-
-## Arquitectura CQRS en HexCore
-
-HexCore v2 integra de forma nativa soporte para el patrón **CQRS (Command Query Responsibility Segregation)**, permitiendo separar conceptual y técnicamente las operaciones de escritura (Commands) de las de lectura (Queries). 
-
-### ¿Cómo funciona el CQRS en HexCore?
-
-El sistema se basa en 3 buses principales, configurables e independientes:
-
-1. **`AbstractCommandBus`**: Despacha inteniones de mutación (`Command`) a un único `AbstractCommandHandler`. Los commands modifican el estado del sistema. La transacción la gestiona el handler (el patrón que enseñan los ejemplos de use case); si preferís que la gestione el bus, añadí `TransactionMiddleware` explícitamente con su `uow_factory`.
-2. **`AbstractQueryBus`**: Despacha intenciones de lectura (`Query`) a un único `AbstractQueryHandler`. Retornan un resultado sin mutar el estado.
-3. **`EventBus`**: Distribuye eventos de dominio (`DomainEvent`) a múltiples suscriptores asíncronamente (vía `subscribe`/`publish`).
-
-La configuración de CQRS se activa mediante el `CQRSConfig` en tu `ServerConfig`:
-
-```python
-from hexcore.config import ServerConfig
-from hexcore.application.cqrs.config import CQRSConfig, BusConfig
-
-config = ServerConfig(
-    cqrs=CQRSConfig(
-        command_bus=BusConfig(
-            # Sin middlewares por defecto. Los que no necesitan configuración se
-            # pueden declarar por dotted path:
-            middlewares=["hexcore.infrastructure.cqrs.middlewares.LoggingMiddleware"]
-        ),
-        # Puedes sustituir el backend en memoria por uno distribuido (Ej: Celery, Procrastinate)
-        # backend="mi_app.infrastructure.ProcrastinateCommandBus" 
-    )
+app = create_app(
+    features=AppFeatures(cors=False, timing=False),
+    routers=[(usuarios_router, {"prefix": "/api/v1"})],
+    title="Red API",          # cualquier kwarg de FastAPI se reenvía tal cual
 )
 ```
 
-> **`TransactionMiddleware` no es el default.** Comitea después del handler, así que
-> con un handler que ya gestiona su propia transacción comitearías dos veces. Y
-> necesita un `uow_factory` construido con *tu* engine, cosa que no se puede expresar
-> como dotted path: instancialo a mano y pasá el pipeline al bus.
->
-> ```python
-> TransactionMiddleware(uow_factory=lambda: SqlAlchemyUnitOfWork(session=session_factory()))
-> ```
-
----
-
-### Guía de Migración: De Casos de Uso Clásicos a CQRS
-
-Si ya tienes una aplicación escrita con la abstracción `UseCase` de HexCore, puedes migrar progresivamente a CQRS sin reescribir todo tu código, utilizando los adaptadores incluidos.
-
-#### Paso 1: Usar el adaptador `UseCaseCommandHandler`
-
-En lugar de instanciar un UseCase directamente en tu endpoint, envuélvelo en un comando:
+### `build_lifespan()`
 
 ```python
-import hexcore.cqrs as cqrs
-
-# 1. Tienes tu UseCase legado, con sus dependencias
-class CreateUserUseCase(UseCase[CreateUserCommand, UserDTO]):
-    def __init__(self, uow: IUnitOfWork) -> None:
-        self.uow = uow
-
-    async def execute(self, request: CreateUserCommand) -> UserDTO:
-        # logica legacy
-        ...
-
-# 2. Lo registras en el registry de CQRS utilizando el adaptador
-registry = cqrs.HandlerRegistry()
-registry.register_command_handler(
-    CreateUserCommand,
-    cqrs.UseCaseCommandHandler(CreateUserUseCase(uow)),
+from hexcore.fastapi import (
+    BeanieStep, CallableStep, CronSeedStep, EventBusStep,
+    ProcrastinateStep, SqlEngineStep, build_lifespan, create_app,
 )
 
-# O con un factory, si quieres resolver las dependencias en el momento del dispatch:
-registry.register_command_handler(
-    CreateUserCommand,
-    cqrs.HandlerRegistry.factory(
-        lambda: cqrs.UseCaseCommandHandler(CreateUserUseCase(build_uow()))
+app = create_app(
+    lifespan=build_lifespan(
+        SqlEngineStep(),
+        BeanieStep(documents=MONGO_DOCUMENTS),
+        EventBusStep(RealtimeEventDispatcher()),
+        ProcrastinateStep(procrastinate_app),
+        CronSeedStep(CRON_JOBS),
+        CallableStep("warm-caches", warm_validation_cache, on_error="warn"),
     ),
 )
 ```
 
-> El método es `register_command_handler` (y `register_query_handler`), no
-> `register_command`.
+Garantías que son la razón de existir del helper:
 
-#### Paso 2: Consumirlo desde el endpoint usando el CommandBus
+- **Teardown en orden inverso**, y sólo de los steps que **sí** arrancaron.
+- `on_error="warn"` **por step**: un warmup de caché no debe tumbar el arranque, y eso se
+  declara en el step sin relajar la política de todo el arranque.
+- Un log por step con su duración.
+- Un teardown que falla no impide los siguientes ni tapa la excepción que provocó el apagado.
+
+### Health checks
 
 ```python
-@router.post("/users")
-async def create_user(
-    cmd: CreateUserCommand, 
-    # factory inyectado por dependencias
-    bus: AbstractCommandBus = Depends(get_command_bus)
-):
-    # El bus despacha el comando al UseCase legacy de forma transparente
-    result = await bus.dispatch(cmd)
-    return result
+from hexcore.fastapi import Probe, register_health_routes
+
+register_health_routes(app)                      # /health y /health/ready
+register_health_routes(app, path="/_status")     # o donde quieras
 ```
 
-#### Paso 3 (Final): Refactor a Handler Puro
+- `/health` → **liveness**: 200 sin tocar nada. Es lo correcto: si sondeara dependencias, un
+  Redis caído provocaría que Kubernetes reiniciara una app perfectamente sana.
+- `/health/ready` → **readiness**: `SELECT 1` al engine, `ping` a Redis y a Mongo, con timeout
+  propio por sonda y todas concurrentes. Devuelve **503** con el detalle y la latencia por
+  dependencia.
 
-Cuando estés listo, convierte tu UseCase directamente en un `AbstractCommandHandler`:
+Una dependencia no crítica reporta `degraded` en vez de `down` (sin Redis la app sirve más
+lento, no deja de servir):
+
+```python
+register_health_routes(app, probes=[
+    Probe("sql", check_database),
+    Probe("cache", check_redis, timeout=1.0, critical=False),
+])
+```
+
+### Rate limiting
+
+```python
+from fastapi import Depends
+from hexcore.fastapi import rate_limit
+
+@router.get("/reports", dependencies=[Depends(rate_limit(10, 60))])
+async def reports(): ...
+
+por_usuario = rate_limit(100, 3600, key=lambda r: r.state.user_id)
+```
+
+Se apoya en el puerto `ICache`, no en Redis directamente, así que funciona con `MemoryCache` en
+tests. Devuelve **429 con `Retry-After`**, y la política ante un backend caído es explícita:
+
+```python
+rate_limit(10, 60, on_backend_error="allow")  # default: un Redis caído no tumba la API
+rate_limit(10, 60, on_backend_error="deny")
+```
+
+### Request-id correlacionado
+
+```python
+from hexcore.fastapi import get_request_id, install_request_id_logging
+
+install_request_id_logging(fmt="%(asctime)s [%(request_id)s] %(message)s")
+```
+
+`RequestIDMiddleware` reusa el header entrante si viene (romper la cadena del gateway es perder
+la traza) y lo publica en un `ContextVar` y en `request.state`. `install_request_id_logging()`
+lo inyecta en **cada línea de log**, que es la mitad del valor: sin eso, tener el header no
+correlaciona nada.
+
+### Streaming: SSE, WebSocket y límite de conexiones
+
+```python
+from hexcore.fastapi import connection_slot, sse_stream, ws_heartbeat
+
+@router.get("/events")
+async def events():
+    return sse_stream(mi_generador(), heartbeat_seconds=30)
+```
+
+El heartbeat es un comentario SSE que los clientes ignoran y los proxies cuentan como tráfico:
+sin él, un balanceador con idle timeout corta la conexión. Se añade también
+`X-Accel-Buffering: no`, sin el cual nginx acumula los eventos y el stream llega a bloques.
+
+```python
+async with connection_slot(cache, f"ws:{user_id}", max_connections=3) as granted:
+    if not granted:
+        await ws.close(code=1013)
+        return
+    await ws.accept()
+    async with ws_heartbeat(ws, interval=30):
+        ...
+```
+
+`connection_slot` libera el slot **aunque el bloque lance o se cancele**: filtrar un slot al
+desconectarse mal deja al usuario sin poder reconectar hasta que expire, y es el bug clásico de
+estos límites.
+
+### Composición de routers
+
+```python
+from fastapi import Depends
+from hexcore.fastapi import build_root_router, mount_routers
+
+admin = build_root_router(
+    "/admin",
+    {"/users": users_router, "/reports": reports_router},
+    dependencies=[Depends(require_admin)],
+    tags=["admin"],
+)
+
+mount_routers(app, [admin, (public_router, {"prefix": "/v1"})])
+```
+
+### Endpoints de listado y búsqueda
+
+```python
+from fastapi import Depends
+from hexcore.fastapi import register_query_endpoint
+
+register_query_endpoint(
+    router,
+    path="/tickets",
+    use_case_factory=lambda: QueryEntitiesUseCase(repo),
+    dependencies=[Depends(get_current_user)],
+)
+```
+
+Soporta `limit`/`offset`, `search`, `search_fields`, `filters` (`campo:operador:valor`) y `sort`
+(`campo:asc|desc`). Un campo inválido devuelve un **422 estructurado** con `field` y `allowed`,
+no un string crudo.
+
+Para listados grandes, donde `OFFSET 100000` obliga a escanear 100.000 filas, hay paginación
+por cursor:
+
+```python
+import hexcore.sql as sql
+
+page = await repo.query_cursor(sql.CursorRequestDTO(limit=50, sort_field="created_at"))
+page.items, page.next_cursor
+```
+
+El cursor es opaco (base64url de `(sort_key, id)`) a propósito: si fuera legible, los clientes
+lo construirían a mano y quedaría congelado como API pública.
+
+### Providers CQRS
+
+```python
+from fastapi import Depends
+from hexcore.fastapi import configure_cqrs, provide_command_bus
+
+container = configure_cqrs(registry, enqueuer=enqueuer)   # una vez, al arrancar
+
+@router.post("/tickets")
+async def crear(cmd: CrearTicket, bus=Depends(provide_command_bus)):
+    return await bus.dispatch(cmd)
+```
+
+Existen como funciones por una única razón: poder sobreescribirlas con
+`app.dependency_overrides` en los tests. Y `container.build_consumer()` construye el consumer
+del worker sobre **los mismos** buses y el mismo serializer, así que no hay dos fuentes de
+verdad entre la web y el worker.
+
+---
+
+## Arquitectura CQRS
+
+HexCore integra CQRS de forma nativa, separando las operaciones de escritura (Commands) de las
+de lectura (Queries).
+
+Tres buses configurables e independientes:
+
+1. **`AbstractCommandBus`** — despacha intenciones de mutación (`Command`) a un único handler.
+   La transacción la gestiona el handler; si preferís que la gestione el bus, añadí
+   `TransactionMiddleware` con su `uow_factory`.
+2. **`AbstractQueryBus`** — despacha intenciones de lectura (`Query`) y retorna un resultado sin
+   mutar estado.
+3. **`AbstractEventBus`** — distribuye eventos de dominio a múltiples suscriptores.
+
+```python
+import hexcore.cqrs as cqrs
+
+class CrearTicket(cqrs.Command):
+    titulo: str
+
+class CrearTicketHandler:
+    async def handle(self, cmd: CrearTicket) -> str: ...
+
+registry = cqrs.HandlerRegistry()
+registry.register_command_handler(CrearTicket, CrearTicketHandler())
+
+bus = cqrs.InMemoryCommandBus(registry=registry)
+await bus.dispatch(CrearTicket(titulo="Algo se rompió"))
+```
+
+Para resolver dependencias en el momento del dispatch, registrá un factory:
+
+```python
+registry.register_command_handler(
+    CrearTicket,
+    cqrs.HandlerRegistry.factory(lambda: CrearTicketHandler(build_uow())),
+)
+```
+
+`HandlerRegistry.factory()` es un marcador explícito. Sin él, un handler que implemente
+`__call__` sería indistinguible de un factory.
+
+### Configuración declarativa
+
+```python
+from hexcore.application.cqrs.config import BusConfig, CQRSConfig
+from hexcore.config import ServerConfig
+
+config = ServerConfig(
+    cqrs=CQRSConfig(
+        command_bus=BusConfig(
+            middlewares=["hexcore.infrastructure.cqrs.middlewares.LoggingMiddleware"],
+        ),
+    ),
+)
+```
+
+`middlewares` admite sólo middlewares construibles sin argumentos: se instancian con `cls()`.
+Los que necesitan configuración se instancian a mano y se le pasa el `MiddlewarePipeline` al
+bus. `options` se reenvía al **bus**, no a los middlewares.
+
+> **`TransactionMiddleware` no es el default.** Comitea después del handler, así que con un
+> handler que ya gestiona su transacción comitearías dos veces. Y necesita un `uow_factory`
+> construido con *tu* engine, que no se puede expresar como dotted path:
+>
+> ```python
+> cqrs.TransactionMiddleware(uow_factory=lambda: SqlAlchemyUnitOfWork(session=session_factory()))
+> ```
+
+> **`RetryMiddleware` y el retry de la cola se multiplican.** Si la cola reintenta 3 veces y el
+> middleware 3 veces dentro de cada intento, el handler corre hasta 12 veces, no 6. Con un
+> handler no idempotente eso son 12 cobros. Elegí uno: el de la cola para
+> `@background_command` (persiste el intento y sobrevive a un reinicio del worker), éste para
+> comandos síncronos. El middleware avisa si detecta las dos cosas juntas.
+
+### Migrar desde `UseCase`
+
+Si ya tenés una aplicación escrita con la abstracción `UseCase`, podés migrar
+progresivamente con el adaptador incluido:
+
+```python
+import hexcore.cqrs as cqrs
+
+class CreateUserUseCase(UseCase[CreateUserCommand, UserDTO]):
+    def __init__(self, uow: IUnitOfWork) -> None:
+        self.uow = uow
+
+    async def execute(self, request: CreateUserCommand) -> UserDTO: ...
+
+registry.register_command_handler(
+    CreateUserCommand,
+    cqrs.UseCaseCommandHandler(CreateUserUseCase(uow)),
+)
+```
+
+Cuando estés listo, el use case pasa a ser un handler puro:
 
 ```python
 from hexcore.domain.cqrs import AbstractCommandHandler
 
 class CreateUserHandler(AbstractCommandHandler[CreateUserCommand, UserDTO]):
-    def __init__(self, uow: IUnitOfWork):
+    def __init__(self, uow) -> None:
         self.uow = uow
 
-    async def handle(self, command: CreateUserCommand) -> UserDTO:
-        # Lógica refactorizada
-        return dto
+    async def handle(self, command: CreateUserCommand) -> UserDTO: ...
 ```
 
----
+### Almacenamiento híbrido para lecturas
 
-### Guía: Almacenamiento Híbrido para Queries (Mongo, Redis, SQL)
-
-La mayor ventaja de CQRS es optimizar las lecturas. HexCore permite que tus **Commands** escriban en una base de datos relacional (SQLAlchemy) fuertemente normalizada, mientras que los **Queries** leen de vistas desnormalizadas súper rápidas en MongoDB o Redis.
-
-#### 1. Sincronización a través del EventBus (La Proyección)
-
-Cuando un Command modifica SQL, dispara un Evento de Dominio. Un handler de eventos intercepta este evento y actualiza el "Read Model" en MongoDB o Redis.
+Los Commands escriben en SQL normalizado; las Queries leen de proyecciones desnormalizadas en
+Mongo o Redis, sincronizadas por el EventBus.
 
 ```python
-from hexcore.domain.events import EventBus, DomainEvent
+async def project_user_to_mongodb(event: UserCreatedEvent) -> None:
+    await UserReadDocument(id=event.user_id, name=event.full_name).insert()
 
-class UserCreatedEvent(DomainEvent):
-    user_id: str
-    full_name: str
-    email: str
-
-async def project_user_to_mongodb(event: UserCreatedEvent):
-    """Proyecta el evento en la BD de lectura (MongoDB)"""
-    doc = UserReadDocument(
-        id=event.user_id, 
-        name=event.full_name, 
-        email=event.email
-    )
-    await doc.insert() # usando Beanie (Mongo)
-
-# Registrar la proyección
 event_bus.subscribe(UserCreatedEvent, project_user_to_mongodb)
 ```
 
-#### 2. Query Handler leyendo del Read Model
-
-Tu QueryHandler nunca toca SQL, simplemente ataca directamente a Mongo o Redis para máxima velocidad.
-
-```python
-from hexcore.domain.cqrs import AbstractQueryHandler, Query
-
-class GetUserQuery(Query[UserReadDTO]):
-    user_id: str
-
-class GetUserQueryHandler(AbstractQueryHandler[GetUserQuery, UserReadDTO]):
-    async def handle(self, query: GetUserQuery) -> UserReadDTO:
-        # Consulta ultra rápida a la colección de lectura en MongoDB
-        doc = await UserReadDocument.get(query.user_id)
-        
-        # O desde Redis:
-        # data = await redis_client.get(f"user:{query.user_id}")
-        
-        if not doc:
-            raise UserNotFoundException()
-        return UserReadDTO(**doc.dict())
-```
-
-Con este esquema, alcanzas una alta escalabilidad: tus endpoints GET son despachados por el `QueryBus` respondiendo en milisegundos desde Mongo/Redis, y tus operaciones POST/PUT/DELETE van por el `CommandBus` transaccionando con ACID en SQL.
-
-#### 3. Definición de Modelos de Lectura (Proyecciones)
-
-Una pregunta frecuente es: **¿HexCore genera automáticamente estos modelos de lectura?** 
-La respuesta es **No**. El patrón CQRS sugiere que tus modelos de lectura estén diseñados *específicamente* para lo que tus interfaces visuales (UI) o APIs van a consultar. Por lo tanto, debes definir estos modelos manualmente.
-
-**Si usas MongoDB (Beanie) para lecturas:**
-Debes crear un documento manual optimizado. Por ejemplo, en lugar de tener joins, puedes embeber datos:
-```python
-from beanie import Document
-
-# Modelo desnormalizado optimizado para la lectura
-class UserReadDocument(Document):
-    id: str  # ID referenciado de la tabla SQL
-    name: str
-    email: str
-    total_purchases_cache: int = 0  # Dato pre-calculado por eventos
-
-    class Settings:
-        name = "users_read_projections"
-```
-
-**Si usas PostgreSQL/MySQL (SQLAlchemy) para lecturas:**
-Si prefieres mantenerte 100% en SQL pero aislando lecturas, puedes crear tablas específicas para proyecciones (Materialized Views o tablas planas):
-```python
-from sqlalchemy.orm import declarative_base
-from sqlalchemy import Column, String, Integer
-
-Base = declarative_base()
-
-class UserReadProjection(Base):
-    __tablename__ = 'users_read_projection'
-    
-    # Modelo totalmente plano sin relaciones ForeignKey complejas
-    id = Column(String, primary_key=True)
-    full_name = Column(String)
-    email = Column(String)
-    total_purchases_cache = Column(Integer, default=0)
-```
-En ambos casos, es tu **EventBus** (o un consumidor como Procrastinate) el encargado de instanciar estos modelos manuales y persistirlos cada vez que se detecte un cambio en los modelos de escritura.
+HexCore **no** genera los modelos de lectura: el patrón pide que estén diseñados
+específicamente para lo que tu UI o API consulta, así que los defines vos. También tenés
+`PostgresEventBus(pool, serializer, channel_name)` con `LISTEN/NOTIFY` nativo si no querés
+Redis.
 
 ---
 
-### Integración con Task Queues (Smart Routing)
+## Task Queues (Smart Routing)
 
-HexCore v2 hace que la delegación de tareas a **Celery**, **Procrastinate** o **ARQ** sea increíblemente sencilla y mágica a través del patrón de **Smart Routing**.
-
-Ya no necesitas instanciar buses separados para código síncrono y asíncrono. HexCore enruta automáticamente tus comandos y eventos hacia las colas de background usando simples decoradores.
-
-#### 1. Decoradores de Background
-
-HexCore ofrece 3 decoradores esenciales en `hexcore.domain.cqrs.decorators` para cubrir todos los casos de uso:
-
-1. **`@background_command(queue="...")`**: Aplícalo sobre una clase `Command`. Todo el comando y su handler se ejecutarán asíncronamente en el Worker. Ideal para operaciones pesadas iniciadas por el usuario (ej. Generar un reporte PDF masivo).
-2. **`@background_handler(queue="...")`**: Aplícalo sobre una función que maneje un evento (`DomainEvent`). Permite que un solo evento dispare algunas acciones síncronas rápidas y otras asíncronas lentas (ej. Enviar emails).
-3. **`@background_task(queue="...")`**: Aplícalo sobre funciones o utilidades genéricas que no pertenecen al modelo estricto de CQRS (ej. Limpiar base de datos, tareas tipo CRON).
-
-**Ejemplos de uso:**
+No necesitás buses separados para código síncrono y asíncrono. HexCore enruta comandos y
+eventos hacia las colas con decoradores.
 
 ```python
-from hexcore.domain.cqrs.decorators import background_command, background_handler, background_task
-from hexcore.domain.cqrs.commands import Command
+import hexcore.cqrs as cqrs
 
-# 1. Comando de ejecución asíncrona obligatoria
-@background_command(queue="high_priority")
-class SendEmailCommand(Command):
+@cqrs.background_command(queue="high_priority")
+class SendEmailCommand(cqrs.Command):
     user_id: str
     template: str
 
-# 2. Handler de evento asíncrono
-@background_handler(queue="analytics")
-async def send_analytics_on_user_created(event: UserCreatedEvent):
-    # Lógica costosa...
-    pass
+@cqrs.background_handler(queue="analytics")
+async def on_user_created(event: UserCreatedEvent) -> None: ...
 
-# 3. Tarea genérica (Non-CQRS)
-@background_task(queue="maintenance")
-async def clean_old_records_task(days_retention: int):
-    # Limpieza de base de datos...
-    pass
+@cqrs.background_task(queue="maintenance")
+async def clean_old_records_task(days_retention: int) -> None: ...
 ```
 
-#### 2. Usar un Enqueuer (Adaptador)
+Los tres decoradores **rechazan al decorar** cualquier objeto definido dentro de otra función:
+su `__qualname__` lleva `<locals>` y el worker nunca podría importarlo. Fallar al importar es
+mejor que fallar en el primer job.
 
-No hace falta escribirlo: HexCore trae `ProcrastinateEnqueuer` y `CeleryEnqueuer` listos, y
-registran las tareas del consumidor con los nombres `hexcore.process_command`,
-`hexcore.process_handler` y `hexcore.process_task`.
+### El enqueuer
 
 ```python
 from hexcore.infrastructure.task_queues.procrastinate_adapter import ProcrastinateEnqueuer
@@ -504,117 +549,93 @@ from hexcore.infrastructure.task_queues.procrastinate_adapter import Procrastina
 enqueuer = ProcrastinateEnqueuer(procrastinate_app)
 ```
 
-Si necesitas otro broker, implementa `ITaskEnqueuer` (4 métodos). Dos advertencias:
+HexCore trae `ProcrastinateEnqueuer` y `CeleryEnqueuer`. Si necesitás otro broker, implementá
+`ITaskEnqueuer` (4 métodos), con dos advertencias:
 
-- **`enqueue_event` no es un `pass`.** Una cola de tareas no puede hacer fan-out a "todos
-  los suscriptores", así que los adaptadores oficiales lanzan `NotImplementedError` en vez
-  de perder el evento en silencio. Para ejecutar un suscriptor concreto en background usa
-  `@background_handler` (el EventBus llamará a `enqueue_handler`); para fan-out real usa
-  `RedisEventBus` o `PostgresEventBus`.
-- Si envuelves corutinas en un worker síncrono (Celery), no uses `asyncio.run()` por tarea:
-  cierra el event loop y deja el pool del `AsyncEngine` atado a un loop muerto. HexCore usa
-  un loop persistente por proceso, expuesto como `run_in_worker_loop(coro)`.
+- **`enqueue_event` no es un `pass`.** Una cola de tareas no puede hacer fan-out a "todos los
+  suscriptores", así que los adaptadores oficiales lanzan `NotImplementedError` en vez de
+  perder el evento en silencio. Para ejecutar un suscriptor concreto en background usá
+  `@background_handler`; para fan-out real, `RedisEventBus` o `PostgresEventBus`.
+- **No uses `asyncio.run()` por tarea** en un worker síncrono: cierra el event loop y deja el
+  pool del `AsyncEngine` atado a un loop muerto (`Event loop is closed`). El adaptador de
+  Celery usa un loop persistente por proceso, expuesto como `run_in_worker_loop(coro)`.
 
-#### 3. Configurar tus Buses con un Adaptador Oficial
+### Los buses con Smart Routing
 
-HexCore provee adaptadores *plug & play* para **Celery** y **Procrastinate**. Simplemente importa el enqueuer, pásale tu app y configúralo en los buses de memoria.
-
-Si además deseas persistencia o distribución de Eventos entre múltiples workers/servidores (Pub/Sub), puedes cambiar el `InMemoryEventBus` por `RedisEventBus`, `PostgresEventBus` o `RabbitMQEventBus`:
+La forma recomendada es la factory, que propaga enqueuer y serializer y falla al construir si
+faltan:
 
 ```python
-from hexcore.application.cqrs.in_memory_buses import InMemoryCommandBus
-from hexcore.infrastructure.task_queues.celery_adapter import CeleryEnqueuer
+factory = cqrs.CQRSFactory(cqrs.CQRSConfig(), registry, enqueuer=enqueuer)
+command_bus = factory.create_command_bus()
+event_bus = factory.create_event_bus()
+```
+
+Para eventos distribuidos entre réplicas, sustituí el bus in-memory:
+
+```python
 from hexcore.infrastructure.cqrs.redis_bus import RedisEventBus
-from celery import Celery
-import redis.asyncio as redis
 
-# 1. Adaptador de Task Queue (Para Comandos asíncronos y Event Handlers asíncronos)
-app = Celery("my_app", broker="redis://localhost:6379/0")
-enqueuer = CeleryEnqueuer(app)
-serializer = PydanticSerializer()
-
-command_bus = InMemoryCommandBus(registry=registry, enqueuer=enqueuer, serializer=serializer)
-
-# 2. Event Bus (Para enviar los Eventos por la red)
-redis_client = redis.from_url("redis://localhost:6379/0")
 event_bus = RedisEventBus(
     redis_client=redis_client,
-    serializer=serializer,
+    serializer=cqrs.PydanticSerializer(),
     stream_name="hexcore:events",
     group_name="api_workers",
-    enqueuer=enqueuer  # <-- Importante para inyectarle la habilidad de Smart Routing
+    enqueuer=enqueuer,   # necesario para que el bus pueda enrutar a background
 )
 ```
 
-> **Tip:** También dispones de `PostgresEventBus(pool, serializer, channel_name)` que usa `LISTEN/NOTIFY` nativo si quieres 0 dependencias externas aparte de tu BD de siempre.
-
-#### 4. Ejecutar tareas genéricas
-
-Para encolar la tarea genérica (`@background_task`), la llamas indirectamente pasándola por el enqueuer:
-
-```python
-# Así se encola una tarea genérica sin CQRS:
-await enqueuer.enqueue_task(
-    task_name=clean_old_records_task.__cqrs_task_name__, 
-    payload={"days_retention": 30},
-    queue=clean_old_records_task.__cqrs_queue__
-)
-```
-
-#### 5. Levantar el Worker (Consumidor Universal)
-
-En el entrypoint de tu worker, `register_hexcore_*_tasks` autoconfigura las rutas
-`hexcore.process_command`, `hexcore.process_handler` y `hexcore.process_task`:
+### El worker
 
 ```python
 import hexcore.cqrs as cqrs
-from hexcore.infrastructure.task_queues.celery_adapter import register_hexcore_celery_tasks
+from hexcore.infrastructure.task_queues.procrastinate_adapter import (
+    register_hexcore_procrastinate_tasks,
+)
 
-# Le pasas el MISMO bus que usa el proceso web: el consumer marca el mensaje como
-# "viene del worker", así que el bus lo ejecuta en vez de reencolarlo.
+# El MISMO bus que usa el proceso web: el consumer marca el mensaje como "viene del
+# worker", así que el bus lo ejecuta en vez de reencolarlo.
 consumer = cqrs.CQRSConsumer(command_bus, event_bus)
+register_hexcore_procrastinate_tasks(procrastinate_app, consumer)  # idempotente
 
-register_hexcore_celery_tasks(app, consumer)  # idempotente: llamarla dos veces no revienta
+await cqrs.run_procrastinate_worker(procrastinate_app, queues=["default"], concurrency=4)
 ```
 
-Un worker que sólo procesa comandos puede omitir el event bus: `cqrs.CQRSConsumer(command_bus)`.
+Un worker sólo-comandos puede omitir el event bus: `cqrs.CQRSConsumer(command_bus)`.
 
-Y el entrypoint completo del worker (con scheduler, muerte mutua y SIGTERM) es una llamada:
+`run_cqrs_worker` es la versión genérica, para cualquier broker:
 
 ```python
-await cqrs.run_procrastinate_worker(
-    procrastinate_app,
-    queues=["default", "reactive"],
-    scheduler=cqrs.DynamicScheduler(repo, enqueuer, lock_provider=lock),
-    on_startup=[lambda: cqrs.seed_cron_jobs(CRON_JOBS)],
+await cqrs.run_cqrs_worker(
+    cqrs.worker_loop("mi-broker", mi_consumidor.run, mi_consumidor.stop),
+    scheduler=scheduler,
+    on_startup=[init_todo],
+    on_shutdown=[cerrar_todo],
 )
 ```
 
-#### 6. Ejecutar un comando "aquí y ahora"
+Si **cualquiera** de los bucles muere, se cancela el resto y el proceso sale con `WorkerDied`
+para que el orquestador lo reinicie completo: correr con un bucle caído —encolar sin consumir,
+o al revés— es peor que caerse. `SIGTERM`/`SIGINT` se traducen a drenaje ordenado.
 
-No hay una API separada para esto, y es a propósito: el contrato es que **el bus decide
-por contexto**.
+### Ejecutar un comando "aquí y ahora"
+
+No hay API separada, y es a propósito: **el bus decide por contexto**.
 
 - Fuera de un worker, un `@background_command` se encola.
-- Dentro de un worker (es decir, cuando el mensaje viene del `CQRSConsumer`) el **mismo**
-  bus lo ejecuta localmente. Por eso puedes —y debes— compartir un único bus entre la app
-  web y el worker.
-- Si un handler despacha a propósito otro `@background_command`, ese sí se encola: el
-  contexto de worker se consume en el primer dispatch.
+- Dentro de un worker (el mensaje viene del `CQRSConsumer`) el **mismo** bus lo ejecuta
+  localmente. Por eso podés —y debés— compartir un único bus entre la web y el worker.
+- Si un handler despacha a propósito otro `@background_command`, ése sí se encola: el contexto
+  de worker se consume en el primer dispatch.
 
-Si necesitas comprobarlo desde tu código, `cqrs.is_worker_execution()` responde si el
-mensaje en curso viene de una cola.
+`cqrs.is_worker_execution()` responde si el mensaje en curso viene de una cola.
 
 ---
 
-## Tareas Periódicas Dinámicas (Cronjobs en Caliente)
+## Tareas periódicas dinámicas (cron en caliente)
 
-HexCore incluye un **`DynamicScheduler`** que te permite programar tareas (`@background_task`) para que se ejecuten periódicamente. La ventaja clave es que lee la configuración desde un repositorio (como tu Base de Datos), permitiendo activar, desactivar o cambiar los horarios **sin necesidad de reiniciar tus servidores**.
-
-### 1. Usa el repositorio SQL de serie (o implementa el tuyo)
-
-Si tu cron vive en SQL —el caso normal— no escribas nada: HexCore trae la tabla, el
-repositorio y el seed (extra `[sql]`).
+`DynamicScheduler` lee su configuración de un repositorio, así que podés activar, desactivar o
+cambiar horarios **sin reiniciar nada**.
 
 ```python
 import hexcore.cqrs as cqrs
@@ -627,128 +648,389 @@ CRON_JOBS = [
 await cqrs.create_cron_tables()        # o una migración de Alembic
 await cqrs.seed_cron_jobs(CRON_JOBS)   # idempotente, y NO pisa lo editado en BD
 
-repo = cqrs.SqlAlchemyCronJobRepository()
-```
-
-`cron_job()` deriva el `task_name` de `__cqrs_task_name__`: escribirlo a mano es cómo se
-acaba con un cron que encola una tarea ya renombrada, y el fallo aparece en el worker.
-
-Si tu configuración vive en otro sitio (Mongo, Redis, un YAML), implementa
-`ICronJobRepository`:
-
-```python
-from datetime import datetime
-
-import hexcore.cqrs as cqrs
-
-
-class MiCronRepository(cqrs.ICronJobRepository):
-    async def get_active_jobs(self) -> list[cqrs.CronJobDefinition]:
-        return [
-            cqrs.CronJobDefinition(
-                job_id="clean-db",
-                task_name="mi_app.tasks.clean_old_records_task",  # un @background_task
-                cron_expression="*/5 * * * *",
-                payload={"days_retention": 30},
-                queue="maintenance",
-            )
-        ]
-
-    async def update_last_run(self, job_id: str, run_time: datetime) -> None:
-        # Importa implementarlo: es lo que deduplica el encolado entre ticks.
-        ...
-```
-
-### 2. Levanta el Scheduler
-En un proceso en background de tu API o en un microservicio separado, arranca el Scheduler inyectándole tu Enqueuer favorito (Celery, Procrastinate):
-
-```python
-import hexcore.cqrs as cqrs
-
 scheduler = cqrs.DynamicScheduler(
-    repository=repo,
+    repository=cqrs.SqlAlchemyCronJobRepository(),
     enqueuer=enqueuer,
-    tick_interval_seconds=60,
+    lock_provider=lock_provider,
 )
-
-# Lo normal es dejar que el runner lo supervise junto al worker: si uno de los dos
-# muere, se cancela el otro y el proceso sale para que el orquestador lo reinicie.
-await cqrs.run_procrastinate_worker(procrastinate_app, scheduler=scheduler)
 ```
 
-El Scheduler evalúa las expresiones con `croniter` y delega la carga pesada al enqueuer. Tu
-Worker no necesita saber de horarios, sólo ejecuta las tareas cuando le llegan.
+Si tu cron vive en SQL no escribas nada: HexCore trae la tabla, el repositorio y el seed. Para
+otro origen (Mongo, Redis, un YAML), implementá `cqrs.ICronJobRepository`.
+
+`cron_job()` deriva el `task_name` de `__cqrs_task_name__`: escribirlo a mano es cómo se acaba
+con un cron que encola una tarea ya renombrada, y el fallo aparece en el worker.
 
 **Cómo decide si toca ejecutar.** No compara contra el minuto actual, sino que busca si hubo
-alguna ocurrencia entre la última ejecución (`last_run_at`) y ahora. Dos consecuencias que
-importan:
+alguna ocurrencia entre `last_run_at` y ahora:
 
 - Un minuto saltado por drift del tick **no** pierde la ejecución.
 - `update_last_run` deduplica de verdad, así que un `tick_interval_seconds < 60` no duplica
-  el encolado dentro del mismo proceso. Entre réplicas sí hace falta lock, y el scheduler
-  emite un `RuntimeWarning` si detecta tick sub-minuto sin `lock_provider`.
+  dentro del mismo proceso. Entre réplicas hace falta lock, y el scheduler emite un
+  `RuntimeWarning` si detecta tick sub-minuto sin `lock_provider`.
+- `catch_up_window_seconds` (1 hora) acota el catch-up: un scheduler caído una semana no
+  dispara ocurrencias antiguas.
 
-`catch_up_window_seconds` (1 hora por defecto) acota el catch-up: un scheduler que estuvo
-caído una semana no dispara ocurrencias antiguas.
+### Locks distribuidos
 
-### 3. Distributed Locks (Evitar ejecuciones dobles)
-
-Si corres tu aplicación en múltiples contenedores o réplicas (ej. Kubernetes), podrías tener múltiples instancias del `DynamicScheduler` ejecutándose al mismo tiempo. Para evitar que el mismo cronjob se encole dos veces en el mismo minuto, HexCore soporta **Locks Distribuidos**.
-
-Puedes inyectar un proveedor de locks (`ILockProvider`) usando Redis o PostgreSQL (si lo usas como tu DB). Al inyectarlo, el Scheduler bloqueará atómicamente la tarea a través de toda tu red.
-
-#### Usando Redis
 ```python
-from hexcore.infrastructure.cqrs.redis_lock import RedisLockProvider
-import redis.asyncio as redis
+import hexcore.cqrs as cqrs
 
-redis_client = redis.from_url("redis://localhost:6379/0")
-lock_provider = RedisLockProvider(redis_client)
+lock_provider = cqrs.RedisLockProvider(redis_client)
 
-scheduler = DynamicScheduler(
-    repository=repo, 
-    enqueuer=enqueuer, 
-    lock_provider=lock_provider
+# O sobre Postgres, si no querés levantar Redis:
+lock_provider = cqrs.PostgresLockProvider(asyncpg_pool)
+await lock_provider.setup()   # crea tabla e índice, y purga lo expirado
+```
+
+El provider de Postgres purga las filas expiradas solo (en `setup()` y cada 100
+adquisiciones), así que la tabla no crece sin límite.
+
+**Si el lock no responde**, hay dos respuestas posibles y las dos son malas de formas
+distintas, así que la decisión es tuya y explícita:
+
+```python
+cqrs.RedisLockProvider(client, on_error="skip")   # default: no correr; el cron se detiene
+cqrs.RedisLockProvider(client, on_error="raise")  # propagar, para que el supervisor lo vea
+```
+
+En los logs, "no pude decidir" es `critical`; "el lock estaba tomado por otra réplica" —el caso
+normal— es `debug`.
+
+---
+
+## Utilidades de test
+
+```python
+from hexcore.testing import FakeLockProvider, InMemoryTaskEnqueuer, build_test_buses, override_cqrs
+
+buses = build_test_buses()
+buses.registry.register_command_handler(SendEmailCommand, SendEmailHandler())
+
+await buses.command_bus.dispatch(SendEmailCommand(user_id="1", template="welcome"))
+assert buses.enqueuer.command_names == ["SendEmailCommand"]
+assert buses.enqueuer.commands[0].queue == "high_priority"
+```
+
+`build_test_buses()` monta los tres buses **con** enqueuer y serializer, que es el error más
+común al testear CQRS: montarlos sin ellos y que el primer `@background_command` lance
+`RuntimeError`.
+
+```python
+with override_cqrs(app, command_bus=buses.command_bus):
+    response = client.post("/tickets", json={...})
+```
+
+`override_cqrs` guarda el valor previo de cada override, así que se puede anidar y restaura
+aunque el bloque lance — `app.dependency_overrides` es un dict de instancia, y un override que
+no se limpia se filtra a todos los tests que reusen la app.
+
+`FakeLockProvider` tiene tres modos: concede siempre, niega siempre, y `shared=True`, que se
+comporta como un lock real en memoria para probar dos schedulers concurrentes.
+
+Fixtures de pytest, activables desde tu `conftest.py`:
+
+```python
+pytest_plugins = ["hexcore.testing.fixtures"]
+```
+
+Trae `anyio_backend`, `task_enqueuer`, `lock_provider`, `cqrs_buses`, `sqlite_engine`,
+`sqlite_session` y `uow`.
+
+---
+
+## Repositorios y entidades
+
+### Entidades y eventos
+
+```python
+from hexcore.domain.base import BaseEntity
+from hexcore.domain.events import EntityCreatedEvent
+
+class User(BaseEntity):
+    id: UUID
+    name: str
+
+class UserCreatedEvent(EntityCreatedEvent[User]):
+    pass
+```
+
+### Repositorios genéricos
+
+`SqlAlchemyRepository` y `BeanieRepository` traen los métodos CRUD (`get_by_id`, `list_all`,
+`query_all`, `query_cursor`, `save`, `delete`):
+
+```python
+from hexcore.infrastructure.repositories.implementations import SqlAlchemyRepository
+
+class UserRepository(SqlAlchemyRepository[UserEntity, UserModel]):
+    @property
+    def entity_cls(self): return UserEntity
+
+    @property
+    def not_found_exception(self): return UserNotFoundException
+```
+
+El UoW los inyecta solo, descubriéndolos desde `repository_discovery_paths`. La conversión
+modelo → entidad la hace `to_entity_from_model_or_document`, aplicando resolvers para atributos
+complejos.
+
+### Documentos Beanie
+
+```python
+from hexcore.infrastructure.repositories.orms.beanie.utils import init_beanie_documents
+
+await init_beanie_documents()
+```
+
+O declarativamente, con `hx.BeanieStep(documents=[...])` en el lifespan.
+
+---
+
+## Configuración
+
+Define un `config.py` en la raíz del proyecto:
+
+```python
+from hexcore.config import ServerConfig
+
+config = ServerConfig(
+    app_title="Red API",
+    app_version="5.0.0",
+    async_sql_database_url="postgresql+asyncpg://user:pass@localhost/red",
+    repository_discovery_paths={
+        "myapp.features.users.infrastructure.repositories",
+        "myapp.features.billing.infrastructure.repositories",
+    },
 )
 ```
 
-#### Usando PostgreSQL (asyncpg)
-Si usas Procrastinate o bases de datos SQL y no quieres levantar Redis:
+`LazyConfig` resuelve el módulo de configuración en este orden:
 
-```python
-from hexcore.infrastructure.cqrs.postgres_lock import PostgresLockProvider
+1. `HEXCORE_CONFIG_MODULE`
+2. `HEXCORE_CONFIG_MODULES` (lista separada por comas)
+3. `LazyConfig.set_config_modules(...)`
+4. `config` en la raíz del proyecto
 
-lock_provider = PostgresLockProvider(my_asyncpg_pool)
-await lock_provider.setup() # Crea la tabla y el índice, y purga lo expirado
+Desde v2, el discovery de repositorios es **explícito**: si `repository_discovery_paths` está
+vacío no se carga ningún módulo, y el UoW falla con un error diagnóstico en vez de adivinar.
 
-scheduler = DynamicScheduler(
-    repository=repo, 
-    enqueuer=enqueuer, 
-    lock_provider=lock_provider
-)
+HexCore no ejecuta I/O ni resuelve la configuración en import time, así que podés llamar a
+`LazyConfig.set_config_modules()` antes de que nada la lea.
+
+---
+
+## Templates de proyecto (CLI)
+
+```sh
+hexcore init mi_proyecto --template hexagonal
+hexcore init mi_proyecto --template vertical-slice
 ```
 
-> El provider purga las filas expiradas solo (en `setup()` y cada 100 adquisiciones), así
-> que la tabla de locks no crece sin límite. `purge_expired()` es pública si prefieres
-> purgar desde un job propio, y `purge_every=0` desactiva la purga automática.
+- `hexagonal` → `src/domain`, `src/application`, `src/infrastructure`.
+- `vertical-slice` → `src/features`, `src/shared/{domain,application,infrastructure}`.
 
-#### Qué pasa si el lock no responde
+Ambos generan `config.py` en la raíz con `repository_discovery_paths` de ejemplo y la
+estructura de migraciones con Alembic.
 
-Si Redis (o Postgres) se cae, `acquire_lock` no puede decidir, y las dos respuestas
-posibles son malas de formas distintas. La decisión es tuya y explícita:
+---
 
-```python
-RedisLockProvider(redis_client, on_error="skip")   # default: no correr. El cron se detiene.
-RedisLockProvider(redis_client, on_error="raise")  # propagar, para que el supervisor lo vea.
+## Versiones y soporte
+
+| Serie | Estado | Qué significa |
+| :-- | :-- | :-- |
+| **5.x** | ✅ **Activa** | La única soportada. Recibe features y correcciones. |
+| **4.x** | ⛔ **Deprecada** | Aplicación **parcial**: le faltan el fix del event loop de Celery, las fachadas y la documentación alineada. |
+| **3.x** | ⛔ **Deprecada** | Aplicación **parcial**: tiene las correcciones P0/P1 pero ninguna de las factories de FastAPI. |
+| **2.x** | ⛔ **Deprecada** | Contiene los bugs silenciosos corregidos en 5.x (ver abajo). |
+| **1.x** | ⛔ **Deprecada** | Sin soporte de ningún tipo. |
+
+**Todo lo anterior a 5.0 está deprecado. Migrá a 5.x.**
+
+3.0.0 y 4.0.0 existen sólo porque el trabajo se mergeó por fases y cada merge disparó un bump
+automático: **no son releases pensadas para usarse**, son cortes intermedios de la misma
+migración. 5.0.0 es la primera versión completa.
+
+### Por qué 2.x y anteriores no deberían estar en producción
+
+No es una cuestión de estilo: 2.x tiene defectos que no lanzan excepción y no aparecen en logs
+de error, así que un proyecto puede estar afectado sin saberlo.
+
+| Defecto en ≤ 2.x | Síntoma |
+| :-- | :-- |
+| El worker **reencolaba** los `@background_command` en vez de ejecutarlos | Bucle infinito silencioso: la cola crece sin límite y el handler no corre jamás |
+| FQN partido con `rsplit(".", 1)` | Un `Command` en una clase contenedora, o una task como `@staticmethod`, se encola bien y **falla en el worker**, donde el mensaje ya no se recupera |
+| `PostgresLockProvider` nunca purgaba | ~10.000 filas/día **para siempre** en la BD principal |
+| `expire_on_commit` sin pasar | `MissingGreenlet` / `DetachedInstanceError` al leer una entidad tras `commit()` |
+| `enqueue_event` era un `pass` | El evento se pierde sin traza |
+| `DynamicScheduler` comparaba con el minuto actual | Con `tick=60s` se salta minutos y el job no corre; con `tick<60s` se duplica |
+| Los lock providers devolvían `False` ante cualquier error | Una caída de Redis **apaga el cron entero**, con un log indistinguible del caso normal |
+| `asyncio.run()` por tarea en Celery | `Event loop is closed` con un `AsyncEngine` compartido |
+| `HandlerRegistry` decía ser thread-safe sin ningún lock | Doble instanciación del handler bajo concurrencia |
+
+La superficie de API de v1/v2 **sigue funcionando** en 5.x —los alias de retrocompatibilidad no
+se han borrado— pero está deprecada, emite `DeprecationWarning` y se eliminará en **6.0**.
+
+### API deprecada y su reemplazo
+
+| Deprecado (v1/v2) | Usá en su lugar |
+| :-- | :-- |
+| `ICommandBus`, `IQueryBus`, `IEventBus` | `AbstractCommandBus`, `AbstractQueryBus`, `AbstractEventBus` |
+| `ICommandHandler`, `IQueryHandler` | `AbstractCommandHandler`, `AbstractQueryHandler` |
+| `IMiddleware` | `AbstractMiddleware` |
+| `ISerializer` | `AbstractSerializer` |
+| `IEventDispatcher` | `EventBus` |
+| `EventBus.register()` / `.dispatch()` | `EventBus.subscribe()` / `.publish()` |
+| `ServerConfig.event_dispatcher` | `ServerConfig.event_bus` |
+| `SQLAlchemyCommonImplementationsRepo` | `SqlAlchemyRepository` |
+| `BeanieODMCommonImplementationsRepo` | `BeanieRepository` |
+| `NoSqlUnitOfWork` | `BeanieUnitOfWork` |
+| `reset_sqlalchemy_engine()` | `dispose_engine()` |
+| `MiddlewareConfig` | **Eliminado en 3.0.** Era código muerto: nunca se leía. |
+
+Para ver qué estás usando, corré tus tests con los warnings visibles:
+
+```sh
+python -m pytest -W "default::DeprecationWarning"
 ```
 
-En los logs, "no pude decidir" es `critical` y "el lock estaba tomado por otra réplica"
-—el caso normal— es `debug`.
+---
+
+## Guía de migración a 5.x
+
+La API de 2.x sigue funcionando. Lo que sí cambió de **comportamiento** —y por tanto puede
+requerir acción— es esto:
+
+### 1. `expire_on_commit=False` en el session factory de HexCore
+
+**Qué cambió.** `get_session_factory()` pasa a `expire_on_commit=False`.
+
+**Por qué.** Con el default de SQLAlchemy (`True`) los atributos expiran al comitear y el
+siguiente acceso dispara un lazy-load sobre una sesión cerrada (`MissingGreenlet` /
+`DetachedInstanceError`). La documentación de HexCore ya enseñaba `False`, así que doc e
+implementación no coincidían.
+
+**Acción.** Ninguna en el caso normal: es el comportamiento que casi todo el mundo quería. Si
+dependías de que las entidades se refrescaran tras el commit, construí tu propio
+`async_sessionmaker(engine, expire_on_commit=True)`.
+
+### 2. `get_sql_uow` ya no entra al UoW
+
+**Qué cambió.** La dependencia cede el UoW **sin** abrir la transacción.
+
+**Por qué.** Los ejemplos de use case hacen su propio `async with self.uow:`, que con la
+dependencia anterior anidaba contextos.
+
+**Acción.** Si tu endpoint operaba sobre un UoW ya abierto, cambiá a `get_sql_uow_open`.
+
+### 3. `TransactionMiddleware` fuera del default, y exige `uow_factory`
+
+**Qué cambió.** `CQRSConfig.command_bus` ya no lo incluye, y `TransactionMiddleware()` sin
+`uow_factory` lanza `ValueError`.
+
+**Por qué.** El default armaba la sesión con el session factory *interno* de HexCore en vez del
+engine de tu aplicación, y comiteaba tras el handler — así que un handler que ya comitea
+comiteaba dos veces.
+
+**Acción.** Si lo querés, declaralo a mano:
+
+```python
+cqrs.TransactionMiddleware(uow_factory=lambda: SqlAlchemyUnitOfWork(session=session_factory()))
+```
+
+Y recordá que es para handlers que **no** gestionan su propia transacción.
+
+### 4. `enqueue_event` lanza en vez de callar
+
+**Qué cambió.** `ProcrastinateEnqueuer.enqueue_event` y el de Celery lanzan
+`NotImplementedError`.
+
+**Por qué.** Eran un `pass`: el evento se perdía sin traza.
+
+**Acción.** Usá `@background_handler` para ejecutar un suscriptor concreto en background, o
+`RedisEventBus`/`PostgresEventBus` para fan-out real.
+
+### 5. Los decoradores rechazan objetos no resolubles
+
+**Qué cambió.** `@background_command`/`@background_handler`/`@background_task` lanzan
+`ValueError` si el objeto está definido dentro de otra función (`<locals>` en su
+`__qualname__`).
+
+**Por qué.** El worker nunca podría importarlo: antes el mensaje se encolaba bien y fallaba en
+el worker, donde ya no se puede recuperar.
+
+**Acción.** Mové esas definiciones al nivel de módulo.
+
+### 6. `CQRSFactory` exige el enqueuer si hay comandos de background
+
+**Qué cambió.** Si el registry tiene `@background_command` y la factory no recibió `enqueuer`,
+`create_command_bus()` falla al construir.
+
+**Por qué.** Antes construía un bus que lanzaba `RuntimeError` en el primer dispatch — con la
+petición del usuario ya en vuelo.
+
+**Acción.** `cqrs.CQRSFactory(config, registry, enqueuer=enqueuer)`.
+
+### 7. Cuándo corre un cron job
+
+**Qué cambió.** `DynamicScheduler` decide por catch-up (¿hubo alguna ocurrencia entre la última
+ejecución y ahora?) en vez de comparar con el minuto actual.
+
+**Por qué.** Con `tick=60s` el drift acumulado se saltaba un minuto entero y el job no corría;
+con `tick<60s` se duplicaba.
+
+**Acción.** Ninguna: arrancar a las 03:00:30 sigue disparando el job de las 03:00. Si tu
+repositorio no implementaba `update_last_run`, implementalo — es lo que deduplica.
+
+### 8. El `detail` del 422 de las queries es un objeto
+
+**Qué cambió.** `build_query_endpoint` devuelve `{"message": ..., "field": ..., "allowed": [...]}`
+en vez de un string.
+
+**Acción.** Ajustá el cliente si parseaba `detail` como texto.
+
+### 9. `MiddlewareConfig` eliminado
+
+Era código muerto: `_build_middlewares` instancia con `cls()` y nunca leía
+`enabled`/`order`/`options`. Quitá el import; no perdés comportamiento porque no tenía.
+
+---
+
+## Contribuir
+
+Gracias por tu interés. Para mantener la colaboración organizada:
+
+1. **Código de conducta** — revisá el [Código de Conducta](CODE_OF_CONDUCT.md) antes de
+   interactuar.
+2. **Ramas** — forkeá y creá una rama (`feat/nombre`, `fix/nombre`, `docs/nombre`).
+3. **Tests** — toda corrección entra con al menos un test que falle antes y pase después. El
+   suite se corre con los extras completos:
+
+   ```sh
+   uv sync --extra all --group dev
+   uv run python -m pytest -q
+   ```
+
+   El CI falla si algún test se **salta**: un skip significa que falta un extra y que
+   estaríamos reportando verde sin ejecutar la mitad del suite.
+4. **Typecheck** — `uv run pyright hexcore`.
+5. **Estilo** — [PEP8](https://pep8.org/). Comentá el *por qué*, no el *qué*.
+6. **Commits** — se usa [Commitizen](https://commitizen-tools.github.io/commitizen/):
+   `feat:`, `fix:`, `docs:`, `refactor:`, y `!` para breaking changes. El bump de versión y el
+   CHANGELOG son automáticos al mergear a `master`.
+7. **PRs** — describí el problema, la reproducción, la solución y **por qué esa opción**.
+   Relacioná los issues que aplique.
+
+### Skills del proyecto
+
+Hay un conjunto de skills para extender HexCore en VS Code y entornos compatibles:
+[Repositorio de Skills de HexCore](https://github.com/Indroic/hexcore-skill).
 
 ---
 
 ## Referencias
 
-- [CONTRIBUTING.md](./CONTRIBUTING.md): Pautas de colaboración.
-- [CHANGELOG.md](./CHANGELOG.md): Historial de cambios.
-- [DOCS.md](./DOCS.md): Documentación básica de clases, funciones y ejemplos.
+- [DOCS.md](./DOCS.md) — guía de arranque y documentación de clases y funciones.
+- [CHANGELOG.md](./CHANGELOG.md) — historial de cambios.
+- [CONTRIBUTING.md](./CONTRIBUTING.md) — pautas de colaboración.
+- [SECURITY.md](./SECURITY.md) — política de seguridad.

--- a/hexcore/_deprecation.py
+++ b/hexcore/_deprecation.py
@@ -1,0 +1,127 @@
+"""
+Mecanismo de deprecación de la superficie de API anterior a 5.0.
+
+Conviven dos nombres para varios conceptos (`AbstractCommandBus`/`ICommandBus`,
+`AbstractSerializer`/`ISerializer`, …) por retrocompatibilidad con 1.x/2.x. Los canónicos
+son los `Abstract*`; los alias siguen funcionando, pero avisan y se eliminarán en 6.0.
+
+Un alias declarado como `ICommandBus = AbstractCommandBus` **no puede avisar**: es una
+asignación, y leerlo no ejecuta nada. Por eso el aviso se implementa con `__getattr__` de
+módulo (PEP 562), que sólo se invoca cuando el nombre no está en los globals del módulo —
+o sea, exactamente al pedir el alias.
+
+Uso en el módulo que declara los alias::
+
+    from hexcore._deprecation import deprecated_aliases
+
+    __getattr__ = deprecated_aliases(
+        __name__,
+        {"ICommandBus": "AbstractCommandBus"},
+        globals(),
+    )
+"""
+from __future__ import annotations
+
+import typing as t
+import warnings
+
+__all__ = [
+    "REMOVED_IN",
+    "deprecated_aliases",
+    "warn_deprecated",
+    "deprecated_callable",
+]
+
+#: Versión en la que se eliminan los alias. Se menciona en cada aviso para que el usuario
+#: sepa cuánto margen tiene.
+REMOVED_IN = "6.0"
+
+
+def warn_deprecated(
+    old: str,
+    new: str,
+    *,
+    kind: str = "nombre",
+    stacklevel: int = 3,
+) -> None:
+    """
+    Emite el `DeprecationWarning` estándar de HexCore.
+
+    `stacklevel=3` por defecto para que el warning apunte al código del usuario y no a las
+    tripas de HexCore: 1 = esta función, 2 = el `__getattr__` que la llama, 3 = quien pidió
+    el nombre.
+    """
+    # El `kind` va entre corchetes, como etiqueta, para no tener que concordar el artículo
+    # ("el nombre" / "la función") con cada categoría.
+    warnings.warn(
+        f"[{kind}] '{old}' quedó deprecado en HexCore 5.0 y se eliminará en "
+        f"{REMOVED_IN}. Usá '{new}' en su lugar.",
+        DeprecationWarning,
+        stacklevel=stacklevel,
+    )
+
+
+def deprecated_aliases(
+    module_name: str,
+    aliases: t.Mapping[str, str],
+    module_globals: dict[str, t.Any],
+) -> t.Callable[[str], t.Any]:
+    """
+    Construye el `__getattr__` de un módulo que expone alias deprecados.
+
+    Args:
+        module_name: `__name__` del módulo, para el mensaje de `AttributeError`.
+        aliases: mapa ``{alias_deprecado: nombre_canónico}``. El canónico tiene que estar
+            en los globals del módulo.
+        module_globals: `globals()` del módulo.
+
+    Returns:
+        La función a asignar a `__getattr__`.
+
+    El alias **no** se cachea en los globals: si se cacheara, el segundo acceso no pasaría
+    por `__getattr__` y no avisaría. Aquí el coste de resolver es irrelevante y avisar
+    siempre es el objetivo.
+    """
+    def module_getattr(name: str) -> t.Any:
+        canonical = aliases.get(name)
+        if canonical is None:
+            raise AttributeError(f"module {module_name!r} has no attribute {name!r}")
+
+        warn_deprecated(name, canonical)
+        try:
+            return module_globals[canonical]
+        except KeyError:  # pragma: no cover - error de programación en la librería
+            raise AttributeError(
+                f"module {module_name!r} declara el alias {name!r} → {canonical!r}, "
+                f"pero {canonical!r} no existe en el módulo"
+            ) from None
+
+    return module_getattr
+
+
+def deprecated_callable(
+    replacement: t.Callable[..., t.Any],
+    old_name: str,
+    new_name: str,
+    *,
+    kind: str = "método",
+) -> t.Callable[..., t.Any]:
+    """
+    Envuelve un callable para que avise al invocarse y delegue en su reemplazo.
+
+    Para métodos deprecados (`EventBus.register`, `reset_sqlalchemy_engine`), donde el
+    aviso va en la llamada y no en el acceso al nombre.
+    """
+    import functools
+
+    @functools.wraps(replacement)
+    def wrapper(*args: t.Any, **kwargs: t.Any) -> t.Any:
+        warn_deprecated(old_name, new_name, kind=kind, stacklevel=2)
+        return replacement(*args, **kwargs)
+
+    wrapper.__name__ = old_name
+    wrapper.__doc__ = (
+        f"Deprecado desde 5.0, se elimina en {REMOVED_IN}. Usá `{new_name}`.\n\n"
+        f"{replacement.__doc__ or ''}"
+    )
+    return wrapper

--- a/hexcore/application/cqrs/adapters.py
+++ b/hexcore/application/cqrs/adapters.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import typing as t
 
 from hexcore.application.use_cases.base import UseCase
-from hexcore.domain.cqrs.handlers import ICommandHandler
+from hexcore.domain.cqrs.handlers import AbstractCommandHandler
 from hexcore.domain.cqrs.commands import Command
 
 
@@ -14,9 +14,9 @@ T = t.TypeVar("T", bound=Command)
 R = t.TypeVar("R")
 
 
-class UseCaseCommandHandler(ICommandHandler[T, R]):
+class UseCaseCommandHandler(AbstractCommandHandler[T, R]):
     """
-    Adaptador que envuelve un UseCase existente como un ICommandHandler.
+    Adaptador que envuelve un UseCase existente como un AbstractCommandHandler.
     Permite migrar progresivamente sin reescribir use cases.
 
     Uso::

--- a/hexcore/application/cqrs/factory.py
+++ b/hexcore/application/cqrs/factory.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 import importlib
 import typing as t
 
-from hexcore.domain.cqrs.buses import ICommandBus, IQueryBus, IEventBus
-from hexcore.domain.cqrs.middleware import IMiddleware
-from hexcore.domain.cqrs.serializer import ISerializer
+from hexcore.domain.cqrs.buses import AbstractCommandBus, AbstractQueryBus, AbstractEventBus
+from hexcore.domain.cqrs.middleware import AbstractMiddleware
+from hexcore.domain.cqrs.serializer import AbstractSerializer
 from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
 
 from .config import CQRSConfig, BusConfig
@@ -25,7 +25,7 @@ def _import_class(dotted_path: str) -> type:
     return getattr(module, class_name)
 
 
-def _build_middlewares(dotted_paths: list[str]) -> list[IMiddleware]:
+def _build_middlewares(dotted_paths: list[str]) -> list[AbstractMiddleware]:
     """
     Instancia middlewares a partir de sus dotted paths.
 
@@ -34,7 +34,7 @@ def _build_middlewares(dotted_paths: list[str]) -> list[IMiddleware]:
     atado al engine de la aplicación) hay que instanciarlos a mano y pasar el
     `MiddlewarePipeline` al bus.
     """
-    middlewares: list[IMiddleware] = []
+    middlewares: list[AbstractMiddleware] = []
     for path in dotted_paths:
         cls = _import_class(path)
         try:
@@ -92,9 +92,9 @@ class CQRSFactory:
         self._config = config
         self._registry = registry
         self._enqueuer = enqueuer
-        self._serializer: ISerializer | None = None
+        self._serializer: AbstractSerializer | None = None
 
-    def create_serializer(self) -> ISerializer:
+    def create_serializer(self) -> AbstractSerializer:
         """
         Crea el serializer configurado (PydanticSerializer por defecto).
 
@@ -106,14 +106,14 @@ class CQRSFactory:
 
         if self._config.serializer:
             cls = _import_class(self._config.serializer)
-            self._serializer = t.cast(ISerializer, cls())
+            self._serializer = t.cast(AbstractSerializer, cls())
         else:
             from hexcore.infrastructure.cqrs.pydantic_serializer import PydanticSerializer
 
             self._serializer = PydanticSerializer()
         return self._serializer
 
-    def create_command_bus(self, **extra_kwargs: t.Any) -> ICommandBus:
+    def create_command_bus(self, **extra_kwargs: t.Any) -> AbstractCommandBus:
         """
         Crea el CommandBus configurado.
         Si no hay backend explícito, retorna InMemoryCommandBus con el enqueuer y el
@@ -142,7 +142,7 @@ class CQRSFactory:
             **extra_kwargs,
         )
 
-    def create_query_bus(self) -> IQueryBus:
+    def create_query_bus(self) -> AbstractQueryBus:
         """
         Crea el QueryBus configurado.
         Nota: Las queries siempre son síncronas en CQRS puro.
@@ -163,7 +163,7 @@ class CQRSFactory:
             **bus_config.options,
         )
 
-    def create_event_bus(self, **extra_kwargs: t.Any) -> IEventBus:
+    def create_event_bus(self, **extra_kwargs: t.Any) -> AbstractEventBus:
         """
         Crea el EventBus configurado.
 

--- a/hexcore/application/cqrs/in_memory_buses.py
+++ b/hexcore/application/cqrs/in_memory_buses.py
@@ -6,13 +6,13 @@ from __future__ import annotations
 import typing as t
 import logging
 
-from hexcore.domain.cqrs.buses import ICommandBus, IQueryBus, IEventBus
+from hexcore.domain.cqrs.buses import AbstractCommandBus, AbstractQueryBus, AbstractEventBus
 from hexcore.domain.cqrs.commands import Command
 from hexcore.domain.cqrs.context import is_worker_execution, local_execution
 from hexcore.domain.cqrs.queries import Query
 from hexcore.domain.events import DomainEvent
 from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
-from hexcore.domain.cqrs.serializer import ISerializer
+from hexcore.domain.cqrs.serializer import AbstractSerializer
 
 from .registry import HandlerRegistry
 from .pipeline import MiddlewarePipeline
@@ -20,7 +20,7 @@ from .pipeline import MiddlewarePipeline
 logger = logging.getLogger("hexcore.cqrs.buses")
 
 
-class InMemoryCommandBus(ICommandBus):
+class InMemoryCommandBus(AbstractCommandBus):
     """
     Bus de commands síncrono en memoria con Smart Routing.
     Resuelve el handler desde el registry, ejecuta el pipeline de middlewares
@@ -40,7 +40,7 @@ class InMemoryCommandBus(ICommandBus):
         registry: HandlerRegistry,
         pipeline: MiddlewarePipeline | None = None,
         enqueuer: ITaskEnqueuer | None = None,
-        serializer: ISerializer | None = None,
+        serializer: AbstractSerializer | None = None,
     ) -> None:
         self._registry = registry
         self._pipeline = pipeline or MiddlewarePipeline()
@@ -86,7 +86,7 @@ class InMemoryCommandBus(ICommandBus):
             return await self._pipeline.execute(command, final_handler)
 
 
-class InMemoryQueryBus(IQueryBus):
+class InMemoryQueryBus(AbstractQueryBus):
     """
     Bus de queries síncrono en memoria.
     Las queries NUNCA pasan por buses asíncronos
@@ -110,7 +110,7 @@ class InMemoryQueryBus(IQueryBus):
         return await self._pipeline.execute(query, final_handler)
 
 
-class InMemoryEventBus(IEventBus):
+class InMemoryEventBus(AbstractEventBus):
     """
     Bus de eventos en memoria con Smart Routing para Handlers Asíncronos.
     
@@ -123,7 +123,7 @@ class InMemoryEventBus(IEventBus):
         self,
         pipeline: MiddlewarePipeline | None = None,
         enqueuer: ITaskEnqueuer | None = None,
-        serializer: ISerializer | None = None,
+        serializer: AbstractSerializer | None = None,
     ) -> None:
         self._handlers: dict[
             type[DomainEvent],

--- a/hexcore/application/cqrs/pipeline.py
+++ b/hexcore/application/cqrs/pipeline.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 import typing as t
 
-from hexcore.domain.cqrs.middleware import IMiddleware, NextHandler
+from hexcore.domain.cqrs.middleware import AbstractMiddleware, NextHandler
 
 
 class MiddlewarePipeline:
@@ -16,15 +16,15 @@ class MiddlewarePipeline:
     Pipeline: [MW1] → [MW2] → ... → [MWn] → [handler.handle]
     """
 
-    def __init__(self, middlewares: t.Sequence[IMiddleware] | None = None) -> None:
-        self._middlewares: list[IMiddleware] = list(middlewares or [])
+    def __init__(self, middlewares: t.Sequence[AbstractMiddleware] | None = None) -> None:
+        self._middlewares: list[AbstractMiddleware] = list(middlewares or [])
 
-    def add(self, middleware: IMiddleware) -> "MiddlewarePipeline":
+    def add(self, middleware: AbstractMiddleware) -> "MiddlewarePipeline":
         """Añade un middleware al pipeline. Retorna self para fluent API."""
         self._middlewares.append(middleware)
         return self
 
-    def add_many(self, middlewares: t.Iterable[IMiddleware]) -> "MiddlewarePipeline":
+    def add_many(self, middlewares: t.Iterable[AbstractMiddleware]) -> "MiddlewarePipeline":
         """Añade múltiples middlewares al pipeline."""
         self._middlewares.extend(middlewares)
         return self
@@ -49,7 +49,7 @@ class MiddlewarePipeline:
         return await chain(message)
 
     @staticmethod
-    def _wrap(middleware: IMiddleware, next_handler: NextHandler) -> NextHandler:
+    def _wrap(middleware: AbstractMiddleware, next_handler: NextHandler) -> NextHandler:
         """Envuelve un middleware y su next_handler en un callable."""
 
         async def wrapped(message: t.Any) -> t.Any:

--- a/hexcore/application/cqrs/registry.py
+++ b/hexcore/application/cqrs/registry.py
@@ -9,13 +9,13 @@ import typing as t
 
 from hexcore.domain.cqrs.commands import Command
 from hexcore.domain.cqrs.queries import Query
-from hexcore.domain.cqrs.handlers import ICommandHandler, IQueryHandler
+from hexcore.domain.cqrs.handlers import AbstractCommandHandler, AbstractQueryHandler
 from hexcore.domain.cqrs.exceptions import HandlerNotFoundError, DuplicateHandlerError
 
 
 # Tipos para factories de handlers (para DI/lazy instantiation)
-CommandHandlerFactory = t.Callable[[], ICommandHandler[t.Any, t.Any]]
-QueryHandlerFactory = t.Callable[[], IQueryHandler[t.Any, t.Any]]
+CommandHandlerFactory = t.Callable[[], AbstractCommandHandler[t.Any, t.Any]]
+QueryHandlerFactory = t.Callable[[], AbstractQueryHandler[t.Any, t.Any]]
 
 TFactory = t.TypeVar("TFactory")
 
@@ -24,7 +24,7 @@ class HandlerFactory(t.Generic[TFactory]):
     """
     Marcador explícito de "esto es un factory, no un handler".
 
-    `callable(entry) and not isinstance(entry, ICommandHandler)` es ambiguo: un handler
+    `callable(entry) and not isinstance(entry, AbstractCommandHandler)` es ambiguo: un handler
     que implemente `__call__` se confundiría con un factory, y un factory que herede de
     la interfaz se confundiría con un handler. Envolver el callable elimina la
     heurística.
@@ -75,10 +75,10 @@ class HandlerRegistry:
 
     def __init__(self, *, allow_override: bool = False) -> None:
         self._command_handlers: dict[
-            type[Command], ICommandHandler[t.Any, t.Any] | CommandHandlerFactory
+            type[Command], AbstractCommandHandler[t.Any, t.Any] | CommandHandlerFactory
         ] = {}
         self._query_handlers: dict[
-            type[Query[t.Any]], IQueryHandler[t.Any, t.Any] | QueryHandlerFactory
+            type[Query[t.Any]], AbstractQueryHandler[t.Any, t.Any] | QueryHandlerFactory
         ] = {}
         self._allow_override = allow_override
         # Reentrante: un factory puede resolver otro handler del mismo registry.
@@ -101,7 +101,7 @@ class HandlerRegistry:
     def register_command_handler(
         self,
         command_type: type[Command],
-        handler: ICommandHandler[t.Any, t.Any] | CommandHandlerFactory,
+        handler: AbstractCommandHandler[t.Any, t.Any] | CommandHandlerFactory,
     ) -> "HandlerRegistry":
         """Registra un handler (o factory) para un tipo de command. Retorna self para fluent API."""
         with self._lock:
@@ -112,25 +112,25 @@ class HandlerRegistry:
 
     def resolve_command_handler(
         self, command_type: type[Command]
-    ) -> ICommandHandler[t.Any, t.Any]:
+    ) -> AbstractCommandHandler[t.Any, t.Any]:
         """Resuelve el handler para el tipo de command dado."""
         with self._lock:
             entry = self._command_handlers.get(command_type)
             if entry is None:
                 raise HandlerNotFoundError(command_type)
-            if _is_factory(entry, ICommandHandler):
+            if _is_factory(entry, AbstractCommandHandler):
                 # Es un factory, invocar y cachear la instancia
                 handler = t.cast(CommandHandlerFactory, entry)()
                 self._command_handlers[command_type] = handler
                 return handler
-            return t.cast(ICommandHandler[t.Any, t.Any], entry)
+            return t.cast(AbstractCommandHandler[t.Any, t.Any], entry)
 
     # ── Query Handlers ────────────────────────────────────────────
 
     def register_query_handler(
         self,
         query_type: type[Query[t.Any]],
-        handler: IQueryHandler[t.Any, t.Any] | QueryHandlerFactory,
+        handler: AbstractQueryHandler[t.Any, t.Any] | QueryHandlerFactory,
     ) -> "HandlerRegistry":
         """Registra un handler (o factory) para un tipo de query. Retorna self para fluent API."""
         with self._lock:
@@ -141,17 +141,17 @@ class HandlerRegistry:
 
     def resolve_query_handler(
         self, query_type: type[Query[t.Any]]
-    ) -> IQueryHandler[t.Any, t.Any]:
+    ) -> AbstractQueryHandler[t.Any, t.Any]:
         """Resuelve el handler para el tipo de query dado."""
         with self._lock:
             entry = self._query_handlers.get(query_type)
             if entry is None:
                 raise HandlerNotFoundError(query_type)
-            if _is_factory(entry, IQueryHandler):
+            if _is_factory(entry, AbstractQueryHandler):
                 handler = t.cast(QueryHandlerFactory, entry)()
                 self._query_handlers[query_type] = handler
                 return handler
-            return t.cast(IQueryHandler[t.Any, t.Any], entry)
+            return t.cast(AbstractQueryHandler[t.Any, t.Any], entry)
 
     # ── Introspección ─────────────────────────────────────────────
 

--- a/hexcore/domain/cqrs/__init__.py
+++ b/hexcore/domain/cqrs/__init__.py
@@ -1,7 +1,15 @@
 """
 hexcore.domain.cqrs — Abstracciones puras del patrón CQRS.
 Cero dependencias de infraestructura.
+
+Los alias `I*` siguen disponibles pero están deprecados desde 5.0 y se eliminan en 6.0.
+Se resuelven por `__getattr__`, no con un `from … import`: importarlos aquí de forma eager
+haría que el aviso se emitiera al importar el paquete, con lo que nadie podría saber
+**quién** usa el alias.
 """
+from __future__ import annotations
+
+import typing as t
 
 from .commands import Command
 from .queries import Query
@@ -16,11 +24,6 @@ from .exceptions import (
     DeserializationError,
 )
 
-# Aliases de retrocompatibilidad (I* → Abstract*)
-from .handlers import ICommandHandler, IQueryHandler
-from .buses import ICommandBus, IQueryBus, IEventBus
-from .middleware import IMiddleware
-from .serializer import ISerializer
 from .cron import CronJobDefinition, ICronJobRepository, ILockProvider
 from .context import IN_WORKER, is_worker_execution, local_execution, worker_execution
 from .resolution import build_fqn, resolve_dotted
@@ -62,3 +65,40 @@ __all__ = [
     "DuplicateHandlerError",
     "DeserializationError",
 ]
+
+
+# ── Alias de retrocompatibilidad (deprecados desde 5.0, se eliminan en 6.0) ────
+# Se resuelven perezosamente: cada acceso emite el DeprecationWarning y delega en el
+# módulo que lo declara, que a su vez avisa. Se filtra el aviso duplicado emitiendo sólo
+# aquí y devolviendo el nombre canónico directamente.
+from hexcore._deprecation import warn_deprecated  # noqa: E402
+
+_DEPRECATED_ALIASES: dict[str, tuple[str, str]] = {
+    "ICommandHandler": ("hexcore.domain.cqrs.handlers", "AbstractCommandHandler"),
+    "IQueryHandler": ("hexcore.domain.cqrs.handlers", "AbstractQueryHandler"),
+    "ICommandBus": ("hexcore.domain.cqrs.buses", "AbstractCommandBus"),
+    "IQueryBus": ("hexcore.domain.cqrs.buses", "AbstractQueryBus"),
+    "IEventBus": ("hexcore.domain.cqrs.buses", "AbstractEventBus"),
+    "IMiddleware": ("hexcore.domain.cqrs.middleware", "AbstractMiddleware"),
+    "ISerializer": ("hexcore.domain.cqrs.serializer", "AbstractSerializer"),
+}
+
+
+def __getattr__(name: str) -> t.Any:
+    entry = _DEPRECATED_ALIASES.get(name)
+    if entry is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+    module_path, canonical = entry
+    warn_deprecated(name, canonical)
+
+    import importlib
+
+    return getattr(importlib.import_module(module_path), canonical)
+
+
+if t.TYPE_CHECKING:
+    from .buses import ICommandBus, IEventBus, IQueryBus
+    from .handlers import ICommandHandler, IQueryHandler
+    from .middleware import IMiddleware
+    from .serializer import ISerializer

--- a/hexcore/domain/cqrs/buses.py
+++ b/hexcore/domain/cqrs/buses.py
@@ -74,7 +74,21 @@ class AbstractEventBus(abc.ABC):
         raise NotImplementedError
 
 
-# Aliases de retrocompatibilidad
-ICommandBus = AbstractCommandBus
-IQueryBus = AbstractQueryBus
-IEventBus = AbstractEventBus
+# ── Alias de retrocompatibilidad (deprecados desde 5.0) ───────────────────────
+# Se exponen por `__getattr__` y no como asignaciones, porque una asignación no puede
+# avisar: leerla no ejecuta nada. Ver hexcore._deprecation.
+from hexcore._deprecation import deprecated_aliases  # noqa: E402
+
+_DEPRECATED_ALIASES = {
+    "ICommandBus": "AbstractCommandBus",
+    "IQueryBus": "AbstractQueryBus",
+    "IEventBus": "AbstractEventBus",
+}
+
+__getattr__ = deprecated_aliases(__name__, _DEPRECATED_ALIASES, globals())
+
+if t.TYPE_CHECKING:
+    # Para que los type checkers sigan resolviendo los alias sin ejecutar el warning.
+    ICommandBus = AbstractCommandBus
+    IQueryBus = AbstractQueryBus
+    IEventBus = AbstractEventBus

--- a/hexcore/domain/cqrs/handlers.py
+++ b/hexcore/domain/cqrs/handlers.py
@@ -47,6 +47,16 @@ class AbstractQueryHandler(abc.ABC, t.Generic[TQuery, TResult]):
         raise NotImplementedError
 
 
-# Aliases de retrocompatibilidad
-ICommandHandler = AbstractCommandHandler
-IQueryHandler = AbstractQueryHandler
+# ── Alias de retrocompatibilidad (deprecados desde 5.0) ───────────────────────
+from hexcore._deprecation import deprecated_aliases  # noqa: E402
+
+_DEPRECATED_ALIASES = {
+    "ICommandHandler": "AbstractCommandHandler",
+    "IQueryHandler": "AbstractQueryHandler",
+}
+
+__getattr__ = deprecated_aliases(__name__, _DEPRECATED_ALIASES, globals())
+
+if t.TYPE_CHECKING:
+    ICommandHandler = AbstractCommandHandler
+    IQueryHandler = AbstractQueryHandler

--- a/hexcore/domain/cqrs/middleware.py
+++ b/hexcore/domain/cqrs/middleware.py
@@ -47,5 +47,12 @@ class AbstractMiddleware(abc.ABC):
         raise NotImplementedError
 
 
-# Alias de retrocompatibilidad
-IMiddleware = AbstractMiddleware
+# ── Alias de retrocompatibilidad (deprecado desde 5.0) ────────────────────────
+from hexcore._deprecation import deprecated_aliases  # noqa: E402
+
+_DEPRECATED_ALIASES = {"IMiddleware": "AbstractMiddleware"}
+
+__getattr__ = deprecated_aliases(__name__, _DEPRECATED_ALIASES, globals())
+
+if t.TYPE_CHECKING:
+    IMiddleware = AbstractMiddleware

--- a/hexcore/domain/cqrs/serializer.py
+++ b/hexcore/domain/cqrs/serializer.py
@@ -35,5 +35,12 @@ class AbstractSerializer(abc.ABC):
         raise NotImplementedError
 
 
-# Alias de retrocompatibilidad
-ISerializer = AbstractSerializer
+# ── Alias de retrocompatibilidad (deprecado desde 5.0) ────────────────────────
+from hexcore._deprecation import deprecated_aliases  # noqa: E402
+
+_DEPRECATED_ALIASES = {"ISerializer": "AbstractSerializer"}
+
+__getattr__ = deprecated_aliases(__name__, _DEPRECATED_ALIASES, globals())
+
+if t.TYPE_CHECKING:
+    ISerializer = AbstractSerializer

--- a/hexcore/domain/events.py
+++ b/hexcore/domain/events.py
@@ -72,31 +72,32 @@ class EventBus(abc.ABC):
         """Publica un evento a todos los handlers suscritos."""
         raise NotImplementedError
 
-    # --- Retrocompatibilidad (Deprecado) ---
+    # --- Retrocompatibilidad (deprecado desde 5.0, se elimina en 6.0) ---
     def register(self, event_type: type, handler: EventHandler) -> None:
-        """
-        Alias deprecado para `subscribe`.
-        """
-        import warnings
-        warnings.warn(
-            "IEventDispatcher.register is deprecated. Use EventBus.subscribe instead.",
-            DeprecationWarning,
-            stacklevel=2,
+        """Alias deprecado de `subscribe`."""
+        from hexcore._deprecation import warn_deprecated
+
+        warn_deprecated(
+            "EventBus.register()", "EventBus.subscribe()", kind="método", stacklevel=2
         )
         self.subscribe(event_type, handler)
 
     async def dispatch(self, event: t.Any) -> None:
-        """
-        Alias deprecado para `publish`.
-        """
-        import warnings
-        warnings.warn(
-            "IEventDispatcher.dispatch is deprecated. Use EventBus.publish instead.",
-            DeprecationWarning,
-            stacklevel=2,
+        """Alias deprecado de `publish`."""
+        from hexcore._deprecation import warn_deprecated
+
+        warn_deprecated(
+            "EventBus.dispatch()", "EventBus.publish()", kind="método", stacklevel=2
         )
         await self.publish(event)
 
 
-# Alias de retrocompatibilidad
-IEventDispatcher = EventBus
+# ── Alias de retrocompatibilidad (deprecado desde 5.0, se elimina en 6.0) ──────
+from hexcore._deprecation import deprecated_aliases  # noqa: E402
+
+_DEPRECATED_ALIASES = {"IEventDispatcher": "EventBus"}
+
+__getattr__ = deprecated_aliases(__name__, _DEPRECATED_ALIASES, globals())
+
+if t.TYPE_CHECKING:
+    IEventDispatcher = EventBus

--- a/hexcore/infrastructure/api/cqrs.py
+++ b/hexcore/infrastructure/api/cqrs.py
@@ -24,7 +24,7 @@ from hexcore.domain.cqrs.buses import (
 if t.TYPE_CHECKING:
     from hexcore.application.cqrs.factory import CQRSFactory
     from hexcore.application.cqrs.registry import HandlerRegistry
-    from hexcore.domain.cqrs.serializer import ISerializer
+    from hexcore.domain.cqrs.serializer import AbstractSerializer
     from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
     from hexcore.infrastructure.workers.consumer import CQRSConsumer
 
@@ -63,7 +63,7 @@ class CQRSContainer:
         return self._factory._registry  # noqa: SLF001 - misma capa lógica
 
     @property
-    def serializer(self) -> "ISerializer":
+    def serializer(self) -> "AbstractSerializer":
         return self._factory.create_serializer()
 
     def command_bus(self) -> AbstractCommandBus:

--- a/hexcore/infrastructure/api/utils.py
+++ b/hexcore/infrastructure/api/utils.py
@@ -18,7 +18,7 @@ from hexcore.infrastructure.repositories.orms.sqlalchemy.session import (
     get_async_db_session,
     get_session_factory,
 )
-from hexcore.infrastructure.uow import SqlAlchemyUnitOfWork, NoSqlUnitOfWork
+from hexcore.infrastructure.uow import BeanieUnitOfWork, SqlAlchemyUnitOfWork
 
 
 async def get_session() -> AsyncGenerator[AsyncSession, None]:
@@ -56,7 +56,7 @@ async def get_sql_uow_open(
 
 
 async def get_nosql_uow() -> AsyncGenerator[IUnitOfWork, None]:
-    uow: IUnitOfWork = NoSqlUnitOfWork()
+    uow: IUnitOfWork = BeanieUnitOfWork()
     async with uow:
         yield uow
 

--- a/hexcore/infrastructure/cqrs/middlewares.py
+++ b/hexcore/infrastructure/cqrs/middlewares.py
@@ -9,10 +9,10 @@ import logging
 import time
 import typing as t
 
-from hexcore.domain.cqrs.middleware import IMiddleware, NextHandler
+from hexcore.domain.cqrs.middleware import AbstractMiddleware, NextHandler
 
 
-class LoggingMiddleware(IMiddleware):
+class LoggingMiddleware(AbstractMiddleware):
     """
     Middleware de logging que registra dispatch, duración y errores.
     """
@@ -52,7 +52,7 @@ class LoggingMiddleware(IMiddleware):
             raise
 
 
-class RetryMiddleware(IMiddleware):
+class RetryMiddleware(AbstractMiddleware):
     """
     Middleware de reintentos con backoff exponencial, **in-process**.
     Solo reintenta excepciones en ``retryable_exceptions``.
@@ -125,7 +125,7 @@ class RetryMiddleware(IMiddleware):
         )
 
 
-class ValidationMiddleware(IMiddleware):
+class ValidationMiddleware(AbstractMiddleware):
     """
     Middleware que valida el mensaje usando Pydantic ``model_validate``
     antes de pasarlo al siguiente handler. Útil para re-validar
@@ -140,7 +140,7 @@ class ValidationMiddleware(IMiddleware):
         return await next_handler(message)
 
 
-class TransactionMiddleware(IMiddleware):
+class TransactionMiddleware(AbstractMiddleware):
     """
     Middleware que envuelve la ejecución del handler en un contexto transaccional
     usando el Unit of Work de Hexcore, y comitea al terminar.

--- a/hexcore/infrastructure/cqrs/postgres_bus.py
+++ b/hexcore/infrastructure/cqrs/postgres_bus.py
@@ -9,7 +9,7 @@ import json
 import logging
 import typing as t
 
-from hexcore.domain.cqrs.buses import IEventBus
+from hexcore.domain.cqrs.buses import AbstractEventBus
 from hexcore.domain.cqrs.context import is_worker_execution, local_execution
 from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
 from hexcore.domain.events import DomainEvent
@@ -22,9 +22,9 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class PostgresEventBus(IEventBus):
+class PostgresEventBus(AbstractEventBus):
     """
-    Implementación de IEventBus utilizando PostgreSQL LISTEN/NOTIFY.
+    Implementación de AbstractEventBus utilizando PostgreSQL LISTEN/NOTIFY.
     Nota: LISTEN/NOTIFY no persiste los eventos una vez entregados. 
     Ideal para eventos efímeros o arquitecturas más simples.
     """

--- a/hexcore/infrastructure/cqrs/procrastinate.py
+++ b/hexcore/infrastructure/cqrs/procrastinate.py
@@ -10,9 +10,9 @@ from __future__ import annotations
 
 import typing as t
 
-from hexcore.domain.cqrs.buses import ICommandBus
+from hexcore.domain.cqrs.buses import AbstractCommandBus
 from hexcore.domain.cqrs.commands import Command
-from hexcore.domain.cqrs.serializer import ISerializer
+from hexcore.domain.cqrs.serializer import AbstractSerializer
 from hexcore.application.cqrs.pipeline import MiddlewarePipeline
 from hexcore.application.cqrs.registry import HandlerRegistry
 
@@ -28,7 +28,7 @@ def _ensure_procrastinate() -> None:
         ) from exc
 
 
-class ProcrastinateCommandBus(ICommandBus):
+class ProcrastinateCommandBus(AbstractCommandBus):
     """
     Bus de commands que encola la ejecución en Procrastinate (PostgreSQL task queue).
 
@@ -53,7 +53,7 @@ class ProcrastinateCommandBus(ICommandBus):
         self,
         app: t.Any,  # procrastinate.App (no tipado para evitar import-time dependency)
         registry: HandlerRegistry,
-        serializer: ISerializer,
+        serializer: AbstractSerializer,
         pipeline: MiddlewarePipeline | None = None,
         *,
         queue_name: str = "hexcore_commands",

--- a/hexcore/infrastructure/cqrs/pydantic_serializer.py
+++ b/hexcore/infrastructure/cqrs/pydantic_serializer.py
@@ -6,12 +6,12 @@ from __future__ import annotations
 
 import typing as t
 
-from hexcore.domain.cqrs.serializer import ISerializer
+from hexcore.domain.cqrs.serializer import AbstractSerializer
 from hexcore.domain.cqrs.exceptions import DeserializationError
 from hexcore.domain.cqrs.resolution import build_fqn, resolve_dotted
 
 
-class PydanticSerializer(ISerializer):
+class PydanticSerializer(AbstractSerializer):
     """
     Serializa/deserializa mensajes Pydantic BaseModel.
     Almacena el fully-qualified type name para reconstrucción.

--- a/hexcore/infrastructure/cqrs/redis_bus.py
+++ b/hexcore/infrastructure/cqrs/redis_bus.py
@@ -10,7 +10,7 @@ import logging
 import typing as t
 import uuid
 
-from hexcore.domain.cqrs.buses import IEventBus
+from hexcore.domain.cqrs.buses import AbstractEventBus
 from hexcore.domain.cqrs.context import is_worker_execution, local_execution
 from hexcore.domain.cqrs.task_queues import ITaskEnqueuer
 from hexcore.domain.events import DomainEvent
@@ -23,9 +23,9 @@ if t.TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class RedisEventBus(IEventBus):
+class RedisEventBus(AbstractEventBus):
     """
-    Implementación de IEventBus usando Redis Streams.
+    Implementación de AbstractEventBus usando Redis Streams.
     """
 
     def __init__(

--- a/hexcore/infrastructure/events/events_backends/memory.py
+++ b/hexcore/infrastructure/events/events_backends/memory.py
@@ -28,5 +28,9 @@ class InMemoryEventBus(EventBus):
                 await handler(event)
 
 
-# Alias de retrocompatibilidad
-InMemoryEventDispatcher = InMemoryEventBus
+# ── Alias de retrocompatibilidad (deprecado desde 5.0, se elimina en 6.0) ──────
+from hexcore._deprecation import deprecated_aliases  # noqa: E402
+
+_DEPRECATED_ALIASES = {"InMemoryEventDispatcher": "InMemoryEventBus"}
+
+__getattr__ = deprecated_aliases(__name__, _DEPRECATED_ALIASES, globals())

--- a/hexcore/infrastructure/repositories/implementations.py
+++ b/hexcore/infrastructure/repositories/implementations.py
@@ -135,13 +135,10 @@ try:
         async def delete(self, entity: T) -> None:
             await sql_logical_delete(self.session, entity, self.model_cls)
 
-    # Alias de retrocompatibilidad
-    SQLAlchemyCommonImplementationsRepo = SqlAlchemyRepository
 
 except ImportError:
     M = t.TypeVar("M") # type: ignore
     class SqlAlchemyRepository(t.Generic[T, M]): ... # type: ignore
-    SQLAlchemyCommonImplementationsRepo = SqlAlchemyRepository # type: ignore
 
 
 try:
@@ -213,10 +210,18 @@ try:
         async def delete(self, entity: T) -> None:
             return await nosql_logical_delete(entity.id, self.document_cls)
 
-    # Alias de retrocompatibilidad
-    BeanieODMCommonImplementationsRepo = BeanieRepository
 
 except ImportError:
     D = t.TypeVar("D") # type: ignore
     class BeanieRepository(t.Generic[T, D]): ... # type: ignore
-    BeanieODMCommonImplementationsRepo = BeanieRepository # type: ignore
+
+
+# ── Alias de retrocompatibilidad (deprecados desde 5.0, se eliminan en 6.0) ────
+from hexcore._deprecation import deprecated_aliases  # noqa: E402
+
+_DEPRECATED_ALIASES = {
+    "SQLAlchemyCommonImplementationsRepo": "SqlAlchemyRepository",
+    "BeanieODMCommonImplementationsRepo": "BeanieRepository",
+}
+
+__getattr__ = deprecated_aliases(__name__, _DEPRECATED_ALIASES, globals())

--- a/hexcore/infrastructure/repositories/orms/sqlalchemy/session.py
+++ b/hexcore/infrastructure/repositories/orms/sqlalchemy/session.py
@@ -199,10 +199,15 @@ async def get_async_db_session() -> AsyncGenerator[AsyncSession, None]:
 
 async def reset_sqlalchemy_engine() -> None:
     """
-    Alias legacy de `dispose_engine()`.
+    Alias legacy de `dispose_engine()`. **Deprecado desde 5.0, se elimina en 6.0.**
 
-    Se conserva porque los workers (RabbitMQ, Celery) lo llaman para re-atar el pool al
-    event loop nuevo. Para el shutdown de una app, `dispose_engine()` dice mejor lo que
-    hace.
+    El nombre dice "reset" pero lo que hace es cerrar el pool y dejar el módulo
+    re-inicializable, que es lo que uno busca para el shutdown de un lifespan.
+    `dispose_engine()` lo dice mejor.
     """
+    from hexcore._deprecation import warn_deprecated
+
+    warn_deprecated(
+        "reset_sqlalchemy_engine()", "dispose_engine()", kind="función", stacklevel=2
+    )
     await dispose_engine()

--- a/hexcore/infrastructure/uow/__init__.py
+++ b/hexcore/infrastructure/uow/__init__.py
@@ -185,8 +185,6 @@ class BeanieUnitOfWork(IUnitOfWork):
         self._entities.clear()
 
 
-# Alias por retrocompatibilidad
-NoSqlUnitOfWork = BeanieUnitOfWork
 
 
 # Scopes para código fuera de FastAPI (workers, cron, scripts, seeds).
@@ -207,3 +205,14 @@ __all__ = [
     "open_uow_scope",
     "nosql_uow_scope",
 ]
+
+
+# ── Alias de retrocompatibilidad (deprecado desde 5.0, se elimina en 6.0) ──────
+from hexcore._deprecation import deprecated_aliases  # noqa: E402
+
+_DEPRECATED_ALIASES = {"NoSqlUnitOfWork": "BeanieUnitOfWork"}
+
+__getattr__ = deprecated_aliases(__name__, _DEPRECATED_ALIASES, globals())
+
+if t.TYPE_CHECKING:
+    NoSqlUnitOfWork = BeanieUnitOfWork

--- a/hexcore/infrastructure/uow/scopes.py
+++ b/hexcore/infrastructure/uow/scopes.py
@@ -86,8 +86,8 @@ async def open_uow_scope() -> t.AsyncIterator["IUnitOfWork"]:
 @asynccontextmanager
 async def nosql_uow_scope() -> t.AsyncIterator["IUnitOfWork"]:
     """Equivalente de `open_uow_scope` para el UoW de Beanie/MongoDB."""
-    from hexcore.infrastructure.uow import NoSqlUnitOfWork
+    from hexcore.infrastructure.uow import BeanieUnitOfWork
 
-    uow: "IUnitOfWork" = NoSqlUnitOfWork()
+    uow: "IUnitOfWork" = BeanieUnitOfWork()
     async with uow:
         yield uow

--- a/hexcore/infrastructure/workers/consumer.py
+++ b/hexcore/infrastructure/workers/consumer.py
@@ -9,7 +9,7 @@ import typing as t
 from hexcore.domain.cqrs.buses import AbstractCommandBus, AbstractEventBus
 from hexcore.domain.cqrs.context import worker_execution
 from hexcore.domain.cqrs.resolution import resolve_dotted
-from hexcore.domain.cqrs.serializer import ISerializer
+from hexcore.domain.cqrs.serializer import AbstractSerializer
 from hexcore.domain.events import DomainEvent
 
 if t.TYPE_CHECKING:
@@ -50,7 +50,7 @@ class CQRSConsumer:
         self,
         command_bus: AbstractCommandBus,
         event_bus: AbstractEventBus | None = None,
-        serializer: ISerializer | None = None,
+        serializer: AbstractSerializer | None = None,
     ) -> None:
         """
         Args:

--- a/hexcore/testing/helpers.py
+++ b/hexcore/testing/helpers.py
@@ -23,7 +23,7 @@ if t.TYPE_CHECKING:
         AbstractEventBus,
         AbstractQueryBus,
     )
-    from hexcore.domain.cqrs.serializer import ISerializer
+    from hexcore.domain.cqrs.serializer import AbstractSerializer
 
     from .fakes import InMemoryTaskEnqueuer
 
@@ -38,7 +38,7 @@ class TestBuses(t.NamedTuple):
     query_bus: "InMemoryQueryBus"
     event_bus: "InMemoryEventBus"
     enqueuer: "InMemoryTaskEnqueuer"
-    serializer: "ISerializer"
+    serializer: "AbstractSerializer"
 
 
 def build_test_buses(

--- a/tests/test_cqrs.py
+++ b/tests/test_cqrs.py
@@ -13,10 +13,10 @@ import pytest
 # ── Domain ────────────────────────────────────────────────────────
 from hexcore.domain.cqrs.commands import Command
 from hexcore.domain.cqrs.queries import Query
-from hexcore.domain.cqrs.handlers import ICommandHandler, IQueryHandler
-from hexcore.domain.cqrs.buses import ICommandBus, IQueryBus, IEventBus
-from hexcore.domain.cqrs.middleware import IMiddleware, NextHandler
-from hexcore.domain.cqrs.serializer import ISerializer
+from hexcore.domain.cqrs.handlers import AbstractCommandHandler, AbstractQueryHandler
+from hexcore.domain.cqrs.buses import AbstractCommandBus, AbstractQueryBus, AbstractEventBus
+from hexcore.domain.cqrs.middleware import AbstractMiddleware, NextHandler
+from hexcore.domain.cqrs.serializer import AbstractSerializer
 from hexcore.domain.cqrs.exceptions import (
     HandlerNotFoundError,
     DuplicateHandlerError,
@@ -79,22 +79,22 @@ class UserCreatedEvent(DomainEvent):
     name: str
 
 
-class CreateUserHandler(ICommandHandler[CreateUserCommand, str]):
+class CreateUserHandler(AbstractCommandHandler[CreateUserCommand, str]):
     async def handle(self, command: CreateUserCommand) -> str:
         return f"created:{command.name}"
 
 
-class DeleteUserHandler(ICommandHandler[DeleteUserCommand, None]):
+class DeleteUserHandler(AbstractCommandHandler[DeleteUserCommand, None]):
     async def handle(self, command: DeleteUserCommand) -> None:
         pass
 
 
-class GetUserHandler(IQueryHandler[GetUserQuery, dict[str, str]]):
+class GetUserHandler(AbstractQueryHandler[GetUserQuery, dict[str, str]]):
     async def handle(self, query: GetUserQuery) -> dict[str, str]:
         return {"id": query.user_id, "name": "Alice"}
 
 
-class ListUsersHandler(IQueryHandler[ListUsersQuery, list[dict[str, str]]]):
+class ListUsersHandler(AbstractQueryHandler[ListUsersQuery, list[dict[str, str]]]):
     async def handle(self, query: ListUsersQuery) -> list[dict[str, str]]:
         return [{"id": "1", "name": "Alice"}]
 
@@ -227,7 +227,7 @@ class TestHandlerRegistry:
 # ═══════════════════════════════════════════════════════════════════
 
 
-class TrackingMiddleware(IMiddleware):
+class TrackingMiddleware(AbstractMiddleware):
     """Middleware que registra el orden de ejecución."""
 
     def __init__(self, name: str, log: list[str]) -> None:

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -1,0 +1,247 @@
+"""
+Deprecación de la superficie de API anterior a 5.0.
+
+Los alias de v1/v2 siguen funcionando —no se han borrado— pero avisan y se eliminarán en
+6.0. Este módulo fija las tres propiedades que hacen que la deprecación sirva de algo:
+
+1. El alias **sigue funcionando** y devuelve el objeto canónico.
+2. Pedirlo emite un `DeprecationWarning` que apunta **al código del usuario**, no a las
+   tripas de HexCore. Un warning que señala un fichero de la librería es inútil.
+3. Importar HexCore, o usar los nombres canónicos, **no** emite nada. Si el import avisara,
+   el usuario no podría saber quién usa el alias, y el aviso se volvería ruido a ignorar.
+"""
+from __future__ import annotations
+
+import importlib
+import warnings
+
+import pytest
+
+from hexcore._deprecation import REMOVED_IN
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# (módulo, alias deprecado, nombre canónico)
+ALIASES = [
+    ("hexcore.domain.cqrs.buses", "ICommandBus", "AbstractCommandBus"),
+    ("hexcore.domain.cqrs.buses", "IQueryBus", "AbstractQueryBus"),
+    ("hexcore.domain.cqrs.buses", "IEventBus", "AbstractEventBus"),
+    ("hexcore.domain.cqrs.handlers", "ICommandHandler", "AbstractCommandHandler"),
+    ("hexcore.domain.cqrs.handlers", "IQueryHandler", "AbstractQueryHandler"),
+    ("hexcore.domain.cqrs.middleware", "IMiddleware", "AbstractMiddleware"),
+    ("hexcore.domain.cqrs.serializer", "ISerializer", "AbstractSerializer"),
+    ("hexcore.domain.events", "IEventDispatcher", "EventBus"),
+    ("hexcore.domain.cqrs", "ICommandBus", "AbstractCommandBus"),
+    ("hexcore.domain.cqrs", "IQueryBus", "AbstractQueryBus"),
+    ("hexcore.domain.cqrs", "IEventBus", "AbstractEventBus"),
+    ("hexcore.domain.cqrs", "ICommandHandler", "AbstractCommandHandler"),
+    ("hexcore.domain.cqrs", "IQueryHandler", "AbstractQueryHandler"),
+    ("hexcore.domain.cqrs", "IMiddleware", "AbstractMiddleware"),
+    ("hexcore.domain.cqrs", "ISerializer", "AbstractSerializer"),
+    (
+        "hexcore.infrastructure.events.events_backends.memory",
+        "InMemoryEventDispatcher",
+        "InMemoryEventBus",
+    ),
+]
+
+# Los que dependen de un extra.
+OPTIONAL_ALIASES = [
+    (
+        "hexcore.infrastructure.repositories.implementations",
+        "SQLAlchemyCommonImplementationsRepo",
+        "SqlAlchemyRepository",
+    ),
+    (
+        "hexcore.infrastructure.repositories.implementations",
+        "BeanieODMCommonImplementationsRepo",
+        "BeanieRepository",
+    ),
+    ("hexcore.infrastructure.uow", "NoSqlUnitOfWork", "BeanieUnitOfWork"),
+]
+
+
+# ── 1. El alias sigue funcionando ──────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(("module_path", "alias", "canonical"), ALIASES + OPTIONAL_ALIASES)
+def test_alias_resolves_to_the_canonical_object(module_path, alias, canonical):
+    module = importlib.import_module(module_path)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        assert getattr(module, alias) is getattr(module, canonical)
+
+
+# ── 2. Avisa, y el aviso es útil ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(("module_path", "alias", "canonical"), ALIASES)
+def test_alias_emits_a_deprecation_warning(module_path, alias, canonical):
+    module = importlib.import_module(module_path)
+
+    with pytest.warns(DeprecationWarning) as record:
+        getattr(module, alias)
+
+    assert len(record) >= 1
+    message = str(record[0].message)
+    assert alias in message
+    assert canonical in message, "el aviso no dice qué usar en su lugar"
+    assert REMOVED_IN in message, "el aviso no dice cuándo se elimina"
+
+
+@pytest.mark.parametrize(("module_path", "alias", "_canonical"), ALIASES)
+def test_the_warning_points_at_the_caller_not_at_hexcore(module_path, alias, _canonical):
+    """
+    Un warning cuyo `filename` es un fichero de HexCore no le sirve a nadie: el usuario
+    necesita saber **su** línea. Lo garantiza el `stacklevel`.
+    """
+    module = importlib.import_module(module_path)
+
+    with pytest.warns(DeprecationWarning) as record:
+        getattr(module, alias)
+
+    assert record[0].filename == __file__, (
+        f"el aviso apunta a {record[0].filename}, no al código que pidió el alias"
+    )
+
+
+# ── 3. Nada avisa si no usás la API vieja ──────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "hexcore",
+        "hexcore.cqrs",
+        "hexcore.sql",
+        "hexcore.domain.cqrs",
+        "hexcore.domain.events",
+        "hexcore.application.cqrs",
+        "hexcore.infrastructure.uow",
+        "hexcore.testing",
+    ],
+)
+def test_importing_does_not_warn(module_path):
+    """
+    Se importa en un subproceso porque los módulos ya están en `sys.modules` y un import
+    repetido no reejecuta nada.
+    """
+    import os
+    import subprocess
+    import sys
+
+    code = f"""
+import warnings
+warnings.simplefilter("error", DeprecationWarning)
+import {module_path}
+print("ok")
+"""
+    env = os.environ.copy()
+    env["PYTHONPATH"] = "."
+    result = subprocess.run(
+        [sys.executable, "-c", code], capture_output=True, text=True, env=env
+    )
+
+    assert result.returncode == 0, (
+        f"importar {module_path} emitió un DeprecationWarning:\n{result.stderr}"
+    )
+
+
+@pytest.mark.parametrize(("module_path", "_alias", "canonical"), ALIASES)
+def test_the_canonical_name_does_not_warn(module_path, _alias, canonical):
+    module = importlib.import_module(module_path)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        assert getattr(module, canonical) is not None
+
+
+def test_the_whole_suite_of_canonical_imports_is_clean():
+    """El camino recomendado del README no debe emitir un solo aviso."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+
+        import hexcore.cqrs as cqrs
+
+        assert cqrs.AbstractCommandBus is not None
+        assert cqrs.AbstractSerializer is not None
+        assert cqrs.HandlerRegistry is not None
+
+        registry = cqrs.HandlerRegistry()
+        cqrs.InMemoryCommandBus(registry=registry)
+
+
+# ── Métodos y funciones deprecadas ─────────────────────────────────────────────
+
+
+@pytest.mark.anyio
+async def test_event_bus_register_warns_and_delegates():
+    from hexcore.infrastructure.events.events_backends.memory import InMemoryEventBus
+
+    bus = InMemoryEventBus()
+    seen: list[object] = []
+
+    async def handler(event: object) -> None:
+        seen.append(event)
+
+    class Evt:
+        pass
+
+    with pytest.warns(DeprecationWarning, match="subscribe"):
+        bus.register(Evt, handler)
+
+    with pytest.warns(DeprecationWarning, match="publish"):
+        await bus.dispatch(Evt())
+
+    assert len(seen) == 1, "el alias deprecado no delegó en la API nueva"
+
+
+@pytest.mark.anyio
+async def test_reset_sqlalchemy_engine_warns_and_delegates():
+    pytest.importorskip("sqlalchemy")
+    pytest.importorskip("aiosqlite")
+
+    from hexcore.infrastructure.repositories.orms.sqlalchemy import session
+
+    session.init_engine("sqlite+aiosqlite:///:memory:")
+    assert session._engine is not None
+
+    with pytest.warns(DeprecationWarning, match="dispose_engine"):
+        await session.reset_sqlalchemy_engine()
+
+    assert session._engine is None
+
+
+@pytest.mark.anyio
+async def test_server_config_event_dispatcher_still_warns():
+    from hexcore.config import ServerConfig
+
+    config = ServerConfig()
+
+    with pytest.warns(DeprecationWarning):
+        assert config.event_dispatcher is config.event_bus
+
+
+# ── Un nombre inexistente sigue siendo AttributeError ──────────────────────────
+
+
+@pytest.mark.parametrize(
+    "module_path",
+    [
+        "hexcore.domain.cqrs",
+        "hexcore.domain.cqrs.buses",
+        "hexcore.domain.events",
+        "hexcore.infrastructure.uow",
+    ],
+)
+def test_unknown_attribute_still_raises_attribute_error(module_path):
+    """El `__getattr__` de deprecación no debe tragarse los errores de tipeo."""
+    module = importlib.import_module(module_path)
+
+    with pytest.raises(AttributeError, match="has no attribute"):
+        module.EstoNoExiste

--- a/tests/test_documentation_examples.py
+++ b/tests/test_documentation_examples.py
@@ -351,7 +351,7 @@ def test_docs_examples_do_not_teach_the_legacy_aliases(doc):
     """
     code = "\n".join(_code_blocks(_read(doc)))
 
-    for legacy in ("ICommandBus", "IQueryBus", "ISerializer", "IMiddleware"):
+    for legacy in ("AbstractCommandBus", "AbstractQueryBus", "AbstractSerializer", "AbstractMiddleware"):
         assert legacy not in code, (
             f"un ejemplo de {doc} usa el alias legacy {legacy}; usá su nombre canónico Abstract*"
         )
@@ -448,40 +448,47 @@ def test_support_policy_marks_only_the_current_major_as_active():
     )
 
 
-def test_deprecated_api_table_lists_real_symbols():
+def test_deprecated_api_table_lists_symbols_that_still_work():
     """
-    Los nombres de la columna "Deprecado" tienen que existir todavía (si no, la tabla
-    miente sobre que siguen funcionando), y los de la columna "Usá en su lugar" también.
+    Si la tabla promete que la superficie de v1/v2 sigue funcionando, tiene que seguir
+    funcionando. Se hace `getattr` de verdad y no `dir()`, porque los alias se resuelven
+    por `__getattr__` de módulo y por tanto no aparecen en `dir()`.
     """
     import importlib
+    import warnings
 
-    modules = [
-        "hexcore.domain.cqrs",
-        "hexcore.domain.events",
-        "hexcore.infrastructure.uow",
-        "hexcore.infrastructure.repositories.implementations",
-        "hexcore.infrastructure.repositories.orms.sqlalchemy.session",
+    must_work = [
+        ("hexcore.domain.cqrs", "AbstractCommandBus"),
+        ("hexcore.domain.cqrs", "AbstractQueryBus"),
+        ("hexcore.domain.cqrs", "AbstractEventBus"),
+        ("hexcore.domain.cqrs", "AbstractCommandHandler"),
+        ("hexcore.domain.cqrs", "AbstractQueryHandler"),
+        ("hexcore.domain.cqrs", "AbstractMiddleware"),
+        ("hexcore.domain.cqrs", "AbstractSerializer"),
+        ("hexcore.domain.cqrs.buses", "AbstractCommandBus"),
+        ("hexcore.domain.cqrs.handlers", "AbstractCommandHandler"),
+        ("hexcore.domain.cqrs.middleware", "AbstractMiddleware"),
+        ("hexcore.domain.cqrs.serializer", "AbstractSerializer"),
+        ("hexcore.domain.events", "IEventDispatcher"),
     ]
-    available: set[str] = set()
-    for path in modules:
-        try:
-            available |= set(dir(importlib.import_module(path)))
-        except ImportError:
-            continue
 
-    # Se comprueban los que no dependen de extras ni son atributos de instancia.
-    must_exist = [
-        "ICommandBus", "IQueryBus", "IEventBus",
-        "ICommandHandler", "IQueryHandler",
-        "IMiddleware", "ISerializer",
+    broken: list[str] = []
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        for module_path, name in must_work:
+            module = importlib.import_module(module_path)
+            if getattr(module, name, None) is None:
+                broken.append(f"{module_path}.{name}")
+
+    assert not broken, (
+        "el README promete que estos alias siguen funcionando, y no: " + ", ".join(broken)
+    )
+
+    readme = _read("README.md")
+    canonical = [
         "AbstractCommandBus", "AbstractQueryBus", "AbstractEventBus",
         "AbstractCommandHandler", "AbstractQueryHandler",
         "AbstractMiddleware", "AbstractSerializer",
     ]
-    missing = [name for name in must_exist if name not in available]
-
-    assert not missing, f"la tabla de API deprecada menciona símbolos que no existen: {missing}"
-
-    readme = _read("README.md")
-    for name in must_exist:
+    for name in {n for _m, n in must_work} | set(canonical):
         assert name in readme, f"{name} no aparece en el README"

--- a/tests/test_documentation_examples.py
+++ b/tests/test_documentation_examples.py
@@ -300,38 +300,46 @@ def test_readme_command_only_consumer_example_runs():
 DOC_FILES = ["README.md", "DOCS.md"]
 
 
-@pytest.mark.parametrize("doc", DOC_FILES)
-def test_docs_do_not_mention_the_wrong_registry_method(doc):
-    """`register_command(` no existe; el método es `register_command_handler`."""
-    content = _read(doc)
-
-    assert not re.search(r"register_command\(", content), (
-        f"{doc} menciona register_command(, que no existe"
-    )
-    assert not re.search(r"register_query\(", content), (
-        f"{doc} menciona register_query(, que no existe"
-    )
-
-
-@pytest.mark.parametrize("doc", DOC_FILES)
-def test_docs_do_not_mention_the_wrong_task_names(doc):
-    """Las tareas del consumidor se llaman `hexcore.process_*`."""
-    content = _read(doc)
-
-    for wrong in ("process_cqrs_command", "process_cqrs_handler", "process_cqrs_task"):
-        assert wrong not in content, f"{doc} menciona {wrong}, que no existe"
-
-
-@pytest.mark.parametrize("doc", DOC_FILES)
-def test_docs_do_not_mention_deleted_api(doc):
-    content = _read(doc)
-
-    assert "MiddlewareConfig" not in content, f"{doc} menciona MiddlewareConfig, borrado"
-
-
 def _code_blocks(content: str) -> list[str]:
     """Los bloques de código de un markdown. La prosa puede *mencionar* lo que quiera."""
     return re.findall(r"```[a-zA-Z]*\n(.*?)```", content, re.DOTALL)
+
+
+# Todos los guardas de abajo miran **sólo los bloques de código**. La prosa puede —y debe—
+# nombrar la API vieja: la tabla de deprecación y la guía de migración existen precisamente
+# para decirte qué dejar de usar. Lo que no debe pasar es que un *ejemplo*, que es lo que la
+# gente copia y pega, enseñe algo que no existe o que está deprecado.
+
+
+@pytest.mark.parametrize("doc", DOC_FILES)
+def test_docs_examples_do_not_use_the_wrong_registry_method(doc):
+    """`register_command(` no existe; el método es `register_command_handler`."""
+    code = "\n".join(_code_blocks(_read(doc)))
+
+    assert not re.search(r"register_command\(", code), (
+        f"un ejemplo de {doc} usa register_command(, que no existe"
+    )
+    assert not re.search(r"register_query\(", code), (
+        f"un ejemplo de {doc} usa register_query(, que no existe"
+    )
+
+
+@pytest.mark.parametrize("doc", DOC_FILES)
+def test_docs_examples_do_not_use_the_wrong_task_names(doc):
+    """Las tareas del consumidor se llaman `hexcore.process_*`."""
+    code = "\n".join(_code_blocks(_read(doc)))
+
+    for wrong in ("process_cqrs_command", "process_cqrs_handler", "process_cqrs_task"):
+        assert wrong not in code, f"un ejemplo de {doc} usa {wrong}, que no existe"
+
+
+@pytest.mark.parametrize("doc", DOC_FILES)
+def test_docs_examples_do_not_use_deleted_api(doc):
+    code = "\n".join(_code_blocks(_read(doc)))
+
+    assert "MiddlewareConfig" not in code, (
+        f"un ejemplo de {doc} usa MiddlewareConfig, que se eliminó en 3.0"
+    )
 
 
 @pytest.mark.parametrize("doc", DOC_FILES)
@@ -396,3 +404,84 @@ def test_docs_facade_attributes_exist():
     assert not missing, "la documentación usa atributos que la fachada no exporta: " + ", ".join(
         sorted(set(missing))
     )
+
+
+# ── La política de soporte tiene que reflejar la versión real ───────────────────
+
+
+def test_support_policy_covers_every_released_major():
+    """
+    Cada major publicado tiene que aparecer en la tabla de soporte del README. Si se
+    releasea un 6.x y nadie actualiza la tabla, el usuario no sabe qué está soportado.
+    """
+    import tomllib
+
+    version = tomllib.loads(
+        (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )["project"]["version"]
+    current_major = int(version.split(".")[0])
+
+    readme = _read("README.md")
+    policy = readme.split("## Versiones y soporte", 1)[1].split("## ", 1)[0]
+
+    for major in range(1, current_major + 1):
+        assert f"**{major}.x**" in policy, (
+            f"la tabla de soporte del README no menciona la serie {major}.x "
+            f"(versión actual: {version})"
+        )
+
+
+def test_support_policy_marks_only_the_current_major_as_active():
+    import tomllib
+
+    version = tomllib.loads(
+        (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )["project"]["version"]
+    current_major = version.split(".")[0]
+
+    policy = _read("README.md").split("## Versiones y soporte", 1)[1].split("## ", 1)[0]
+    active_rows = [line for line in policy.splitlines() if "**Activa**" in line]
+
+    assert len(active_rows) == 1, "debe haber exactamente una serie activa"
+    assert f"**{current_major}.x**" in active_rows[0], (
+        f"la serie activa del README no es la {current_major}.x"
+    )
+
+
+def test_deprecated_api_table_lists_real_symbols():
+    """
+    Los nombres de la columna "Deprecado" tienen que existir todavía (si no, la tabla
+    miente sobre que siguen funcionando), y los de la columna "Usá en su lugar" también.
+    """
+    import importlib
+
+    modules = [
+        "hexcore.domain.cqrs",
+        "hexcore.domain.events",
+        "hexcore.infrastructure.uow",
+        "hexcore.infrastructure.repositories.implementations",
+        "hexcore.infrastructure.repositories.orms.sqlalchemy.session",
+    ]
+    available: set[str] = set()
+    for path in modules:
+        try:
+            available |= set(dir(importlib.import_module(path)))
+        except ImportError:
+            continue
+
+    # Se comprueban los que no dependen de extras ni son atributos de instancia.
+    must_exist = [
+        "ICommandBus", "IQueryBus", "IEventBus",
+        "ICommandHandler", "IQueryHandler",
+        "IMiddleware", "ISerializer",
+        "AbstractCommandBus", "AbstractQueryBus", "AbstractEventBus",
+        "AbstractCommandHandler", "AbstractQueryHandler",
+        "AbstractMiddleware", "AbstractSerializer",
+    ]
+    missing = [name for name in must_exist if name not in available]
+
+    assert not missing, f"la tabla de API deprecada menciona símbolos que no existen: {missing}"
+
+    readme = _read("README.md")
+    for name in must_exist:
+        assert name in readme, f"{name} no aparece en el README"

--- a/tests/test_facades.py
+++ b/tests/test_facades.py
@@ -65,6 +65,8 @@ def test_resolution_is_cached_in_module_globals(facade_name):
     assert getattr(facade, name) is first
 
 
+# El alias legacy se pide a propósito para comprobar que sigue funcionando.
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 def test_cqrs_facade_exposes_only_the_canonical_names():
     """
     S4: un solo nombre por concepto en la superficie que enseña la documentación. Los

--- a/tests/test_handler_registry.py
+++ b/tests/test_handler_registry.py
@@ -5,7 +5,7 @@ P1-5: el `HandlerRegistry` decía ser thread-safe y no lo era.
 (y con el free-threading de Python 3.14 son hilos reales) el handler se instanciaba
 dos veces y cada hilo se quedaba con la suya.
 
-También cubre la ambigüedad de `callable(entry) and not isinstance(entry, ICommandHandler)`
+También cubre la ambigüedad de `callable(entry) and not isinstance(entry, AbstractCommandHandler)`
 cuando un handler implementa `__call__`.
 """
 from __future__ import annotations

--- a/tests/test_infrastructure_query_path.py
+++ b/tests/test_infrastructure_query_path.py
@@ -11,8 +11,8 @@ from hexcore.domain.repositories import IBaseRepository
 from hexcore.domain.services import BaseDomainService
 from hexcore.domain.uow import IUnitOfWork
 from hexcore.infrastructure.repositories.implementations import (
-    BeanieODMCommonImplementationsRepo,
-    SQLAlchemyCommonImplementationsRepo,
+    BeanieRepository,
+    SqlAlchemyRepository,
 )
 
 
@@ -20,7 +20,7 @@ class _Entity(BaseEntity):
     name: str
 
 
-class _SqlRepo(SQLAlchemyCommonImplementationsRepo[_Entity, t.Any]):
+class _SqlRepo(SqlAlchemyRepository[_Entity, t.Any]):
     @property
     def entity_cls(self):
         return _Entity
@@ -34,7 +34,7 @@ class _SqlRepo(SQLAlchemyCommonImplementationsRepo[_Entity, t.Any]):
         return ValueError
 
 
-class _NoSqlRepo(BeanieODMCommonImplementationsRepo[_Entity, t.Any]):
+class _NoSqlRepo(BeanieRepository[_Entity, t.Any]):
     @property
     def entity_cls(self):
         return _Entity

--- a/tests/test_sql_session_layer.py
+++ b/tests/test_sql_session_layer.py
@@ -223,6 +223,8 @@ async def test_dispose_engine_is_safe_without_an_engine():
 
 
 @pytest.mark.anyio
+# El alias legacy se invoca a propósito; su deprecación se cubre en test_deprecations.py.
+@pytest.mark.filterwarnings("ignore::DeprecationWarning")
 async def test_reset_sqlalchemy_engine_is_still_available():
     init_engine(SQLITE_URL)
     await reset_sqlalchemy_engine()


### PR DESCRIPTION
Dos cosas que van juntas a propósito: el README **anuncia** que la API vieja está deprecada y
emite `DeprecationWarning`, así que si la documentación entrara sin el mecanismo, mentiría.

## 1. README reescrito para v5

El README describía HexCore como "un módulo base para arquitectura hexagonal y event
handling" y no mencionaba **nada** de lo que se añadió al llegar a 5.0: las factories de
FastAPI, la capa de sesión SQL, los scopes, el runner del worker, el cron de serie, las
utilidades de test, la paginación por cursor ni las fachadas. Alguien que llegara al proyecto
no tenía forma de saber que existen.

Qué trae ahora:

- **El arranque en la primera pantalla**: el `main.py` y el `worker.py` completos de una app.
- Tabla de extras, con qué habilita cada uno.
- Los tres imports de fachada.
- Tabla "qué necesitás → qué API → qué extra", que es cómo la gente busca de verdad.
- Secciones nuevas: capa SQL (incluido *por qué* `expire_on_commit=False` y la normalización
  del DSN no son parámetros), scopes fuera de request y la convención de transacción,
  `create_app`/`build_lifespan`, health, rate limit, streaming, routing, endpoints de query,
  cursor, providers CQRS y `hexcore.testing`.
- Se corrigen los nombres legacy que quedaban en los ejemplos.
- Se documentan las dos trampas de configuración que cuestan un incidente:
  `TransactionMiddleware` (comitea dos veces) y `RetryMiddleware` (los reintentos se
  **multiplican** con los de la cola: 3 × 3 = 12 ejecuciones, no 6).

## 2. Política de soporte: deprecado todo lo anterior a 5.0

| Serie | Estado |
| :-- | :-- |
| **5.x** | ✅ Activa — la única soportada |
| **4.x** | ⛔ Deprecada — aplicación **parcial** |
| **3.x** | ⛔ Deprecada — aplicación **parcial** |
| **2.x** | ⛔ Deprecada |
| **1.x** | ⛔ Deprecada |

3.0.0 y 4.0.0 existen sólo porque el trabajo se mergeó por fases y cada merge disparó un bump
automático: **no son releases pensadas para usarse**, son cortes intermedios de la misma
migración. A 3.0.0 le faltan todas las factories de FastAPI; a 4.0.0 el fix del event loop de
Celery, las fachadas y la documentación alineada. Marcarlas como válidas sería engañoso.

El README incluye una tabla con los **nueve defectos silenciosos concretos** de ≤ 2.x —los que
no lanzan excepción ni aparecen en logs de error— para que alguien pueda comprobar si le
afectan en vez de fiarse de un "actualizá".

## 3. Guía de migración

Hacía falta por un motivo concreto: commitizen genera el CHANGELOG a partir de los asuntos de
commit, así que las notas de `BEHAVIOR CHANGE` que se escribieron a mano en `## Unreleased` se
**perdieron** al releasear. Alguien subiendo de 2.5.0 a 5.0.0 no tenía dónde leer qué cambió.

La guía cubre nueve puntos con qué cambió, **por qué** y qué acción tomar:
`expire_on_commit`, `get_sql_uow`, `TransactionMiddleware`, `enqueue_event`, los decoradores
que rechazan `<locals>`, `CQRSFactory` y el enqueuer, cuándo corre un cron job, el `detail`
del 422, y `MiddlewareConfig`.

## 4. `DeprecationWarning` en la API anterior a 5.0

`ICommandBus = AbstractCommandBus` es una asignación: leerla no ejecuta nada, así que **no
puede avisar**. Los alias pasan a resolverse con `__getattr__` de módulo (PEP 562), que se
invoca exactamente al pedir el alias. Helper compartido en `hexcore/_deprecation.py`.

Tres propiedades que hacen que la deprecación sirva de algo, y que los tests fijan:

1. **El alias sigue funcionando** y devuelve el objeto canónico, comprobado por identidad.
2. **El aviso apunta al código del usuario**, no a las tripas de HexCore. Un warning cuyo
   `filename` es un fichero de la librería no le sirve a nadie; hay un test que comprueba el
   `filename` del registro.
3. **Importar HexCore no avisa.** Si el import avisara, nadie podría saber *quién* usa el
   alias y el aviso se volvería ruido a ignorar. Para conseguirlo,
   `hexcore/domain/cqrs/__init__.py` deja de hacer `from .buses import ICommandBus` — ese
   import eager disparaba el aviso al importar el paquete.

Detalles: el alias **no** se cachea en los globals (si se cacheara, el segundo acceso dejaría
de avisar), y bajo `t.TYPE_CHECKING` se declaran como asignaciones normales para que los type
checkers los sigan resolviendo.

**Superficie cubierta.** Alias de módulo: `ICommandBus`, `IQueryBus`, `IEventBus`,
`ICommandHandler`, `IQueryHandler`, `IMiddleware`, `ISerializer`, `IEventDispatcher`,
`InMemoryEventDispatcher`, `SQLAlchemyCommonImplementationsRepo`,
`BeanieODMCommonImplementationsRepo`, `NoSqlUnitOfWork`. Callables: `EventBus.register()`,
`EventBus.dispatch()` y `reset_sqlalchemy_engine()`.

**Requisito previo:** sin migrar los usos internos, la propia librería dispararía los avisos.
Se migran 13 módulos de `hexcore/` y 4 de `tests/` a los nombres canónicos — rename mecánico,
los alias apuntaban al mismo objeto. Los dos tests que piden un alias *a propósito* quedan
marcados con `filterwarnings`, así que el suite corre con **cero avisos** y cualquiera nuevo
destaca.

## Riesgo / compatibilidad

Nada deja de funcionar. Un proyecto con API vieja verá `DeprecationWarning` —que es el
objetivo— y romperá sólo si corre con `-W error::DeprecationWarning`. Para inventariar:

```sh
python -m pytest -W "default::DeprecationWarning"
```

Los alias se eliminan en **6.0**, como anuncia el README.

## Tests

`616 passed, 0 skipped, 0 warnings` (+83).

- `tests/test_deprecations.py` — 83 tests: alias que resuelven al canónico, que avisan con el
  reemplazo y la versión de eliminación, con el `filename` del llamador; 8 módulos que se
  importan sin avisar (en subproceso, porque un import repetido no reejecuta nada); los
  nombres canónicos que no avisan; el camino recomendado del README completo bajo
  `simplefilter("error")`; los tres callables que avisan **y delegan**; y que un nombre
  inexistente sigue dando `AttributeError` — el `__getattr__` no debe tragarse los typos.
- Tres tests nuevos en `test_documentation_examples.py` que impiden que la política se
  desincronice: cada major publicado aparece en la tabla (leyendo `pyproject.toml`), hay
  exactamente una serie activa y es la del major actual, y los alias que la tabla promete que
  funcionan **funcionan de verdad** (con `getattr`, no `dir()`, porque `__getattr__` no
  aparece en `dir()`).
- Tres guardas del test de documentación pasan a mirar sólo los bloques de código: la tabla de
  deprecación tiene que poder nombrar la API vieja para decirte que la dejes de usar.

Pyright: 42 errores no-import (baseline 44).
