### PR TITLE
feat: CronJobDefinition lleva description, y el seed la persiste

### DIFF
--- a/README.md
+++ b/README.md
@@ -861,17 +861,22 @@ estructura de migraciones con Alembic.
 
 | Serie | Estado | Qué significa |
 | :-- | :-- | :-- |
-| **5.x** | ✅ **Activa** | La única soportada. Recibe features y correcciones. |
+| **6.x** | ✅ **Activa** | La única soportada. Recibe features y correcciones. |
+| **5.x** | ⛔ **Deprecada** | Misma superficie de API que 6.x. Migrar es actualizar la versión. |
 | **4.x** | ⛔ **Deprecada** | Aplicación **parcial**: le faltan el fix del event loop de Celery, las fachadas y la documentación alineada. |
 | **3.x** | ⛔ **Deprecada** | Aplicación **parcial**: tiene las correcciones P0/P1 pero ninguna de las factories de FastAPI. |
 | **2.x** | ⛔ **Deprecada** | Contiene los bugs silenciosos corregidos en 5.x (ver abajo). |
 | **1.x** | ⛔ **Deprecada** | Sin soporte de ningún tipo. |
 
-**Todo lo anterior a 5.0 está deprecado. Migrá a 5.x.**
+**Todo lo anterior a 5.0 está deprecado. Migrá a 6.x.**
 
 3.0.0 y 4.0.0 existen sólo porque el trabajo se mergeó por fases y cada merge disparó un bump
 automático: **no son releases pensadas para usarse**, son cortes intermedios de la misma
 migración. 5.0.0 es la primera versión completa.
+
+6.0.0 es el mismo caso: la disparó un PR de documentación con un commit `feat!:`. No hay
+**ninguna** ruptura de API entre 5.x y 6.x — los alias anteriores a 5.0 siguen importables y
+siguen avisando.
 
 ### Por qué 2.x y anteriores no deberían estar en producción
 

--- a/README.md
+++ b/README.md
@@ -661,6 +661,28 @@ otro origen (Mongo, Redis, un YAML), implementá `cqrs.ICronJobRepository`.
 `cron_job()` deriva el `task_name` de `__cqrs_task_name__`: escribirlo a mano es cómo se acaba
 con un cron que encola una tarea ya renombrada, y el fallo aparece en el worker.
 
+Cada job lleva además una `description` que viaja a la tabla. El scheduler no la usa: es lo que
+un panel le muestra al operador para que sepa **qué hace** un cron antes de desactivarlo — con
+sólo `task_name` y una expresión cron no se distingue apagar algo inofensivo de dejar de
+facturar. Por defecto sale de la primera línea del docstring de la tarea, que suele ser
+exactamente eso:
+
+```python
+@cqrs.background_task(queue="billing")
+async def emitir_facturas() -> None:
+    """Emite las facturas del mes y las envía por email."""
+    ...
+
+cqrs.cron_job(emitir_facturas, "0 6 1 * *")
+# description == "Emite las facturas del mes y las envía por email."
+
+cqrs.cron_job(cerrar_caja, "0 3 * * *", description="Cierra la caja del día.")
+```
+
+> Si tu tabla es anterior a esta columna, la migración es un `add_column` nullable —
+> `create_cron_tables()` lo trae escrito en su docstring. Un modelo propio que no la tenga no
+> rompe: el seed inserta lo que la tabla admita.
+
 **Cómo decide si toca ejecutar.** No compara contra el minuto actual, sino que busca si hubo
 alguna ocurrencia entre `last_run_at` y ahora:
 

--- a/hexcore/domain/cqrs/cron.py
+++ b/hexcore/domain/cqrs/cron.py
@@ -20,9 +20,18 @@ class CronJobDefinition:
     payload: dict[str, t.Any] = field(default_factory=dict)
     queue: str = "default"
     is_active: bool = True
-    
+
     # Para control de estado si se usa sin locks distribuidos
     last_run_at: datetime | None = None
+
+    # Qué hace el job, en prosa. No lo usa el scheduler: existe para el humano que ve la
+    # tabla en un panel de administración y tiene que decidir si desactivar un cron. Sin
+    # esto sólo se ve `task_name` y una expresión cron, que no dicen si apagarlo es
+    # inofensivo o deja de facturar.
+    #
+    # Va al final del dataclass a propósito: intercalarlo cambiaría el significado de los
+    # argumentos posicionales de quien ya construye definiciones a mano.
+    description: str | None = None
 
 
 class ICronJobRepository(abc.ABC):

--- a/hexcore/infrastructure/cqrs/cron_sql.py
+++ b/hexcore/infrastructure/cqrs/cron_sql.py
@@ -69,6 +69,11 @@ class CronJobModelMixin:
     last_run_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True, default=None
     )
+    # Nullable: las tablas que ya existen no tienen la columna, y una migración que la
+    # añadiera NOT NULL exigiría inventarle una descripción a cada job ya sembrado.
+    description: Mapped[str | None] = mapped_column(
+        String(512), nullable=True, default=None
+    )
 
     @declared_attr
     def payload(cls) -> Mapped[dict[str, t.Any]]:  # noqa: N805
@@ -85,6 +90,7 @@ class CronJobModelMixin:
             queue=self.queue,
             is_active=self.is_active,
             last_run_at=self.last_run_at,
+            description=self.description,
         )
 
 
@@ -196,22 +202,28 @@ async def seed_cron_jobs(
             return 0
 
         statement = _insert_ignore(session, model)
+        # Un modelo propio anterior a la columna `description` no la tiene, y un INSERT de
+        # Core con una clave que no es columna revienta con `Unconsumed column names`. Se
+        # siembra lo que la tabla admita en vez de tirar el arranque entero.
+        columns = set(model.__table__.c.keys())
         inserted = 0
         # Fila a fila para que `rowcount` sea fiable en todos los dialectos: con
         # executemany varios drivers devuelven -1 y el contador mentiría. Son un puñado
         # de filas y esto corre una vez al arrancar.
         for job in missing:
+            values = {
+                "job_id": job.job_id,
+                "task_name": job.task_name,
+                "cron_expression": job.cron_expression,
+                "payload": job.payload,
+                "queue": job.queue,
+                "is_active": job.is_active,
+                "last_run_at": _as_utc(job.last_run_at) if job.last_run_at else None,
+                "description": job.description,
+            }
             result = await session.execute(
                 statement,
-                {
-                    "job_id": job.job_id,
-                    "task_name": job.task_name,
-                    "cron_expression": job.cron_expression,
-                    "payload": job.payload,
-                    "queue": job.queue,
-                    "is_active": job.is_active,
-                    "last_run_at": _as_utc(job.last_run_at) if job.last_run_at else None,
-                },
+                {key: value for key, value in values.items() if key in columns},
             )
             if result.rowcount != 0:
                 inserted += 1
@@ -271,6 +283,14 @@ async def create_cron_tables(
             sa.Column("queue", sa.String(64), nullable=False),
             sa.Column("is_active", sa.Boolean(), nullable=False),
             sa.Column("last_run_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("description", sa.String(512), nullable=True),
+        )
+
+    Si la tabla es anterior a la columna `description`, la migración de actualización es::
+
+        op.add_column(
+            "hexcore_cron_jobs",
+            sa.Column("description", sa.String(512), nullable=True),
         )
     """
     from hexcore.infrastructure.repositories.orms.sqlalchemy.session import get_engine
@@ -290,6 +310,7 @@ def cron_job(
     payload: dict[str, t.Any] | None = None,
     queue: str | None = None,
     is_active: bool = True,
+    description: str | None = None,
 ) -> CronJobDefinition:
     """
     Construye un `CronJobDefinition` a partir de una función decorada con
@@ -299,11 +320,16 @@ def cron_job(
     escribir el nombre a mano es cómo se acaba con un cron que encola una tarea que ya
     se renombró, y el fallo aparece en el worker, no aquí.
 
+    `description` no la lee el scheduler: viaja a la tabla para que el panel que muestra
+    los crons pueda decir **qué hace** cada uno antes de que alguien lo desactive. Si no
+    se pasa, se usa la primera línea del docstring de la tarea, que suele ser justo eso.
+
     Uso::
 
         seed = [
             cron_job(cerrar_caja, "0 3 * * *"),
             cron_job(purgar_logs, "0 4 * * 0", payload={"days": 30}),
+            cron_job(facturar, "0 6 1 * *", description="Emite las facturas del mes."),
         ]
 
     Raises:
@@ -325,7 +351,27 @@ def cron_job(
         payload=payload or {},
         queue=queue or getattr(task, "__cqrs_queue__", "default"),
         is_active=is_active,
+        description=description or _first_docstring_line(task),
     )
+
+
+def _first_docstring_line(task: t.Callable[..., t.Any]) -> str | None:
+    """
+    La primera línea del docstring de la tarea, o `None`.
+
+    Que el default salga del docstring y no quede vacío es lo que hace que la columna
+    sirva sin trabajo extra: la descripción que el operador necesita casi siempre ya está
+    escrita justo encima de la función.
+    """
+    doc = getattr(task, "__doc__", None)
+    if not doc:
+        return None
+
+    for line in doc.strip().splitlines():
+        stripped = line.strip()
+        if stripped:
+            return stripped
+    return None
 
 
 def _default_session_scope() -> t.AsyncContextManager[AsyncSession]:

--- a/tests/test_cron_sql.py
+++ b/tests/test_cron_sql.py
@@ -11,6 +11,9 @@ import pytest
 pytest.importorskip("sqlalchemy")
 pytest.importorskip("aiosqlite")
 
+from sqlalchemy import Boolean, DateTime, String  # noqa: E402
+from sqlalchemy.orm import Mapped, mapped_column  # noqa: E402
+
 from hexcore.domain.cqrs.cron import CronJobDefinition, ICronJobRepository  # noqa: E402
 from hexcore.domain.cqrs.decorators import background_task  # noqa: E402
 from hexcore.infrastructure.cqrs.cron_sql import (  # noqa: E402
@@ -312,6 +315,109 @@ async def test_cron_job_definitions_are_seedable():
     job = (await repo.get_active_jobs())[0]
     assert job.task_name == f"{__name__}.scheduled_cleanup"
     assert job.queue == "maintenance"
+
+
+# ── R3: `description`, la columna que el operador lee antes de apagar un cron ──
+
+
+@background_task(queue="billing")
+async def emitir_facturas() -> None:  # pragma: no cover
+    """Emite las facturas del mes y las envía por email.
+
+    El resto del docstring no debería viajar a la columna.
+    """
+    ...
+
+
+@pytest.mark.anyio
+async def test_seed_persists_the_description():
+    """
+    Sin esto, una app que quiere descripciones no puede usar `seed_cron_jobs()` y se
+    queda con su propio seed: F7 adoptado a medias por una columna.
+    """
+    repo = await _prepare()
+    await seed_cron_jobs(
+        [_definition("close_books", description="Cierra la caja del día.")]
+    )
+
+    job = (await repo.get_active_jobs())[0]
+
+    assert job.description == "Cierra la caja del día."
+
+
+@pytest.mark.anyio
+async def test_description_defaults_to_none_and_round_trips():
+    repo = await _prepare()
+    await seed_cron_jobs([_definition("sin_descripcion")])
+
+    job = (await repo.get_active_jobs())[0]
+
+    assert job.description is None
+
+
+def test_description_is_the_last_field_of_the_definition():
+    """
+    Intercalarla cambiaría el significado de los argumentos posicionales de quien ya
+    construye `CronJobDefinition` a mano, y ese rompimiento sería silencioso: los tipos
+    de `last_run_at` y `description` no colisionan en runtime.
+    """
+    import dataclasses
+
+    fields = [f.name for f in dataclasses.fields(CronJobDefinition)]
+
+    assert fields[-1] == "description"
+
+
+def test_cron_job_takes_the_description_from_the_docstring():
+    """La descripción que el operador necesita casi siempre ya está escrita ahí."""
+    definition = cron_job(emitir_facturas, "0 6 1 * *")
+
+    assert definition.description == "Emite las facturas del mes y las envía por email."
+
+
+def test_cron_job_explicit_description_wins_over_the_docstring():
+    definition = cron_job(
+        emitir_facturas, "0 6 1 * *", description="Facturación mensual."
+    )
+
+    assert definition.description == "Facturación mensual."
+
+
+def test_cron_job_without_docstring_leaves_the_description_empty():
+    definition = cron_job(scheduled_cleanup, "0 4 * * *")
+
+    assert definition.description is None
+
+
+@pytest.mark.anyio
+async def test_seed_tolerates_a_model_without_the_description_column():
+    """
+    Un modelo propio anterior a R3 no tiene la columna. El seed tiene que sembrar lo que
+    la tabla admita en vez de tirar el arranque con `Unconsumed column names`.
+    """
+    from sqlalchemy.pool import StaticPool
+
+    class LegacyCronJob(Base):
+        __tablename__ = "legacy_cron_jobs"
+
+        job_id: Mapped[str] = mapped_column(String(128), primary_key=True)
+        task_name: Mapped[str] = mapped_column(String(255), nullable=False)
+        cron_expression: Mapped[str] = mapped_column(String(128), nullable=False)
+        queue: Mapped[str] = mapped_column(String(64), nullable=False, default="default")
+        is_active: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+        last_run_at: Mapped[datetime | None] = mapped_column(
+            DateTime(timezone=True), nullable=True, default=None
+        )
+
+    init_engine(SQLITE_URL, poolclass=StaticPool)
+    await create_cron_tables(model=LegacyCronJob)
+
+    inserted = await seed_cron_jobs(
+        [_definition("legacy", description="se pierde, pero no rompe")],
+        model=LegacyCronJob,
+    )
+
+    assert inserted == 1
 
 
 # ── Integración con el scheduler ───────────────────────────────────────────────


### PR DESCRIPTION
﻿## Ítem del plan

**R3.** `CronJobDefinition` no tiene `description`.

## Problema

Campos actuales: `job_id`, `task_name`, `cron_expression`, `payload`, `queue`, `is_active`, `last_run_at`.

Sin `description`, `seed_cron_jobs()` no puede sembrar la descripción de cada job — que es lo que un panel muestra al operador para saber **qué hace** un cron antes de desactivarlo. Con sólo `task_name` y una expresión cron no se distingue apagar algo inofensivo de dejar de facturar.

**Impacto medido.** La app real adoptó el repositorio de la librería pero **mantiene su propio seed**, sólo por este campo. F7 quedó a medio adoptar por una columna.

## Reproducción

```python
cqrs.seed_cron_jobs([
    cqrs.cron_job(emitir_facturas, "0 6 1 * *", description="Emite las facturas del mes."),
])
# TypeError: cron_job() got an unexpected keyword argument 'description'
```

## Solución

- `CronJobDefinition.description: str | None = None`, **al final** del dataclass.
- `CronJobModelMixin.description`, `String(512)` nullable.
- `to_definition()` y `seed_cron_jobs()` la propagan.
- `cron_job(..., description=...)`.

**Por qué al final del dataclass:** intercalarla habría cambiado el significado de los argumentos posicionales de quien ya construye definiciones a mano, y ese rompimiento sería **silencioso** — los tipos de `last_run_at` y `description` no colisionan en runtime, así que la descripción acabaría en la fecha sin que nada proteste. Hay un test que fija la posición.

**Por qué nullable:** una tabla que ya existe no tiene la columna, y añadirla `NOT NULL` obligaría a inventarle una descripción a cada job ya sembrado.

**Por qué el default sale del docstring de la tarea:** es lo que hace que la columna sirva sin trabajo extra — la descripción que el operador necesita casi siempre ya está escrita justo encima de la función. Un `description=` explícito gana sobre el docstring.

**Por qué `seed_cron_jobs` filtra los valores contra las columnas reales:** un modelo propio anterior a esta columna reventaría el arranque con `Unconsumed column names`. Ahora siembra lo que la tabla admita.

## Riesgo / compatibilidad

- **Migración necesaria si tu tabla ya existe.** Es un `add_column` nullable, y queda escrito en el docstring de `create_cron_tables()` junto a la migración de creación:

  ```python
  op.add_column("hexcore_cron_jobs", sa.Column("description", sa.String(512), nullable=True))
  ```

- Sin migración y con un modelo propio sin la columna, el seed **no rompe**: inserta el resto. La descripción se pierde, que es lo que ya pasaba.
- La API es aditiva: nada de lo que existía cambia de firma ni de comportamiento.

## Tests

Siete nuevos en `tests/test_cron_sql.py`:

- `test_seed_persists_the_description` y `test_description_defaults_to_none_and_round_trips`
- `test_description_is_the_last_field_of_the_definition` — protege el orden posicional.
- `test_cron_job_takes_the_description_from_the_docstring`, `..._explicit_description_wins_over_the_docstring`, `..._without_docstring_leaves_the_description_empty`
- `test_seed_tolerates_a_model_without_the_description_column`

Comprobado revirtiendo `cron.py` y `cron_sql.py`: los siete fallan. Con el cambio: pasan. `pyright` sobre ambos módulos: mismo recuento que en `master`.

> La CI arrastra los dos fallos de política de soporte que arregla #38. Son previos a esta rama.
