### PR TITLE
feat: build_root_router acepta una secuencia de hijos, no sólo un mapa

### DIFF
--- a/README.md
+++ b/README.md
@@ -851,17 +851,22 @@ estructura de migraciones con Alembic.
 
 | Serie | Estado | Qué significa |
 | :-- | :-- | :-- |
-| **5.x** | ✅ **Activa** | La única soportada. Recibe features y correcciones. |
+| **6.x** | ✅ **Activa** | La única soportada. Recibe features y correcciones. |
+| **5.x** | ⛔ **Deprecada** | Misma superficie de API que 6.x. Migrar es actualizar la versión. |
 | **4.x** | ⛔ **Deprecada** | Aplicación **parcial**: le faltan el fix del event loop de Celery, las fachadas y la documentación alineada. |
 | **3.x** | ⛔ **Deprecada** | Aplicación **parcial**: tiene las correcciones P0/P1 pero ninguna de las factories de FastAPI. |
 | **2.x** | ⛔ **Deprecada** | Contiene los bugs silenciosos corregidos en 5.x (ver abajo). |
 | **1.x** | ⛔ **Deprecada** | Sin soporte de ningún tipo. |
 
-**Todo lo anterior a 5.0 está deprecado. Migrá a 5.x.**
+**Todo lo anterior a 5.0 está deprecado. Migrá a 6.x.**
 
 3.0.0 y 4.0.0 existen sólo porque el trabajo se mergeó por fases y cada merge disparó un bump
 automático: **no son releases pensadas para usarse**, son cortes intermedios de la misma
 migración. 5.0.0 es la primera versión completa.
+
+6.0.0 es el mismo caso: la disparó un PR de documentación con un commit `feat!:`. No hay
+**ninguna** ruptura de API entre 5.x y 6.x — los alias anteriores a 5.0 siguen importables y
+siguen avisando.
 
 ### Por qué 2.x y anteriores no deberían estar en producción
 

--- a/README.md
+++ b/README.md
@@ -340,6 +340,18 @@ admin = build_root_router(
 mount_routers(app, [admin, (public_router, {"prefix": "/v1"})])
 ```
 
+`children` acepta también una **secuencia**, y no es azúcar: un dict no puede tener dos claves
+`""`, así que un raíz con varios hijos que **ya traen su propio prefijo** —lo normal cuando cada
+feature declara sus rutas completas— no se puede expresar con un mapa.
+
+```python
+# usuarios_router y tickets_router ya son APIRouter(prefix="/usuarios") y (prefix="/tickets").
+api_v1 = build_root_router("/api/v1", [usuarios_router, tickets_router])
+
+# Se pueden mezclar: un router pelado equivale a ("", router).
+api_v1 = build_root_router("/api/v1", [usuarios_router, ("/reports", reports_router)])
+```
+
 ### Endpoints de listado y búsqueda
 
 ```python

--- a/hexcore/infrastructure/api/routing.py
+++ b/hexcore/infrastructure/api/routing.py
@@ -17,10 +17,35 @@ __all__ = ["build_root_router", "mount_routers"]
 # (`prefix`, `tags`, `dependencies`…).
 MountableRouter = t.Union[APIRouter, t.Tuple[APIRouter, t.Dict[str, t.Any]]]
 
+# Los hijos de un router raíz. El `Mapping` es la forma bonita cuando cada hijo tiene su
+# sub-prefijo; la secuencia existe porque un dict **no puede** tener dos claves `""`, y un
+# raíz cuyos hijos ya declaran sus rutas completas necesita exactamente eso.
+RouterChildren = t.Union[
+    t.Mapping[str, APIRouter],
+    t.Sequence[t.Union[APIRouter, t.Tuple[str, APIRouter]]],
+]
+
+
+def _iter_children(
+    children: RouterChildren,
+) -> t.Iterator[t.Tuple[str, APIRouter]]:
+    """Normaliza las dos formas de `children` a pares ``(sub_prefijo, router)``."""
+    if isinstance(children, t.Mapping):
+        yield from children.items()
+        return
+
+    for entry in children:
+        if isinstance(entry, tuple):
+            yield entry
+        else:
+            # Un router pelado en la secuencia = sin sub-prefijo. Es el caso que motivó
+            # aceptar secuencias, así que merece no tener que escribir `("", router)`.
+            yield "", entry
+
 
 def build_root_router(
     prefix: str,
-    children: t.Mapping[str, APIRouter],
+    children: RouterChildren,
     *,
     dependencies: t.Sequence[t.Any] = (),
     tags: list[str] | None = None,
@@ -31,8 +56,16 @@ def build_root_router(
 
     Args:
         prefix: Prefijo del router raíz (p. ej. ``"/admin"``).
-        children: Mapa ``{sub_prefijo: router}``. Un sub-prefijo vacío monta el hijo
-            directamente sobre el prefijo raíz.
+        children: Los hijos, en cualquiera de las dos formas:
+
+            - **Mapa** ``{sub_prefijo: router}``. Un sub-prefijo vacío monta el hijo
+              directamente sobre el prefijo raíz.
+            - **Secuencia** de routers o de pares ``(sub_prefijo, router)``. Un router
+              pelado equivale a sub-prefijo vacío.
+
+            La secuencia no es azúcar: un dict no puede tener **dos** claves ``""``, así
+            que un raíz con varios hijos que ya traen su propio prefijo —lo normal cuando
+            cada feature declara sus rutas completas— no se puede expresar con un mapa.
         dependencies: Dependencias comunes a todos los hijos (típicamente la auth).
         tags: Tags comunes.
         **router_kwargs: Se pasan tal cual a `APIRouter` (``responses``,
@@ -49,6 +82,9 @@ def build_root_router(
             dependencies=[Depends(require_admin)],
             tags=["admin"],
         )
+
+        # Hijos que ya declaran sus rutas completas: no hay sub-prefijo que poner.
+        api_router = build_root_router("/api/v1", [usuarios_router, tickets_router])
     """
     root = APIRouter(
         prefix=prefix,
@@ -56,7 +92,7 @@ def build_root_router(
         tags=t.cast(t.Any, tags),
         **router_kwargs,
     )
-    for child_prefix, child in children.items():
+    for child_prefix, child in _iter_children(children):
         root.include_router(child, prefix=child_prefix)
     return root
 

--- a/tests/test_api_middlewares_and_routing.py
+++ b/tests/test_api_middlewares_and_routing.py
@@ -282,6 +282,74 @@ def test_build_root_router_supports_empty_child_prefix():
         assert client.get("/root/items").json() == {"from": "direct"}
 
 
+def _self_prefixed_child(prefix: str, name: str) -> APIRouter:
+    """Un hijo que ya declara su propia ruta completa: no le queda sub-prefijo que poner."""
+    router = APIRouter(prefix=prefix)
+
+    @router.get("/items")
+    async def items() -> dict[str, str]:
+        return {"from": name}
+
+    return router
+
+
+def test_build_root_router_accepts_two_children_without_sub_prefix():
+    """
+    El caso que un `Mapping` **no puede expresar**: dos hijos que ya traen sus rutas
+    completas, o sea dos sub-prefijos vacíos. Un dict no admite dos claves `""`, así que
+    con la firma anterior este root router había que escribirse a mano.
+    """
+    root = build_root_router(
+        "/api/v1",
+        [
+            _self_prefixed_child("/usuarios", "usuarios"),
+            _self_prefixed_child("/tickets", "tickets"),
+        ],
+    )
+    app = FastAPI()
+    app.include_router(root)
+
+    with TestClient(app) as client:
+        assert client.get("/api/v1/usuarios/items").json() == {"from": "usuarios"}
+        assert client.get("/api/v1/tickets/items").json() == {"from": "tickets"}
+
+
+def test_build_root_router_sequence_mixes_bare_routers_and_pairs():
+    root = build_root_router(
+        "/api",
+        [_child("raiz"), ("/reports", _child("reports"))],
+    )
+    app = FastAPI()
+    app.include_router(root)
+
+    with TestClient(app) as client:
+        assert client.get("/api/items").json() == {"from": "raiz"}
+        assert client.get("/api/reports/items").json() == {"from": "reports"}
+
+
+def test_build_root_router_sequence_still_applies_dependencies_and_tags():
+    """Las dos formas de `children` tienen que ser equivalentes en todo lo demás."""
+    calls: list[str] = []
+
+    async def guard() -> None:
+        calls.append("checked")
+
+    root = build_root_router(
+        "/secure",
+        [("/a", _child("a"))],
+        dependencies=[Depends(guard)],
+        tags=["admin"],
+    )
+    app = FastAPI()
+    app.include_router(root)
+
+    with TestClient(app) as client:
+        assert client.get("/secure/a/items").status_code == 200
+
+    assert calls == ["checked"]
+    assert app.openapi()["paths"]["/secure/a/items"]["get"]["tags"] == ["admin"]
+
+
 def test_mount_routers_accepts_plain_routers_and_tuples():
     app = FastAPI()
     mount_routers(


### PR DESCRIPTION
﻿## Ítem del plan

**R2.** `build_root_router` no admite dos hijos sin sub-prefijo.

## Problema

```python
children: t.Mapping[str, APIRouter]
```

Un dict no puede tener dos claves `""`. Así que un router raíz cuyos hijos **ya traen su propio prefijo** —el caso normal cuando cada feature declara sus rutas completas— no se puede expresar con esta firma.

**Impacto medido.** De los tres root routers de la app real que migró a 6.0, dos se convirtieron y el tercero hubo que dejarlo escrito a mano. F13 quedó a 2/3 por la firma de un parámetro.

## Reproducción

```python
# usuarios_router es APIRouter(prefix="/usuarios"), tickets_router es APIRouter(prefix="/tickets")
build_root_router("/api/v1", {"": usuarios_router, "": tickets_router})
#                                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
# La segunda clave pisa a la primera: sólo se monta tickets_router. Silenciosamente.
```

Ni siquiera falla — se pierde un router entero sin decir nada.

## Solución

`children` acepta también `Sequence[APIRouter | tuple[str, APIRouter]]`:

```python
api_v1 = build_root_router("/api/v1", [usuarios_router, tickets_router])
api_v1 = build_root_router("/api/v1", [usuarios_router, ("/reports", reports_router)])
```

**Por qué una secuencia y no otra cosa:** es la estructura que sí admite repetidos, que es exactamente lo que falta. Un `list[tuple]` es además la forma canónica de "mapa con claves repetibles" en Python.

**Por qué un router pelado equivale a `("", router)`:** el caso que motivó el cambio es precisamente el de sub-prefijo vacío; obligar a escribir `("", router)` en cada elemento sería ceremonia para el caso mayoritario. El par explícito sigue disponible para mezclar en la misma lista.

**Por qué `_iter_children`:** normaliza las dos formas en un solo sitio, así que `dependencies`, `tags` y `router_kwargs` no pueden divergir entre ellas. Hay un test que fija esa equivalencia.

## Riesgo / compatibilidad

Compatible hacia atrás. Un `Mapping` sigue funcionando idéntico y sigue siendo la forma bonita cuando cada hijo tiene su sub-prefijo — no se deprecia nada.

## Tests

Tres nuevos en `tests/test_api_middlewares_and_routing.py`:

- `test_build_root_router_accepts_two_children_without_sub_prefix` — el caso que el `Mapping` no puede expresar.
- `test_build_root_router_sequence_mixes_bare_routers_and_pairs`
- `test_build_root_router_sequence_still_applies_dependencies_and_tags` — la equivalencia entre las dos formas.

Comprobado revirtiendo `routing.py`: los tres fallan. Con el cambio: pasan. `pyright` sobre el módulo: 0 errores.

> La CI arrastra los dos fallos de política de soporte que arregla #38. Son previos a esta rama.
