### PR TITLE
docs: fija en CONTRIBUTING que el CHANGELOG lo genera commitizen

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,19 +16,65 @@ Por favor, mantén siempre una comunicación respetuosa y profesional. Revisa el
 - Usa comentarios cuando sea necesario para clarificar el propósito del código.
 - Idealmente, incluye pruebas unitarias para nuevas funciones y arreglos.
 
-## 4. Revisión de Pull Requests
+## 4. El `CHANGELOG.md` no se toca en los PRs
+
+**Regla: ningún PR edita `CHANGELOG.md`.** Lo genera `commitizen` en el release, a partir de
+los commits convencionales. Si un cambio merece prosa, esa prosa va en el **cuerpo del
+commit**, no en el changelog.
+
+No es una preferencia de estilo. Un changelog se escribe por *prepend*, así que cada rama y
+cada `cz bump` en master editan **la misma línea 1**: con N ramas abiertas, cada release
+rompe las N. En la ronda de mejoras anterior costó tres tandas de conflictos, y el coste
+subió cada vez — la primera fue borrar tres marcadores, la tercera exigió reubicar bloques
+entre secciones.
+
+Como los commits ya son convencionales y `commitizen` ya está configurado
+(`[tool.commitizen]` en `pyproject.toml`), el changelog sale solo:
+
+```sh
+cz bump            # calcula la versión, taggea y regenera el CHANGELOG
+```
+
+Lo que sí se te pide a cambio: **escribí el commit para que se lea en el changelog**. El
+asunto es la línea que va a aparecer publicada; el cuerpo explica el *porqué*, que es lo que
+un `git log` no puede reconstruir después.
+
+### Poner al día una rama divergida: `merge`, no `rebase`
+
+```sh
+git config rerere.enabled true     # una vez, antes de empezar
+git merge origin/master
+```
+
+Con `rebase`, un conflicto se repite una vez por cada commit que tocó el archivo. Con
+`rerere` activado, una resolución se reaplica sola en el resto de las ramas de la pila.
+
+### "No puedo mergear" casi nunca es un conflicto
+
+`mergeable: MERGEABLE` sólo dice que no hay conflictos; lo que bloquea el botón es
+`mergeStateStatus`. Diagnosticá antes de tocar git:
+
+```sh
+gh pr view <n> --json mergeable,mergeStateStatus,reviewDecision
+gh pr checks <n>
+```
+
+`DIRTY` = conflictos reales · `UNSTABLE` = checks pendientes o fallando · `BEHIND` = la base
+exige estar al día · `BLOCKED` = falta review · `CLEAN` = listo.
+
+## 5. Revisión de Pull Requests
 - Todos los PR serán revisados antes de ser aceptados. Se pueden solicitar cambios o aclaraciones.
 - Responde a los comentarios de los revisores para facilitar el proceso.
 
-## 5. Issues
+## 6. Issues
 - Describe claramente los problemas que encuentres.
 - Proporciona información relevante (logs, versiones, pasos para reproducir, etc.).
 
-## 6. Comunicación
+## 7. Comunicación
 - Usa los issues y las discusiones para preguntas, sugerencias o propuestas.
 - Si tienes dudas sobre cómo empezar, puedes abrir un issue para orientación.
 
-## 7. Licencia
+## 8. Licencia
 Al contribuir, aceptas que tu código será distribuido bajo la licencia del repositorio.
 
 ---

--- a/README.md
+++ b/README.md
@@ -839,17 +839,22 @@ estructura de migraciones con Alembic.
 
 | Serie | Estado | Qué significa |
 | :-- | :-- | :-- |
-| **5.x** | ✅ **Activa** | La única soportada. Recibe features y correcciones. |
+| **6.x** | ✅ **Activa** | La única soportada. Recibe features y correcciones. |
+| **5.x** | ⛔ **Deprecada** | Misma superficie de API que 6.x. Migrar es actualizar la versión. |
 | **4.x** | ⛔ **Deprecada** | Aplicación **parcial**: le faltan el fix del event loop de Celery, las fachadas y la documentación alineada. |
 | **3.x** | ⛔ **Deprecada** | Aplicación **parcial**: tiene las correcciones P0/P1 pero ninguna de las factories de FastAPI. |
 | **2.x** | ⛔ **Deprecada** | Contiene los bugs silenciosos corregidos en 5.x (ver abajo). |
 | **1.x** | ⛔ **Deprecada** | Sin soporte de ningún tipo. |
 
-**Todo lo anterior a 5.0 está deprecado. Migrá a 5.x.**
+**Todo lo anterior a 5.0 está deprecado. Migrá a 6.x.**
 
 3.0.0 y 4.0.0 existen sólo porque el trabajo se mergeó por fases y cada merge disparó un bump
 automático: **no son releases pensadas para usarse**, son cortes intermedios de la misma
 migración. 5.0.0 es la primera versión completa.
+
+6.0.0 es el mismo caso: la disparó un PR de documentación con un commit `feat!:`. No hay
+**ninguna** ruptura de API entre 5.x y 6.x — los alias anteriores a 5.0 siguen importables y
+siguen avisando.
 
 ### Por qué 2.x y anteriores no deberían estar en producción
 


### PR DESCRIPTION
﻿## Ítem del plan

**W-CL.** El `CHANGELOG.md` no se toca en los PRs. Se elige la **opción A** (generado por `commitizen`).

## Problema

Un changelog se escribe por *prepend*, así que cada rama y cada `cz bump` en master editan **la misma línea 1**. Con N ramas abiertas, cada release rompe las N.

En la ronda anterior costó **tres** tandas de conflictos, y el coste subió cada vez: la primera fue borrar tres marcadores, la tercera exigió reubicar bloques entre secciones. Con los siete PRs de esta ronda abiertos a la vez, el mismo patrón se repetiría amplificado.

## Reproducción

No es un bug de código: es lo que pasa cada vez que se abre el primer PR de una tanda. Dos ramas que añaden su entrada al principio del archivo conflictúan siempre, aunque los cambios de código no se toquen entre sí.

## Solución

Queda escrito en `CONTRIBUTING.md`: **ningún PR edita `CHANGELOG.md`**. Lo genera `commitizen` en el release. Si un cambio merece prosa, esa prosa va en el **cuerpo del commit**.

**Por qué A y no B (fragmentos en `changelog.d/`):** A no necesita infraestructura nueva. Los commits ya son convencionales y `[tool.commitizen]` ya está en `pyproject.toml`, así que la política es sólo dejar de hacer algo. B haría el conflicto imposible por construcción, pero exige un directorio, una convención de nombres y un script de concatenación en el release — coste permanente para un problema que A también elimina.

**Qué se pide a cambio,** y queda dicho explícitamente: escribir el commit para que se lea en el changelog. El asunto es la línea que va a aparecer publicada; el cuerpo explica el *porqué*, que es lo que un `git log` no puede reconstruir después.

Van con ello las dos reglas de git que costaron tiempo en la ronda anterior:

- **`merge`, no `rebase`,** para poner al día una rama divergida, con `rerere` activado. Con rebase el conflicto se repite una vez por cada commit que tocó el archivo.
- **Diagnosticar antes de tocar git.** `mergeable: MERGEABLE` sólo dice que no hay conflictos; lo que bloquea el botón es `mergeStateStatus`. En la ronda anterior apareció dos veces `UNSTABLE` con cero conflictos: eran checks pendientes.

## Riesgo / compatibilidad

Ninguno: sólo toca `CONTRIBUTING.md`. No cambia el `CHANGELOG.md` existente ni la configuración de `commitizen`, que ya tiene `update_changelog_on_bump = false` — **eso sí habría que revisarlo** para que `cz bump` regenere el archivo, pero es una decisión de release y no de este PR.

## Tests

No aplica: es política de proceso. Los tests de documentación siguen en verde.

> La CI arrastra los dos fallos de política de soporte que arregla #38. Son previos a esta rama.
