### PR TITLE
feat: las rutas de health se adoptan por partes

### DIFF
--- a/README.md
+++ b/README.md
@@ -869,17 +869,22 @@ estructura de migraciones con Alembic.
 
 | Serie | Estado | Qué significa |
 | :-- | :-- | :-- |
-| **5.x** | ✅ **Activa** | La única soportada. Recibe features y correcciones. |
+| **6.x** | ✅ **Activa** | La única soportada. Recibe features y correcciones. |
+| **5.x** | ⛔ **Deprecada** | Misma superficie de API que 6.x. Migrar es actualizar la versión. |
 | **4.x** | ⛔ **Deprecada** | Aplicación **parcial**: le faltan el fix del event loop de Celery, las fachadas y la documentación alineada. |
 | **3.x** | ⛔ **Deprecada** | Aplicación **parcial**: tiene las correcciones P0/P1 pero ninguna de las factories de FastAPI. |
 | **2.x** | ⛔ **Deprecada** | Contiene los bugs silenciosos corregidos en 5.x (ver abajo). |
 | **1.x** | ⛔ **Deprecada** | Sin soporte de ningún tipo. |
 
-**Todo lo anterior a 5.0 está deprecado. Migrá a 5.x.**
+**Todo lo anterior a 5.0 está deprecado. Migrá a 6.x.**
 
 3.0.0 y 4.0.0 existen sólo porque el trabajo se mergeó por fases y cada merge disparó un bump
 automático: **no son releases pensadas para usarse**, son cortes intermedios de la misma
 migración. 5.0.0 es la primera versión completa.
+
+6.0.0 es el mismo caso: la disparó un PR de documentación con un commit `feat!:`. No hay
+**ninguna** ruptura de API entre 5.x y 6.x — los alias anteriores a 5.0 siguen importables y
+siguen avisando.
 
 ### Por qué 2.x y anteriores no deberían estar en producción
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ pero están deprecados — ver [Versiones y soporte](#versiones-y-soporte).
 | Sesión o UoW fuera de un request | `sql.session_scope()`, `sql.uow_scope()` | `sql` |
 | Request-id correlacionado en los logs | `hx.RequestIDMiddleware`, `hx.install_request_id_logging()` | `api` |
 | Excepciones de dominio → HTTP | `hx.register_exception_handlers()` | `api` |
-| Health checks que sondean de verdad | `hx.register_health_routes()`, `hx.check_health()` | `api` |
+| Health checks que sondean de verdad | `hx.register_health_routes()`, `hx.check_health()`, `hx.HealthRoutes` | `api` |
 | Rate limiting | `hx.rate_limit()` | `api` |
 | SSE / WebSocket / límite de conexiones | `hx.sse_stream()`, `hx.ws_heartbeat()`, `hx.connection_slot()` | `api` |
 | Composición de routers | `hx.build_root_router()`, `hx.mount_routers()` | `api` |
@@ -261,6 +261,36 @@ register_health_routes(app, probes=[
     Probe("sql", check_database),
     Probe("cache", check_redis, timeout=1.0, critical=False),
 ])
+```
+
+#### Si tu app ya publica su propio `/health`
+
+Las dos rutas se registran por separado, así que una app **ya en producción** —con su forma de
+respuesta y un cliente tipado generado desde su OpenAPI— puede quedarse con la readiness, que es
+la parte que no se escribe a mano, sin tocar el contrato que ya publicó:
+
+```python
+register_health_routes(app, liveness=False)          # sólo /health/ready
+register_health_routes(app, liveness=False, readiness_path="/_ready")
+```
+
+Y si lo que hay que conservar es la **forma del cuerpo**, `response_factory` la adapta sin
+renunciar a las sondas. El status code lo sigue decidiendo el informe, que es lo que lee el
+orquestador:
+
+```python
+register_health_routes(
+    app,
+    response_factory=lambda r: {"ok": r.status != "down", "checks": r.dependencies},
+)
+```
+
+Lo mismo desde `create_app`, sin apagar la feature entera:
+
+```python
+from hexcore.fastapi import AppFeatures, HealthRoutes, create_app
+
+app = create_app(features=AppFeatures(health=HealthRoutes(liveness=False)))
 ```
 
 ### Rate limiting

--- a/hexcore/fastapi.py
+++ b/hexcore/fastapi.py
@@ -21,6 +21,7 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     # ── App y lifespan ────────────────────────────────────────────────────────
     "create_app": ("hexcore.infrastructure.api.app", "create_app"),
     "AppFeatures": ("hexcore.infrastructure.api.app", "AppFeatures"),
+    "HealthRoutes": ("hexcore.infrastructure.api.app", "HealthRoutes"),
     "build_lifespan": ("hexcore.infrastructure.api.lifespan", "build_lifespan"),
     "StartupStep": ("hexcore.infrastructure.api.lifespan", "StartupStep"),
     "CallableStep": ("hexcore.infrastructure.api.lifespan", "CallableStep"),

--- a/hexcore/fastapi.py
+++ b/hexcore/fastapi.py
@@ -99,6 +99,7 @@ _EXPORTS: dict[str, tuple[str, str]] = {
     "HealthReport": ("hexcore.infrastructure.api.health", "HealthReport"),
     "DependencyReport": ("hexcore.infrastructure.api.health", "DependencyReport"),
     "Probe": ("hexcore.infrastructure.api.health", "Probe"),
+    "ResponseFactory": ("hexcore.infrastructure.api.health", "ResponseFactory"),
 }
 
 __all__ = sorted(_EXPORTS)

--- a/hexcore/infrastructure/api/app.py
+++ b/hexcore/infrastructure/api/app.py
@@ -15,11 +15,29 @@ from fastapi.middleware.cors import CORSMiddleware
 from pydantic import BaseModel
 
 from .exception_handlers import register_exception_handlers
-from .health import Probe, register_health_routes
+from .health import Probe, ResponseFactory, register_health_routes
 from .middlewares import RequestIDMiddleware, TimingMiddleware
 from .routing import MountableRouter, mount_routers
 
-__all__ = ["AppFeatures", "create_app"]
+__all__ = ["AppFeatures", "HealthRoutes", "create_app"]
+
+
+class HealthRoutes(BaseModel):
+    """
+    Qué rutas de health cablea `create_app()`, y con qué forma.
+
+    Existe para que una app **ya publicada** pueda adoptar la readiness sin renunciar a
+    su `/health` ni al cliente tipado generado desde su OpenAPI. Los argumentos son los
+    de `register_health_routes`, agrupados para no engordar la firma de `create_app`.
+    """
+
+    model_config = {"arbitrary_types_allowed": True}
+
+    path: str = "/health"
+    liveness: bool = True
+    readiness: bool = True
+    readiness_path: str | None = None
+    response_factory: ResponseFactory | None = None
 
 
 class AppFeatures(BaseModel):
@@ -41,8 +59,16 @@ class AppFeatures(BaseModel):
     exception_handlers: bool = True
     """Mapeo de excepciones de dominio a HTTP (F5)."""
 
-    health: bool = True
-    """Rutas `/health` y `/health/ready` (F16)."""
+    health: bool | HealthRoutes = True
+    """
+    Rutas `/health` y `/health/ready` (F16).
+
+    Acepta también un `HealthRoutes` para adoptarlas **por partes**: una app que ya
+    publica su propio `/health` puede quedarse con la readiness, que es la que no se
+    escribe a mano, sin apagar la feature entera::
+
+        AppFeatures(health=HealthRoutes(liveness=False))
+    """
 
 
 def create_app(
@@ -65,7 +91,8 @@ def create_app(
         features: Qué cablear. Ver `AppFeatures`.
         routers: Routers a montar. Acepta `APIRouter` o `(APIRouter, kwargs)` (F13).
         health_probes: Sondas para `/health/ready`. Por defecto, las deducidas de la
-            configuración (F16).
+            configuración (F16). Qué rutas se registran y con qué forma se controla con
+            `AppFeatures(health=HealthRoutes(...))`.
         exception_mapping: Excepciones extra a mapear, fusionadas con el default (F5).
         **fastapi_kwargs: Se pasan tal cual a `FastAPI` (`title`, `version`,
             `docs_url`, `openapi_tags`…). Lo que pases gana sobre los defaults derivados
@@ -99,7 +126,20 @@ def create_app(
         register_exception_handlers(app, mapping=exception_mapping)
 
     if resolved_features.health:
-        register_health_routes(app, probes=health_probes)
+        health_routes = (
+            resolved_features.health
+            if isinstance(resolved_features.health, HealthRoutes)
+            else HealthRoutes()
+        )
+        register_health_routes(
+            app,
+            probes=health_probes,
+            path=health_routes.path,
+            liveness=health_routes.liveness,
+            readiness=health_routes.readiness,
+            readiness_path=health_routes.readiness_path,
+            response_factory=health_routes.response_factory,
+        )
 
     if routers:
         mount_routers(app, list(routers))

--- a/hexcore/infrastructure/api/health.py
+++ b/hexcore/infrastructure/api/health.py
@@ -26,6 +26,7 @@ __all__ = [
     "DependencyReport",
     "HealthReport",
     "Probe",
+    "ResponseFactory",
     "check_health",
     "register_health_routes",
     "default_probes",
@@ -54,6 +55,11 @@ class HealthReport(BaseModel):
     def http_status(self) -> int:
         """503 si algo está caído; 200 en el resto de los casos."""
         return 503 if self.status == "down" else 200
+
+
+#: Adapta el cuerpo de las rutas de health a la forma que ya publica una app. Recibe el
+#: informe y devuelve lo que haya que serializar.
+ResponseFactory = t.Callable[[HealthReport], t.Any]
 
 
 class Probe(t.NamedTuple):
@@ -231,6 +237,10 @@ def register_health_routes(
     *,
     path: str = "/health",
     probes: t.Sequence[Probe] | None = None,
+    liveness: bool = True,
+    readiness: bool = True,
+    readiness_path: str | None = None,
+    response_factory: ResponseFactory | None = None,
 ) -> None:
     """
     Registra `GET {path}` (liveness) y `GET {path}/ready` (readiness).
@@ -238,18 +248,71 @@ def register_health_routes(
     - `{path}` responde 200 sin I/O. Apuntá aquí el liveness probe.
     - `{path}/ready` sondea las dependencias y responde **503** si algo crítico falla,
       con el detalle y la latencia por dependencia. Apuntá aquí el readiness probe.
-    """
-    @app.get(path, tags=["health"], summary="Liveness: el proceso responde")
-    async def health() -> HealthReport:
-        return await check_health(deep=False)
 
-    @app.get(
-        f"{path}/ready",
-        tags=["health"],
-        summary="Readiness: las dependencias responden",
-        responses={503: {"description": "Alguna dependencia crítica no responde"}},
-    )
-    async def health_ready(response: Response) -> HealthReport:
-        report = await check_health(deep=True, probes=probes)
-        response.status_code = report.http_status
-        return report
+    Las dos rutas se registran por separado a propósito. Una app que **ya publica**
+    `/health` con su propia forma —y con un cliente tipado generado desde su OpenAPI— no
+    puede aceptar la forma de `HealthReport` sin romper el contrato, pero sí quiere la
+    readiness, que es la parte que no se puede escribir a mano en cinco minutos::
+
+        register_health_routes(app, liveness=False)   # sólo /health/ready
+
+    Y si lo que hace falta es conservar la forma del cuerpo, `response_factory` la
+    adapta sin renunciar a las sondas::
+
+        register_health_routes(
+            app,
+            response_factory=lambda r: {"ok": r.status != "down", "checks": r.dependencies},
+        )
+
+    Args:
+        app: La app donde registrar.
+        path: Ruta del liveness. También la base del readiness, salvo que se dé
+            `readiness_path`.
+        probes: Sondas del readiness. Por defecto, las de `default_probes()`.
+        liveness: Registrar `GET {path}`. Poné `False` si ya publicás el tuyo.
+        readiness: Registrar el readiness.
+        readiness_path: Ruta del readiness. Por defecto ``f"{path}/ready"``.
+        response_factory: Si se da, se le pasa el `HealthReport` y lo que devuelva es el
+            cuerpo de la respuesta. El **status code** lo sigue decidiendo el informe
+            (503 si algo crítico está caído), salvo que devuelvas una `Response` propia,
+            en cuyo caso el status es cosa tuya.
+
+    Raises:
+        ValueError: Si se desactivan las dos rutas. Una llamada que no registra nada es
+            un error de configuración, y descubrirlo por silencio cuesta un incidente.
+    """
+    if not liveness and not readiness:
+        raise ValueError(
+            "register_health_routes(liveness=False, readiness=False) no registra nada. "
+            "Si no querés ninguna de las dos rutas, no llames a la función."
+        )
+
+    # Sin factory se declara `HealthReport` para que el OpenAPI documente la forma; con
+    # factory el cuerpo es lo que devuelva el usuario y no hay modelo que prometer.
+    response_model = None if response_factory is not None else HealthReport
+
+    def render(report: HealthReport) -> t.Any:
+        return report if response_factory is None else response_factory(report)
+
+    if liveness:
+        @app.get(
+            path,
+            tags=["health"],
+            summary="Liveness: el proceso responde",
+            response_model=response_model,
+        )
+        async def health() -> t.Any:
+            return render(await check_health(deep=False))
+
+    if readiness:
+        @app.get(
+            readiness_path or f"{path}/ready",
+            tags=["health"],
+            summary="Readiness: las dependencias responden",
+            response_model=response_model,
+            responses={503: {"description": "Alguna dependencia crítica no responde"}},
+        )
+        async def health_ready(response: Response) -> t.Any:
+            report = await check_health(deep=True, probes=probes)
+            response.status_code = report.http_status
+            return render(report)

--- a/tests/test_api_health.py
+++ b/tests/test_api_health.py
@@ -218,3 +218,114 @@ def test_health_report_is_serializable():
     report = HealthReport(status="ok")
 
     assert report.model_dump()["status"] == "ok"
+
+
+# ── R5: adopción por partes en una app que ya publica su /health ───────────────
+
+
+def test_readiness_can_be_registered_without_touching_the_published_liveness():
+    """
+    El caso que dejó F16 sin adoptar: la app ya publica `/health` con su propia forma y
+    un cliente tipado generado desde el OpenAPI. Antes había que apagar la feature
+    entera, y con ella se perdía la readiness, que es la parte valiosa.
+    """
+    app = FastAPI()
+
+    @app.get("/health")
+    async def mi_health() -> dict[str, str]:
+        return {"estado": "vivo"}          # el contrato ya publicado, intacto
+
+    register_health_routes(app, liveness=False, probes=[Probe("sql", _boom)])
+
+    with TestClient(app) as client:
+        assert client.get("/health").json() == {"estado": "vivo"}
+        assert client.get("/health/ready").status_code == 503
+
+
+def test_liveness_can_be_registered_alone():
+    app = FastAPI()
+    register_health_routes(app, readiness=False, probes=[Probe("sql", _boom)])
+
+    with TestClient(app) as client:
+        assert client.get("/health").status_code == 200
+        assert client.get("/health/ready").status_code == 404
+
+
+def test_disabling_both_routes_is_an_error_not_a_silent_noop():
+    app = FastAPI()
+
+    with pytest.raises(ValueError, match="no registra nada"):
+        register_health_routes(app, liveness=False, readiness=False)
+
+
+def test_readiness_path_can_be_set_independently():
+    app = FastAPI()
+    register_health_routes(
+        app, liveness=False, readiness_path="/_ready", probes=[Probe("sql", _ok)]
+    )
+
+    with TestClient(app) as client:
+        assert client.get("/_ready").status_code == 200
+        assert client.get("/health/ready").status_code == 404
+
+
+def test_response_factory_adapts_the_body_but_not_the_status():
+    """
+    La otra mitad de la adopción: conservar la forma del cuerpo sin renunciar a que un
+    503 siga siendo un 503, que es lo que lee el orquestador.
+    """
+    app = FastAPI()
+    register_health_routes(
+        app,
+        probes=[Probe("sql", _boom)],
+        response_factory=lambda report: {
+            "ok": report.status != "down",
+            "checks": [dep.name for dep in report.dependencies],
+        },
+    )
+
+    with TestClient(app) as client:
+        live = client.get("/health")
+        ready = client.get("/health/ready")
+
+    assert live.status_code == 200
+    assert live.json() == {"ok": True, "checks": []}
+
+    assert ready.status_code == 503
+    assert ready.json() == {"ok": False, "checks": ["sql"]}
+
+
+def test_response_factory_body_is_not_forced_into_the_health_report_schema():
+    """
+    Con `response_model=HealthReport`, FastAPI filtraría el cuerpo del factory a los
+    campos del informe y devolvería `{}`: adaptarlo sería inútil.
+    """
+    app = FastAPI()
+    register_health_routes(app, response_factory=lambda report: {"forma": "propia"})
+
+    with TestClient(app) as client:
+        assert client.get("/health").json() == {"forma": "propia"}
+
+
+def test_create_app_can_register_only_the_readiness():
+    from hexcore.infrastructure.api.app import AppFeatures, HealthRoutes, create_app
+
+    app = create_app(features=AppFeatures(health=HealthRoutes(liveness=False)))
+
+    @app.get("/health")
+    async def mi_health() -> dict[str, str]:
+        return {"estado": "vivo"}
+
+    with TestClient(app) as client:
+        assert client.get("/health").json() == {"estado": "vivo"}
+        assert client.get("/health/ready").status_code in (200, 503)
+
+
+def test_create_app_health_true_still_registers_both():
+    from hexcore.infrastructure.api.app import create_app
+
+    app = create_app()
+
+    paths = {route.path for route in app.routes if hasattr(route, "path")}
+
+    assert {"/health", "/health/ready"} <= paths


### PR DESCRIPTION
﻿## Ítem del plan

**R5.** `register_health_routes` no permite adopción incremental.

## Problema

```python
register_health_routes(app, *, path="/health", probes=None)
```

Registra `/health` **y** `/health/ready` como un paquete indivisible, con una forma de respuesta fija (`{status, deep, dependencies}`).

Una app que ya publica `/health` con su propia forma —y con un cliente tipado generado desde su OpenAPI— no puede aceptar `HealthReport` sin romper el contrato. Su única salida era desactivar la feature entera, y con ella perdía la **readiness**, que es la parte valiosa: el liveness lo escribe cualquiera en tres líneas; sondear las dependencias con timeout por sonda y concurrencia, no.

**Impacto medido.** La app real quedó con `AppFeatures(health=False)` y **sin readiness real**, conservando un `/health/detailed` que no sondea nada. F16 no se adoptó, y el health check que no puede fallar sigue en producción.

## Reproducción

```python
app = create_app()          # registra /health con la forma de HealthReport

@app.get("/health")         # el contrato que la app ya publicó
async def mi_health(): return {"estado": "vivo"}

# Ruta duplicada: gana la primera registrada. Para quedarse con la suya,
# la app tiene que apagar la feature entera…
app = create_app(features=AppFeatures(health=False))
# …y ahora no tiene readiness. Que era lo único que quería.
```

## Solución

Dos ejes independientes.

**1. Qué rutas se registran.**

```python
register_health_routes(app, liveness=False)                          # sólo /health/ready
register_health_routes(app, liveness=False, readiness_path="/_ready")
```

**2. Qué forma tiene el cuerpo.**

```python
register_health_routes(
    app,
    response_factory=lambda r: {"ok": r.status != "down", "checks": r.dependencies},
)
```

Y lo mismo desde `create_app`, sin salirse de la factory:

```python
app = create_app(features=AppFeatures(health=HealthRoutes(liveness=False)))
```

**Por qué dos ejes y no uno:** son dos incompatibilidades distintas. Una app puede tener el path ocupado (eje 1), la forma incompatible (eje 2), o las dos. Un solo interruptor obligaría a elegir.

**Por qué `response_model=None` cuando hay factory:** con `HealthReport` declarado, FastAPI filtraría el cuerpo del factory a los campos del informe y devolvería `{}` — adaptarlo sería inútil. Sin factory se sigue declarando, para que el OpenAPI documente la forma. Hay un test que fija esto.

**Por qué el status lo sigue decidiendo el informe:** un 503 es lo que lee el orquestador. Adaptar el cuerpo no debería poder convertir una readiness caída en un 200 por descuido. Si devolvés una `Response` propia, el status vuelve a ser tuyo, y eso está documentado.

**Por qué `HealthRoutes` y no cuatro keywords en `create_app`:** S2 del plan — máximo 3 parámetros propios por factory, lo demás en un settings object tipado.

**Por qué desactivar las dos rutas lanza `ValueError`:** una llamada que no registra nada es un error de configuración. Descubrirlo por silencio cuesta un incidente, que es la lección de R4.

## Riesgo / compatibilidad

Todo aditivo, todos los defaults preservan el comportamiento actual:

- `register_health_routes(app)` registra las dos rutas con la forma de siempre.
- `AppFeatures.health` sigue aceptando `bool`; `True` sigue registrando las dos.
- `AppFeatures(health=False)` sigue sin registrar nada.

`ResponseFactory` y `HealthRoutes` se exportan desde `hexcore.fastapi`.

## Tests

Ocho nuevos en `tests/test_api_health.py`:

- `test_readiness_can_be_registered_without_touching_the_published_liveness` — el criterio de cierre del plan.
- `test_liveness_can_be_registered_alone`, `test_readiness_path_can_be_set_independently`
- `test_disabling_both_routes_is_an_error_not_a_silent_noop`
- `test_response_factory_adapts_the_body_but_not_the_status`
- `test_response_factory_body_is_not_forced_into_the_health_report_schema`
- `test_create_app_can_register_only_the_readiness`, `test_create_app_health_true_still_registers_both`

Comprobado revirtiendo `health.py`, `app.py` y `fastapi.py`: siete fallan. Con el cambio: pasan los 23 del archivo.

> La CI arrastra los dos fallos de política de soporte que arregla #38. Son previos a esta rama.
