### PR TITLE
fix: install_request_id_logging avisa en vez de ser un no-op silencioso

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,8 +286,11 @@ rate_limit(10, 60, on_backend_error="deny")
 ### Request-id correlacionado
 
 ```python
+import logging
+
 from hexcore.fastapi import get_request_id, install_request_id_logging
 
+logging.basicConfig(level=logging.INFO)          # primero: configurá el logging
 install_request_id_logging(fmt="%(asctime)s [%(request_id)s] %(message)s")
 ```
 
@@ -295,6 +298,10 @@ install_request_id_logging(fmt="%(asctime)s [%(request_id)s] %(message)s")
 la traza) y lo publica en un `ContextVar` y en `request.state`. `install_request_id_logging()`
 lo inyecta en **cada línea de log**, que es la mitad del valor: sin eso, tener el header no
 correlaciona nada.
+
+> **El orden importa.** `install_request_id_logging()` instrumenta los handlers que **ya
+> existen**. En un proceso donde nadie configuró el logging todavía no hay ninguno, así que la
+> llamada no tiene nada que hacer — y avisa con un `RuntimeWarning` en vez de quedarse callada.
 
 ### Streaming: SSE, WebSocket y límite de conexiones
 

--- a/README.md
+++ b/README.md
@@ -846,17 +846,22 @@ estructura de migraciones con Alembic.
 
 | Serie | Estado | Qué significa |
 | :-- | :-- | :-- |
-| **5.x** | ✅ **Activa** | La única soportada. Recibe features y correcciones. |
+| **6.x** | ✅ **Activa** | La única soportada. Recibe features y correcciones. |
+| **5.x** | ⛔ **Deprecada** | Misma superficie de API que 6.x. Migrar es actualizar la versión. |
 | **4.x** | ⛔ **Deprecada** | Aplicación **parcial**: le faltan el fix del event loop de Celery, las fachadas y la documentación alineada. |
 | **3.x** | ⛔ **Deprecada** | Aplicación **parcial**: tiene las correcciones P0/P1 pero ninguna de las factories de FastAPI. |
 | **2.x** | ⛔ **Deprecada** | Contiene los bugs silenciosos corregidos en 5.x (ver abajo). |
 | **1.x** | ⛔ **Deprecada** | Sin soporte de ningún tipo. |
 
-**Todo lo anterior a 5.0 está deprecado. Migrá a 5.x.**
+**Todo lo anterior a 5.0 está deprecado. Migrá a 6.x.**
 
 3.0.0 y 4.0.0 existen sólo porque el trabajo se mergeó por fases y cada merge disparó un bump
 automático: **no son releases pensadas para usarse**, son cortes intermedios de la misma
 migración. 5.0.0 es la primera versión completa.
+
+6.0.0 es el mismo caso: la disparó un PR de documentación con un commit `feat!:`. No hay
+**ninguna** ruptura de API entre 5.x y 6.x — los alias anteriores a 5.0 siguen importables y
+siguen avisando.
 
 ### Por qué 2.x y anteriores no deberían estar en producción
 

--- a/hexcore/infrastructure/api/middlewares.py
+++ b/hexcore/infrastructure/api/middlewares.py
@@ -12,6 +12,7 @@ import logging
 import time
 import typing as t
 import uuid
+import warnings
 from contextvars import ContextVar
 
 from starlette.middleware.base import BaseHTTPMiddleware, RequestResponseEndpoint
@@ -123,11 +124,25 @@ def install_request_id_logging(
     """
     Instala el filtro de request-id en los handlers de un logger.
 
+    **Configurá el logging primero.** Esta función instrumenta los handlers que
+    **ya existen**; si no hay ninguno, no hay nada que instrumentar y no hace nada::
+
+        logging.basicConfig(level=logging.INFO)          # primero
+        install_request_id_logging(fmt="%(asctime)s [%(request_id)s] %(message)s")
+
+    Al revés no falla, pero deja el logging sin configurar y el request-id sin
+    aparecer. Por eso el caso "sin handlers" emite un `RuntimeWarning` en vez de
+    devolver en silencio: el síntoma sería "no veo el request-id en los logs", que no
+    apunta a ninguna causa.
+
     Args:
         logger: El logger a instrumentar. Por defecto, el root logger.
         fmt: Si se da, se aplica como formato a los handlers del logger. Usá
             ``%(request_id)s`` en él. Si es None, no se toca el formato: el filtro
             deja el atributo disponible para el formato que ya tengas.
+
+    Warns:
+        RuntimeWarning: Si el logger de destino no tiene ningún handler.
     """
     target = logger or logging.getLogger()
     log_filter = RequestIDLogFilter()
@@ -135,6 +150,19 @@ def install_request_id_logging(
     # El filtro va en los handlers, no en el logger: un filtro de logger no se aplica
     # a los registros que suben por propagación desde loggers hijos.
     handlers = target.handlers or logging.getLogger().handlers
+    if not handlers:
+        # Un no-op silencioso en una utilidad de *observabilidad* es especialmente malo:
+        # el usuario descubre que no funcionó cuando necesita correlacionar un incidente.
+        warnings.warn(
+            f"install_request_id_logging: el logger {target.name!r} no tiene handlers, "
+            "así que no hay nada que instrumentar y esta llamada no hizo nada. "
+            "Configurá el logging primero (p. ej. logging.basicConfig(...)) y llamá "
+            "después.",
+            RuntimeWarning,
+            stacklevel=2,
+        )
+        return
+
     for handler in handlers:
         if not any(isinstance(f, RequestIDLogFilter) for f in handler.filters):
             handler.addFilter(log_filter)

--- a/tests/test_api_middlewares_and_routing.py
+++ b/tests/test_api_middlewares_and_routing.py
@@ -4,6 +4,7 @@ F11 (middlewares de serie) y F13 (composición de routers).
 from __future__ import annotations
 
 import logging
+import warnings
 
 import pytest
 
@@ -207,6 +208,59 @@ def test_install_request_id_logging_can_set_the_format():
         assert handler.formatter.format(record) == "[-] hola"
     finally:
         logger.removeHandler(handler)
+
+
+# ── R4: sin handlers, la llamada no puede quedarse callada ─────────────────────
+
+
+def test_install_request_id_logging_warns_when_there_is_nothing_to_instrument():
+    """
+    El README presenta la llamada como si bastara. En un proceso limpio —nadie llamó a
+    `basicConfig`— no hay handlers, la llamada es un no-op y el síntoma es "no veo el
+    request-id en los logs", sin ninguna pista de la causa.
+    """
+    logger = logging.getLogger("hexcore.test.sin_handlers")
+    logger.handlers.clear()
+
+    root = logging.getLogger()
+    saved = root.handlers[:]
+    root.handlers.clear()
+    try:
+        with pytest.warns(RuntimeWarning, match="no tiene handlers"):
+            install_request_id_logging(logger)
+    finally:
+        root.handlers[:] = saved
+
+
+def test_install_request_id_logging_does_not_warn_when_it_has_work_to_do():
+    logger = logging.getLogger("hexcore.test.con_handlers")
+    handler = logging.StreamHandler()
+    logger.addHandler(handler)
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            install_request_id_logging(logger)
+    finally:
+        logger.removeHandler(handler)
+
+
+def test_install_request_id_logging_falls_back_to_the_root_handlers():
+    """Instrumentar el root cuando el logger pedido no tiene handlers propios no es el
+    caso vacío: hay handlers, y son los que van a formatear la línea."""
+    logger = logging.getLogger("hexcore.test.hereda_root")
+    logger.handlers.clear()
+
+    root = logging.getLogger()
+    handler = logging.StreamHandler()
+    root.addHandler(handler)
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("error", RuntimeWarning)
+            install_request_id_logging(logger)
+
+        assert any(isinstance(f, RequestIDLogFilter) for f in handler.filters)
+    finally:
+        root.removeHandler(handler)
 
 
 # ── F13: build_root_router / mount_routers ─────────────────────────────────────


### PR DESCRIPTION
﻿## Ítem del plan

**R4.** `install_request_id_logging` es un no-op silencioso sin handlers.

## Problema

La función instala el filtro en los handlers **ya existentes**. Si nadie llamó antes a `basicConfig`, `target.handlers` está vacío, el bucle no itera y la llamada no hace **nada**, sin avisar.

El README lo presentaba como si bastara por sí solo:

```python
install_request_id_logging(fmt="%(asctime)s [%(request_id)s] %(message)s")
```

En un proceso limpio eso deja el logging sin configurar. El orden correcto es `basicConfig(...)` y **después** instalar — algo que hoy sólo se descubre leyendo la fuente.

Un no-op silencioso en una utilidad de **observabilidad** es especialmente caro: el síntoma es "no veo el request-id en los logs", sin ninguna pista de la causa, y se descubre justo cuando hace falta correlacionar un incidente.

## Reproducción

```python
import logging
from hexcore.fastapi import install_request_id_logging

# Proceso limpio: nadie configuró logging todavía.
install_request_id_logging(fmt="%(asctime)s [%(request_id)s] %(message)s")

logging.getLogger().handlers
# []  ← no se instaló nada, y la llamada no dijo una palabra
```

## Solución

El caso "sin handlers" emite un `RuntimeWarning` que dice qué pasó y qué hacer, y el orden queda documentado en el docstring y en el README —que es donde nació el malentendido—.

**Por qué un warning y no una excepción:** llamarla antes de configurar el logging es un error de orden, no una condición imposible. Una excepción tumbaría el arranque de apps que hoy funcionan de casualidad (porque algo más configuró el logging después); un warning las arregla sin romperlas.

**Por qué no auto-configurar el logging:** `basicConfig` desde una librería es exactamente el tipo de side effect que la app tiene derecho a decidir. Avisar es lo correcto; decidir por el usuario, no.

**Qué NO cuenta como caso vacío:** el fallback a los handlers del root. Ahí sí hay handlers que instrumentar, y son los que van a formatear la línea. Hay un test que fija que ese camino no avisa.

## Riesgo / compatibilidad

Nada cambia para quien ya la llamaba en el orden correcto. Quien la llamaba en el orden incorrecto pasa de un silencio a un warning — que es el punto.

Un `pytest` configurado con `-W error` en un proyecto que hace la llamada mal empezaría a fallar. Es un descubrimiento correcto: hasta ahora ese proyecto no tenía request-id en los logs y no lo sabía.

## Tests

Tres nuevos en `tests/test_api_middlewares_and_routing.py`:

- `test_install_request_id_logging_warns_when_there_is_nothing_to_instrument`
- `test_install_request_id_logging_does_not_warn_when_it_has_work_to_do`
- `test_install_request_id_logging_falls_back_to_the_root_handlers` — el camino feliz del fallback, que no debe avisar.

Comprobado revirtiendo `middlewares.py`: el primero falla. Con el cambio: pasan los tres.

> La CI arrastra los dos fallos de política de soporte que arregla #38. Son previos a esta rama.
