### PR TITLE
fix: declara 6.x como serie activa en la política de soporte

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,17 +839,22 @@ estructura de migraciones con Alembic.
 
 | Serie | Estado | Qué significa |
 | :-- | :-- | :-- |
-| **5.x** | ✅ **Activa** | La única soportada. Recibe features y correcciones. |
+| **6.x** | ✅ **Activa** | La única soportada. Recibe features y correcciones. |
+| **5.x** | ⛔ **Deprecada** | Misma superficie de API que 6.x. Migrar es actualizar la versión. |
 | **4.x** | ⛔ **Deprecada** | Aplicación **parcial**: le faltan el fix del event loop de Celery, las fachadas y la documentación alineada. |
 | **3.x** | ⛔ **Deprecada** | Aplicación **parcial**: tiene las correcciones P0/P1 pero ninguna de las factories de FastAPI. |
 | **2.x** | ⛔ **Deprecada** | Contiene los bugs silenciosos corregidos en 5.x (ver abajo). |
 | **1.x** | ⛔ **Deprecada** | Sin soporte de ningún tipo. |
 
-**Todo lo anterior a 5.0 está deprecado. Migrá a 5.x.**
+**Todo lo anterior a 5.0 está deprecado. Migrá a 6.x.**
 
 3.0.0 y 4.0.0 existen sólo porque el trabajo se mergeó por fases y cada merge disparó un bump
 automático: **no son releases pensadas para usarse**, son cortes intermedios de la misma
 migración. 5.0.0 es la primera versión completa.
+
+6.0.0 es el mismo caso: la disparó un PR de documentación con un commit `feat!:`. No hay
+**ninguna** ruptura de API entre 5.x y 6.x — los alias anteriores a 5.0 siguen importables y
+siguen avisando.
 
 ### Por qué 2.x y anteriores no deberían estar en producción
 


### PR DESCRIPTION
## Ítem del plan

Ninguno directamente: es el **baseline roto** que aparece al empezar la ronda 2. Comparte causa con R1.

## Problema

`master` tiene dos tests en rojo:

```
FAILED tests/test_documentation_examples.py::test_support_policy_covers_every_released_major
FAILED tests/test_documentation_examples.py::test_support_policy_marks_only_the_current_major_as_active
```

El README anuncia `5.x` como la única serie soportada mientras el paquete ya publica `6.0.0`. Consecuencias:

- Todo PR nuevo nace con CI roja, así que el rojo deja de significar nada.
- Un usuario que llega al README en 6.0.0 lee que su versión no está soportada.

La causa es la misma que denuncia R1: el bump a 6.0 lo disparó un PR de documentación con un commit `feat!:`, y nada de la documentación se movió con él.

## Reproducción

```bash
.venv/Scripts/python.exe -m pytest tests/test_documentation_examples.py -q
# 2 failed, 23 passed
```

## Solución

Se añade la fila `6.x` como serie activa y se baja `5.x` a deprecada. Además se deja escrito, junto a la nota que ya existía sobre 3.0.0 y 4.0.0, que **entre 5.x y 6.x no hay ninguna ruptura de API** — para que nadie busque una guía de migración que no existe.

**Por qué esta opción y no relajar el test:** el test es correcto y es el que detectó el desfase. Lo que estaba mal era la documentación.

## Riesgo / compatibilidad

Ninguno: sólo toca `README.md`.

## Tests

Los dos que ya existían y estaban fallando. No hace falta test nuevo — este PR es precisamente el que los pone en verde.

> **Este PR debería mergearse primero.** Mientras siga fuera, la CI de los otros seis PRs de la ronda arrastra estos dos fallos.
