### PR TITLE
fix: mueve REMOVED_IN a 7.0 y lo blinda con un test

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,17 +839,22 @@ estructura de migraciones con Alembic.
 
 | Serie | Estado | Qué significa |
 | :-- | :-- | :-- |
-| **5.x** | ✅ **Activa** | La única soportada. Recibe features y correcciones. |
+| **6.x** | ✅ **Activa** | La única soportada. Recibe features y correcciones. |
+| **5.x** | ⛔ **Deprecada** | Misma superficie de API que 6.x. Migrar es actualizar la versión. |
 | **4.x** | ⛔ **Deprecada** | Aplicación **parcial**: le faltan el fix del event loop de Celery, las fachadas y la documentación alineada. |
 | **3.x** | ⛔ **Deprecada** | Aplicación **parcial**: tiene las correcciones P0/P1 pero ninguna de las factories de FastAPI. |
 | **2.x** | ⛔ **Deprecada** | Contiene los bugs silenciosos corregidos en 5.x (ver abajo). |
 | **1.x** | ⛔ **Deprecada** | Sin soporte de ningún tipo. |
 
-**Todo lo anterior a 5.0 está deprecado. Migrá a 5.x.**
+**Todo lo anterior a 5.0 está deprecado. Migrá a 6.x.**
 
 3.0.0 y 4.0.0 existen sólo porque el trabajo se mergeó por fases y cada merge disparó un bump
 automático: **no son releases pensadas para usarse**, son cortes intermedios de la misma
 migración. 5.0.0 es la primera versión completa.
+
+6.0.0 es el mismo caso: la disparó un PR de documentación con un commit `feat!:`. No hay
+**ninguna** ruptura de API entre 5.x y 6.x — los alias anteriores a 5.0 siguen importables y
+siguen avisando.
 
 ### Por qué 2.x y anteriores no deberían estar en producción
 

--- a/hexcore/_deprecation.py
+++ b/hexcore/_deprecation.py
@@ -3,7 +3,7 @@ Mecanismo de deprecación de la superficie de API anterior a 5.0.
 
 Conviven dos nombres para varios conceptos (`AbstractCommandBus`/`ICommandBus`,
 `AbstractSerializer`/`ISerializer`, …) por retrocompatibilidad con 1.x/2.x. Los canónicos
-son los `Abstract*`; los alias siguen funcionando, pero avisan y se eliminarán en 6.0.
+son los `Abstract*`; los alias siguen funcionando, pero avisan y se eliminarán en 7.0.
 
 Un alias declarado como `ICommandBus = AbstractCommandBus` **no puede avisar**: es una
 asignación, y leerlo no ejecuta nada. Por eso el aviso se implementa con `__getattr__` de
@@ -34,7 +34,14 @@ __all__ = [
 
 #: Versión en la que se eliminan los alias. Se menciona en cada aviso para que el usuario
 #: sepa cuánto margen tiene.
-REMOVED_IN = "6.0"
+#:
+#: **Tiene que ser estrictamente mayor que la versión publicada**, o el aviso se contradice
+#: a sí mismo: anunciar "se elimina en 6.0" corriendo en 6.0.0, con los alias delante, le
+#: enseña al usuario que estos avisos no hay que leerlos. Ya pasó, porque en este repo dos
+#: majors salieron de commits `feat!:` involuntarios. Lo vigila
+#: `test_removed_in_is_ahead_of_the_published_version`: si un bump vuelve a alcanzar a este
+#: valor, el fallo salta en CI y no en el aviso que lee el usuario.
+REMOVED_IN = "7.0"
 
 
 def warn_deprecated(

--- a/tests/test_deprecations.py
+++ b/tests/test_deprecations.py
@@ -2,7 +2,7 @@
 Deprecación de la superficie de API anterior a 5.0.
 
 Los alias de v1/v2 siguen funcionando —no se han borrado— pero avisan y se eliminarán en
-6.0. Este módulo fija las tres propiedades que hacen que la deprecación sirva de algo:
+7.0. Este módulo fija las tres propiedades que hacen que la deprecación sirva de algo:
 
 1. El alias **sigue funcionando** y devuelve el objeto canónico.
 2. Pedirlo emite un `DeprecationWarning` que apunta **al código del usuario**, no a las
@@ -13,16 +13,75 @@ Los alias de v1/v2 siguen funcionando —no se han borrado— pero avisan y se e
 from __future__ import annotations
 
 import importlib
+import tomllib
 import warnings
+from pathlib import Path
 
 import pytest
 
 from hexcore._deprecation import REMOVED_IN
 
+REPO_ROOT = Path(__file__).resolve().parent.parent
+
 
 @pytest.fixture
 def anyio_backend():
     return "asyncio"
+
+
+def _published_version() -> str:
+    """
+    La versión que declara el repo.
+
+    Se lee de `pyproject.toml` y no de `importlib.metadata.version("hexcore")`: los
+    metadatos del dist instalado se quedan en la versión del último `pip install`, así
+    que en un checkout de desarrollo mienten. El que tiene que ir por delante del bump
+    es el aviso, y el bump vive aquí.
+    """
+    return tomllib.loads(
+        (REPO_ROOT / "pyproject.toml").read_text(encoding="utf-8")
+    )["project"]["version"]
+
+
+def _release(version: str, width: int = 3) -> tuple[int, ...]:
+    """
+    `"7.0"` → `(7, 0, 0)`. Sólo el tramo numérico, rellenado a `width` componentes.
+
+    El relleno es lo que hace la comparación honesta: sin él `("7","0") > ("6","0","0")`
+    compara tuplas de distinta longitud y `"6.0"` vs `"6.0.0"` daría "menor" en vez de
+    "igual", que es justo el caso contradictorio que hay que detectar.
+    """
+    parts: list[int] = []
+    for chunk in version.split("."):
+        digits = ""
+        for char in chunk:
+            if not char.isdigit():
+                break
+            digits += char
+        if not digits:
+            break
+        parts.append(int(digits))
+    return tuple((parts + [0] * width)[:width])
+
+
+def test_removed_in_is_ahead_of_the_published_version():
+    """
+    El aviso promete una eliminación **futura**, así que `REMOVED_IN` tiene que ser
+    estrictamente mayor que la versión publicada.
+
+    Sin esta comprobación, un `feat!:` involuntario deja el aviso diciendo "se eliminará
+    en 6.0" mientras corre en 6.0.0 con los alias todavía presentes: el usuario no sabe
+    cuánto margen tiene y aprende que estos avisos son basura. En este repo ya hubo dos
+    majors accidentales, así que no es hipotético.
+    """
+    published = _release(_published_version())
+    removal = _release(REMOVED_IN)
+
+    assert removal > published, (
+        f"REMOVED_IN es {REMOVED_IN!r} pero el paquete ya publica "
+        f"{_published_version()!r}: el aviso anuncia una eliminación que, según él "
+        f"mismo, ya debería haber ocurrido. Subí REMOVED_IN al próximo major."
+    )
 
 
 # (módulo, alias deprecado, nombre canónico)


### PR DESCRIPTION
﻿## Ítem del plan

**R1.** `REMOVED_IN = "6.0"` es autocontradictorio en 6.0.

## Problema

El aviso de deprecación dice *"quedó deprecado en HexCore 5.0 y se eliminará en **6.0**"* mientras corre **en** 6.0.0, con los alias todavía presentes.

Impacto bajo pero corrosivo:

- El usuario que lo lee no sabe cuánto margen tiene.
- El que ya está en 6.0 concluye que el aviso es basura y **deja de leer los siguientes**. Ese es el daño real: un canal de deprecación sólo funciona mientras se le cree.

La causa fue un bump involuntario — el major lo disparó un PR de documentación con un commit `feat!:`. En este repo ya van dos majors accidentales.

## Reproducción

```python
import warnings
from hexcore.domain.cqrs import ICommandBus   # noqa

# DeprecationWarning: [nombre] 'ICommandBus' quedó deprecado en HexCore 5.0
# y se eliminará en 6.0. Usá 'AbstractCommandBus' en su lugar.
#
# …corriendo en hexcore 6.0.0, donde el alias sigue ahí.
```

## Solución

`REMOVED_IN = "7.0"`, **y** un test que asserta que es estrictamente mayor que la versión publicada.

**Por qué el test y no sólo la constante:** sin él esto se repite en cada major involuntario, y ya hay dos de precedente. Con él, el próximo bump accidental falla en CI en vez de publicar otro aviso que se desmiente a sí mismo.

**Por qué la versión se lee de `pyproject.toml` y no de `importlib.metadata.version("hexcore")`:** los metadatos del dist instalado se quedan en la versión del último `pip install` — en este checkout declaran `2.0.6` — así que en desarrollo mentirían y el test pasaría siempre. El que tiene que ir por delante del bump es el aviso, y el bump vive en `pyproject.toml`.

## Riesgo / compatibilidad

Ninguno funcional. Sólo cambia el texto del aviso, y a mejor: promete una eliminación que efectivamente no ha ocurrido. Los alias siguen exactamente igual.

## Tests

- `test_removed_in_is_ahead_of_the_published_version` (nuevo).
- Comprobado revirtiendo la constante a `"6.0"`: el test falla. Con `"7.0"`: pasa.
- Los 84 tests de `tests/test_deprecations.py` siguen en verde.

> La CI arrastra los dos fallos de política de soporte que arregla #38. Son previos a esta rama.
